### PR TITLE
Do not write non-stored properties, split key and non-key serialization

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseWrapper.cs
@@ -203,7 +203,9 @@ public class MongoDatabaseWrapper : Database
         }
 
         writer.WriteStartDocument();
-        SerializationHelper.WriteProperties(writer, entry, propertyFilter);
+
+        SerializationHelper.WriteKeyProperties(writer, entry);
+        SerializationHelper.WriteNonKeyProperties(writer, entry, propertyFilter);
 
         foreach (var navigation in entry.EntityType.GetNavigations())
         {


### PR DESCRIPTION
Splits the key and non-key parts of seialization to ensure filtering is clear and prevent writing non-stored properties.