### PR TITLE
Treat shared identity updates as individual changes

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseWrapper.cs
@@ -146,15 +146,6 @@ public class MongoDatabaseWrapper : Database
         string collectionName = entry.EntityType.GetCollectionName();
         var state = entry.EntityState;
 
-        // This entry may share its identity with another that it is replacing or being
-        // replaced by. If this one is the deleted side do nothing, if it is the replacement
-        // then treat it as a database update.
-        if (entry.SharedIdentityEntry != null)
-        {
-            if (state == EntityState.Deleted) return null;
-            if (state == EntityState.Added) state = EntityState.Modified;
-        }
-
         return state switch
         {
             EntityState.Added => ConvertAddedEntryToMongoUpdate(collectionName, entry),


### PR DESCRIPTION
Share Identity changes are when an identity with a given ID/PK is deleted and another is added without an intermediate savechanges between them.

In the case of root level elements existing EF Core providers (Cosmos, relational) treat this as an update right now however we can not do so as we issue partial updates to MongoDB that would result in expected merges of data.

EF Core also plans to stop doing this in the future for their providers https://github.com/dotnet/efcore/issues/30705

Once we've completed #21 we should test and fix (if necessary) the delete/add scenarios for:

- Top level/root documents (delete + add in correct order)
- Embedded/owned entities (mark parent entity as changed and ensure correct entity is serialized)
- Collections of owned entities (mark parent entity as changed and ensure whole collection is serialized)