### PR TITLE
EF-24: Owned entity collections

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeBuilderExtensions.cs
@@ -1,19 +1,20 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using MongoDB.EntityFrameworkCore.Metadata;
@@ -114,5 +115,78 @@ public static class MongoEntityTypeBuilderExtensions
             throw new ArgumentException(ArgumentNameCannotBeEmptyExceptionMessage);
 
         return entityTypeBuilder.CanSetAnnotation(MongoAnnotationNames.CollectionName, name, fromDataAnnotation);
+    }
+
+    /// <summary>
+    /// Configures the element name that the entity is mapped to when stored as an embedded document.
+    /// </summary>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="name">The name of the parent element.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static OwnedNavigationBuilder SetElementName(
+        this OwnedNavigationBuilder entityTypeBuilder,
+        string? name)
+    {
+        entityTypeBuilder.OwnedEntityType.SetContainingElementName(name);
+
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    /// Configures the element name that the entity is mapped to when stored as an embedded document.
+    /// </summary>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="name">The name of the parent element.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> SetElementName<TOwnerEntity, TDependentEntity>(
+        this OwnedNavigationBuilder<TOwnerEntity, TDependentEntity> entityTypeBuilder,
+        string? name)
+        where TOwnerEntity : class
+        where TDependentEntity : class
+    {
+        entityTypeBuilder.OwnedEntityType.SetContainingElementName(name);
+
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    /// Configures the element name that the entity is mapped to when stored as an embedded document.
+    /// </summary>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="name">The name of the parent element.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The same builder instance if the configuration was applied, <see langword="null" /> otherwise.</returns>
+    public static IConventionEntityTypeBuilder? SetElementName(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        string? name,
+        bool fromDataAnnotation = false)
+    {
+        if (!entityTypeBuilder.CanSetElementName(name, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        entityTypeBuilder.Metadata.SetContainingElementName(name, fromDataAnnotation);
+
+        return entityTypeBuilder;
+    }
+
+    /// <summary>
+    /// Returns a value indicating whether the parent element name to which the entity type is mapped to can be set
+    /// from the current configuration source.
+    /// </summary>
+    /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
+    /// <param name="name">The name of the element property.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the configuration can be applied.</returns>
+    public static bool CanSetElementName(
+        this IConventionEntityTypeBuilder entityTypeBuilder,
+        string? name,
+        bool fromDataAnnotation = false)
+    {
+        if (name is not null && name.Trim().Length == 0)
+            throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(nameof(name)));
+
+        return entityTypeBuilder.CanSetAnnotation(MongoAnnotationNames.ElementName, name, fromDataAnnotation);
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
@@ -1,21 +1,20 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.EntityFrameworkCore.Metadata;
@@ -87,4 +86,43 @@ public static class MongoEntityTypeExtensions
         => entityType.FindOwnership() is IReadOnlyForeignKey ownership
             ? ownership.PrincipalToDependent!.Name
             : null;
+
+    /// <summary>
+    /// Sets the name of the parent element to which the entity type is mapped.
+    /// </summary>
+    /// <param name="entityType">The entity type to set the containing element name for.</param>
+    /// <param name="name">The name to set.</param>
+    public static void SetContainingElementName(this IMutableEntityType entityType, string? name)
+    {
+        if (name is not null && name.Trim().Length == 0)
+            throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(nameof(name)));
+
+        entityType.SetOrRemoveAnnotation(MongoAnnotationNames.ElementName, name);
+    }
+
+    /// <summary>
+    /// Sets the name of the parent element to which the entity type is mapped.
+    /// </summary>
+    /// <param name="entityType">The entity type to set the containing element name for.</param>
+    /// <param name="name">The name to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    public static string? SetContainingElementName(
+        this IConventionEntityType entityType,
+        string? name,
+        bool fromDataAnnotation = false)
+    {
+        if (name is not null && name.Trim().Length == 0)
+            throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(nameof(name)));
+
+        return (string?)entityType.SetOrRemoveAnnotation(MongoAnnotationNames.ElementName, name, fromDataAnnotation)?.Value;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ConfigurationSource" /> for the parent element to which the entity type is mapped.
+    /// </summary>
+    /// <param name="entityType">The entity type to find configuration source for.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the parent element to which the entity type is mapped.</returns>
+    public static ConfigurationSource? GetContainingElementNameConfigurationSource(this IConventionEntityType entityType)
+        => entityType.FindAnnotation(MongoAnnotationNames.ElementName)
+            ?.GetConfigurationSource();
 }

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
@@ -106,6 +106,7 @@ public static class MongoEntityTypeExtensions
     /// <param name="entityType">The entity type to set the containing element name for.</param>
     /// <param name="name">The name to set.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The new annotation or <see langword="null" /> if it was removed.</returns>
     public static string? SetContainingElementName(
         this IConventionEntityType entityType,
         string? name,

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
@@ -1,17 +1,17 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -31,9 +31,29 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IReadOnlyProperty"/> to obtain the element name for.</param>
     /// <returns>Returns the element name that the property is mapped to.</returns>
-    public static string GetElementName(this IReadOnlyPropertyBase property)
+    public static string GetElementName(this IReadOnlyProperty property)
         => (string?)property[MongoAnnotationNames.ElementName]
-           ?? property.Name;
+           ?? GetDefaultElementName(property);
+
+    private static string GetDefaultElementName(IReadOnlyProperty property)
+    {
+        var entityType = property.DeclaringEntityType;
+        var ownership = entityType.FindOwnership();
+
+        if (ownership != null && !entityType.IsDocumentRoot())
+        {
+            var pk = property.FindContainingPrimaryKey();
+            if (pk != null
+                && (property.ClrType == typeof(int) || ownership.Properties.Contains(property))
+                && pk.Properties.Count == ownership.Properties.Count + (ownership.IsUnique ? 0 : 1)
+                && ownership.Properties.All(fkProperty => pk.Properties.Contains(fkProperty)))
+            {
+                return "";
+            }
+        }
+
+        return property.Name;
+    }
 
     public static bool IsOwnedTypeKey(this IProperty property)
     {
@@ -87,7 +107,7 @@ public static class MongoPropertyExtensions
     public static ConfigurationSource? GetElementNameConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(MongoAnnotationNames.ElementName)?.GetConfigurationSource();
 
-    internal static bool IsOrdinalKeyProperty(this IReadOnlyProperty property)
+    internal static bool IsOwnedCollectionShadowKey(this IReadOnlyProperty property)
     {
         return property.FindContainingPrimaryKey()
                 is {Properties.Count: > 1} && !property.IsForeignKey()

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
@@ -1,17 +1,17 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System;
 using Microsoft.EntityFrameworkCore;
@@ -20,12 +20,14 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Infrastructure;
 using MongoDB.EntityFrameworkCore.Metadata.Conventions;
 using MongoDB.EntityFrameworkCore.Query.Factories;
 using MongoDB.EntityFrameworkCore.Storage;
+using MongoDB.EntityFrameworkCore.ValueGeneration;
 
 // ReSharper disable once CheckNamespace (extensions should be in the EF namespace for discovery)
 namespace Microsoft.Extensions.DependencyInjection;
@@ -99,6 +101,7 @@ public static class MongoServiceCollectionExtensions
             .TryAdd<IDatabase, MongoDatabaseWrapper>()
             .TryAdd<IModelValidator, MongoModelValidator>()
             .TryAdd<IProviderConventionSetBuilder, MongoConventionSetBuilder>()
+            .TryAdd<IValueGeneratorSelector, MongoValueGeneratorSelector>()
             .TryAdd<IQueryContextFactory, MongoQueryContextFactory>()
             .TryAdd<ITypeMappingSource, MongoTypeMappingSource>()
             .TryAdd<IQueryCompilationContextFactory, MongoQueryCompilationContextFactory>()

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
@@ -180,7 +180,7 @@ public class MongoModelValidator : ModelValidator
             foreach (var key in entityType.GetDeclaredKeys())
             {
                 var mutableProperty = key.Properties.FirstOrDefault(p => p.ValueGenerated.HasFlag(ValueGenerated.OnUpdate));
-                if (mutableProperty != null && !mutableProperty.IsCollectionIndexShadowKey())
+                if (mutableProperty != null && !mutableProperty.IsOwnedCollectionShadowKey())
                 {
                     throw new InvalidOperationException(CoreStrings.MutableKeyProperty(mutableProperty.Name));
                 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
@@ -272,8 +272,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
             if (!entityType.IsDocumentRoot())
             {
                 var ownership = entityType.FindOwnership();
-                if (!ownership.IsUnique
-                    && property.IsOrdinalKeyProperty())
+                if (ownership?.IsUnique == false && property.IsOwnedCollectionShadowKey())
                 {
                     var readExpression = _ordinalParameterBindings[docExpression];
                     if (readExpression.Type != type)

--- a/src/MongoDB.EntityFrameworkCore/ValueGeneration/MongoValueGeneratorSelector.cs
+++ b/src/MongoDB.EntityFrameworkCore/ValueGeneration/MongoValueGeneratorSelector.cs
@@ -1,0 +1,49 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace MongoDB.EntityFrameworkCore.ValueGeneration;
+
+/// <summary>
+/// Implements <see cref="ValueGeneratorSelector"/> adding temporary ID
+/// functionality for owned entity collections.
+/// </summary>
+public class MongoValueGeneratorSelector : ValueGeneratorSelector
+{
+    /// <summary>
+    /// Create a new <see cref="MongoValueGeneratorSelector"/>.
+    /// </summary>
+    /// <param name="dependencies">The <see cref="ValueGeneratorSelectorDependencies"/> to use.</param>
+    public MongoValueGeneratorSelector(ValueGeneratorSelectorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override ValueGenerator? FindForType(IProperty property, IEntityType entityType, Type clrType)
+    {
+        // Required to ensure we generate unique IDs for owned entity collections
+        if (entityType.IsOwned() && clrType == typeof(int) && property.IsShadowProperty())
+        {
+            return new OwnedEntityIndexValueGenerator();
+        }
+
+        return base.FindForType(property, entityType, clrType);
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/ValueGeneration/OwnedEntityIndexValueGenerator.cs
+++ b/src/MongoDB.EntityFrameworkCore/ValueGeneration/OwnedEntityIndexValueGenerator.cs
@@ -1,0 +1,37 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace MongoDB.EntityFrameworkCore.ValueGeneration;
+
+/// <summary>
+/// Creates an auto-incrementing number used by owned entity collections to ensure
+/// key uniqueness within EF tracking.
+/// </summary>
+internal class OwnedEntityIndexValueGenerator : ValueGenerator<int>
+{
+    private int _current = int.MinValue;
+
+    /// <inheritdoc/>
+    public override int Next(EntityEntry entry) =>
+        Interlocked.Increment(ref _current);
+
+    /// <inheritdoc/>
+    public override bool GeneratesTemporaryValues
+        => false;
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -74,7 +74,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         Assert.Equal(__location1.longitude, actual[0].location.longitude);
     }
 
-    [Fact(Skip = "We do not yet support updating owned types")]
+    [Fact]
     public void OwnedEntity_nested_one_level_creates()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
@@ -96,12 +96,14 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         }
     }
 
-    [Fact(Skip = "We do not yet support updating owned types")]
-    public void OwnedEntity_nested_collection_creates()
+    [Fact]
+    public void OwnedEntity_collection_creates()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
+
         var expected = new PersonWithMultipleLocations
         {
+            _id = ObjectId.GenerateNewId(),
             name = "Alfred",
             locations = new List<Location>
             {
@@ -117,7 +119,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var actual = db.Entitites.First(p => p.name == "Charlie");
+            var actual = db.Entitites.First(p => p.name == "Alfred");
 
             Assert.Equal(expected.name, actual.name);
             Assert.Equal(expected.locations[0].latitude, actual.locations[0].latitude);

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/MongoValueGeneratorSelectorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/MongoValueGeneratorSelectorTests.cs
@@ -1,0 +1,76 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.ValueGeneration;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.ValueGeneration;
+
+public class MongoValueGeneratorSelectorTests
+{
+    private readonly IModel __model;
+    private readonly IValueGeneratorSelector __valueGeneratorSelector;
+    private readonly IEntityType __entityType;
+
+    public MongoValueGeneratorSelectorTests()
+    {
+        var instance = MongoTestHelpers.Instance;
+        var builder = instance.CreateConventionBuilder();
+        var e = builder.Entity<RootEntity>();
+
+        builder.FinalizeModel();
+        __model = (IModel)builder.Model;
+        var serviceProvider = instance.CreateServiceProvider();
+        __valueGeneratorSelector = (IValueGeneratorSelector)serviceProvider.GetService(typeof(IValueGeneratorSelector))!;
+        __entityType = __model.FindEntityType(typeof(EntityWithDifferentTypes))!;
+    }
+
+    [Fact]
+    public void Create_returns_OwnedEntityIndexValueGenerator_for_mapped_int()
+    {
+        var generator = __valueGeneratorSelector.Select(__entityType.FindProperty("_unique")!, __entityType);
+        Assert.IsType<OwnedEntityIndexValueGenerator>(generator);
+    }
+
+    [Fact]
+    public void Create_throws_NotSupportedException_for_int()
+    {
+        Assert.Throws<NotSupportedException>(() =>
+            __valueGeneratorSelector.Select(__entityType.FindProperty("someInt")!, __entityType));
+    }
+
+    [Fact]
+    public void Create_throws_NotSupportedException_for_guid()
+    {
+        var generator = __valueGeneratorSelector.Select(__entityType.FindProperty("someGuid")!, __entityType);
+        Assert.IsType<GuidValueGenerator>(generator);
+    }
+
+    class RootEntity
+    {
+        public ObjectId _id { get; set; }
+        public List<EntityWithDifferentTypes> OwnedEntityList { get; set; }
+    }
+
+    class EntityWithDifferentTypes
+    {
+        public ObjectId _id { get; set; }
+        public int someInt { get; set; }
+        public Guid someGuid { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/MongoValueGeneratorSelectorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/MongoValueGeneratorSelectorTests.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using MongoDB.Bson;
@@ -23,27 +22,26 @@ namespace MongoDB.EntityFrameworkCore.UnitTests.ValueGeneration;
 
 public class MongoValueGeneratorSelectorTests
 {
-    private readonly IModel __model;
-    private readonly IValueGeneratorSelector __valueGeneratorSelector;
-    private readonly IEntityType __entityType;
+    private readonly IValueGeneratorSelector _valueGeneratorSelector;
+    private readonly IEntityType _entityType;
 
     public MongoValueGeneratorSelectorTests()
     {
         var instance = MongoTestHelpers.Instance;
         var builder = instance.CreateConventionBuilder();
-        var e = builder.Entity<RootEntity>();
+        builder.Entity<RootEntity>();
 
         builder.FinalizeModel();
-        __model = (IModel)builder.Model;
+        IModel model = (IModel)builder.Model;
         var serviceProvider = instance.CreateServiceProvider();
-        __valueGeneratorSelector = (IValueGeneratorSelector)serviceProvider.GetService(typeof(IValueGeneratorSelector))!;
-        __entityType = __model.FindEntityType(typeof(EntityWithDifferentTypes))!;
+        _valueGeneratorSelector = (IValueGeneratorSelector)serviceProvider.GetService(typeof(IValueGeneratorSelector))!;
+        _entityType = model.FindEntityType(typeof(EntityWithDifferentTypes))!;
     }
 
     [Fact]
     public void Create_returns_OwnedEntityIndexValueGenerator_for_mapped_int()
     {
-        var generator = __valueGeneratorSelector.Select(__entityType.FindProperty("_unique")!, __entityType);
+        var generator = _valueGeneratorSelector.Select(_entityType.FindProperty("_unique")!, _entityType);
         Assert.IsType<OwnedEntityIndexValueGenerator>(generator);
     }
 
@@ -51,13 +49,13 @@ public class MongoValueGeneratorSelectorTests
     public void Create_throws_NotSupportedException_for_int()
     {
         Assert.Throws<NotSupportedException>(() =>
-            __valueGeneratorSelector.Select(__entityType.FindProperty("someInt")!, __entityType));
+            _valueGeneratorSelector.Select(_entityType.FindProperty("someInt")!, _entityType));
     }
 
     [Fact]
     public void Create_throws_NotSupportedException_for_guid()
     {
-        var generator = __valueGeneratorSelector.Select(__entityType.FindProperty("someGuid")!, __entityType);
+        var generator = _valueGeneratorSelector.Select(_entityType.FindProperty("someGuid")!, _entityType);
         Assert.IsType<GuidValueGenerator>(generator);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/OwnedEntityIndexValueGeneratorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/OwnedEntityIndexValueGeneratorTests.cs
@@ -1,0 +1,34 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.EntityFrameworkCore.ValueGeneration;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.ValueGeneration;
+
+public class OwnedEntityIndexValueGeneratorTests
+{
+    [Fact]
+    public void Next_generates_non_temporary_id()
+    {
+        const int loops = 100;
+        var generator = new OwnedEntityIndexValueGenerator();
+        var values = new HashSet<int>(loops);
+
+        for (int i = 0; i < loops; i++)
+            values.Add(generator.Next(null));
+
+        Assert.Equal(loops, values.Count);
+    }
+}


### PR DESCRIPTION
Implementation of owned entity collections.

The main issue here was handling the synthetic non-stored keys on the collection which as well as having the parent key like non-collections also needed another value. We use a generator even though we don't persist or read these values to keep EF happy.