### PR TITLE
Support count, longcount and any at top-level.

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
@@ -104,6 +104,7 @@ public static class MongoServiceCollectionExtensions
             .TryAdd<IValueGeneratorSelector, MongoValueGeneratorSelector>()
             .TryAdd<IQueryContextFactory, MongoQueryContextFactory>()
             .TryAdd<ITypeMappingSource, MongoTypeMappingSource>()
+            .TryAdd<IQueryTranslationPreprocessorFactory, MongoQueryTranslationPreprocessorFactory>()
             .TryAdd<IQueryCompilationContextFactory, MongoQueryCompilationContextFactory>()
             .TryAdd<IQueryTranslationPostprocessorFactory, MongoQueryTranslationPostprocessorFactory>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, MongoQueryableMethodTranslatingExpressionVisitorFactory>()

--- a/src/MongoDB.EntityFrameworkCore/Query/Factories/MongoQueryTranslationPostprocessorFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Factories/MongoQueryTranslationPostprocessorFactory.cs
@@ -38,7 +38,7 @@ public class MongoQueryTranslationPostprocessorFactory : IQueryTranslationPostpr
     protected virtual QueryTranslationPostprocessorDependencies Dependencies { get; }
 
     /// <summary>
-    /// Create a new <see cref="MongoQueryCompilationContext"/> with the necessary dependencies.
+    /// Create a new <see cref="MongoQueryTranslationPostprocessor"/> with the necessary dependencies.
     /// </summary>
     /// <param name="queryCompilationContext">The <see cref="QueryCompilationContext"/> to pass to the new <see cref="MongoQueryTranslationPostprocessorFactory"/>.</param>
     /// <returns>The newly created <see cref="MongoQueryTranslationPostprocessorFactory"/>.</returns>

--- a/src/MongoDB.EntityFrameworkCore/Query/Factories/MongoQueryTranslationPreprocessorFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Factories/MongoQueryTranslationPreprocessorFactory.cs
@@ -1,0 +1,47 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace MongoDB.EntityFrameworkCore.Query.Factories;
+
+/// <summary>
+/// A factory for creating <see cref="MongoQueryTranslationPreprocessor" /> instances.
+/// </summary>
+public class MongoQueryTranslationPreprocessorFactory : IQueryTranslationPreprocessorFactory
+{
+    /// <summary>
+    /// Create a <see cref="MongoQueryTranslationPreprocessorFactory"/>.
+    /// </summary>
+    /// <param name="dependencies">The <see cref="QueryTranslationPreprocessorDependencies"/> passed to each created <see cref="MongoQueryTranslationPreprocessor" /> instance.</param>
+    public MongoQueryTranslationPreprocessorFactory(
+        QueryTranslationPreprocessorDependencies dependencies)
+    {
+        Dependencies = dependencies;
+    }
+
+    /// <summary>
+    /// The <see cref="QueryTranslationPreprocessorDependencies"/> passed to each <see cref="MongoQueryTranslationPreprocessor"/> created by this factory.
+    /// </summary>
+    protected virtual QueryTranslationPreprocessorDependencies Dependencies { get; }
+
+    /// <summary>
+    /// Create a new <see cref="MongoQueryTranslationPreprocessor"/> with the necessary dependencies.
+    /// </summary>
+    /// <param name="queryCompilationContext">The <see cref="QueryCompilationContext"/> to pass to the new <see cref="MongoQueryTranslationPreprocessor"/>.</param>
+    /// <returns>The newly created <see cref="MongoQueryTranslationPreprocessorFactory"/>.</returns>
+    public virtual QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
+        => new MongoQueryTranslationPreprocessor(Dependencies, queryCompilationContext);
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPreprocessor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPreprocessor.cs
@@ -1,0 +1,36 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.EntityFrameworkCore.Query.Visitors;
+
+namespace MongoDB.EntityFrameworkCore.Query;
+
+public class MongoQueryTranslationPreprocessor : QueryTranslationPreprocessor
+{
+    public MongoQueryTranslationPreprocessor(
+        QueryTranslationPreprocessorDependencies dependencies,
+        QueryCompilationContext queryCompilationContext)
+        : base(dependencies, queryCompilationContext)
+    {
+    }
+
+    public override Expression Process(Expression query)
+    {
+        query = FinalPredicateHoistingVisitor.Hoist(query);
+        return base.Process(query);
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/FinalPredicateHoistingVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/FinalPredicateHoistingVisitor.cs
@@ -1,0 +1,87 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace MongoDB.EntityFrameworkCore.Query.Visitors;
+
+/// <summary>
+/// Visit the tree and move any end-of-evaluation predicates we can further up the tree to ensure
+/// that they are translated correctly as we have to remove and post-replay the final predicate
+/// in order to utilize the LINQ V3 provider.
+/// </summary>
+internal class FinalPredicateHoistingVisitor : ExpressionVisitor
+{
+    private static readonly FinalPredicateHoistingVisitor __instance = new();
+
+    private FinalPredicateHoistingVisitor()
+    {
+    }
+
+    /// <summary>
+    /// Hoist a predicate from a final query-executing method call up one level so
+    /// it can be translated before being passed to the LINQ v3 provider.
+    /// </summary>
+    /// <param name="expression">The full LINQ query expression.</param>
+    /// <returns>A hoisted version of the LINQ query expression if required, otherwise the original expression.</returns>
+    public static Expression Hoist(Expression expression)
+    {
+        return __instance.Visit(expression);
+    }
+
+    /// <inheritdoc/>
+    protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+    {
+        var method = methodCallExpression.Method;
+        if (method.DeclaringType == typeof(Queryable) && method.IsGenericMethod)
+        {
+            var genericMethod = method.GetGenericMethodDefinition();
+            var genericType = method.GetGenericArguments()[0];
+
+            switch (method.Name)
+            {
+                case nameof(Queryable.Count) when genericMethod == QueryableMethods.CountWithPredicate:
+                    return Expression.Call(null,
+                        QueryableMethods.CountWithoutPredicate.MakeGenericMethod(genericType),
+                        Expression.Call(null,
+                            QueryableMethods.Where.MakeGenericMethod(genericType),
+                            methodCallExpression.Arguments));
+
+                case nameof(Queryable.LongCount) when genericMethod == QueryableMethods.LongCountWithPredicate:
+                    return Expression.Call(null,
+                        QueryableMethods.LongCountWithoutPredicate.MakeGenericMethod(genericType),
+                        Expression.Call(null,
+                            QueryableMethods.Where.MakeGenericMethod(genericType),
+                            methodCallExpression.Arguments));
+
+                case nameof(Queryable.Any) when genericMethod == QueryableMethods.AnyWithPredicate:
+                    return Expression.Call(null,
+                        QueryableMethods.AnyWithoutPredicate.MakeGenericMethod(genericType),
+                        Expression.Call(null,
+                            QueryableMethods.Where.MakeGenericMethod(genericType),
+                            methodCallExpression.Arguments));
+
+                // We do not support All at this time as there is no predicate-less version we can use
+                case nameof(Queryable.All) when genericMethod == QueryableMethods.All:
+                    throw new NotImplementedException("All() is not supported at this time.");
+            }
+        }
+
+        return methodCallExpression;
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
@@ -1,0 +1,200 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
+using XUnitCollection = Xunit.CollectionAttribute;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+[XUnitCollection(nameof(SampleGuidesFixture))]
+public class TopScalarTests
+{
+    private readonly GuidesDbContext _db;
+
+    public TopScalarTests(SampleGuidesFixture fixture)
+    {
+        _db = GuidesDbContext.Create(fixture.MongoDatabase);
+    }
+
+    [Fact]
+    public void Count_with_no_predicate()
+    {
+        int result = _db.Planets.Count();
+        Assert.Equal(8, result);
+    }
+
+    [Fact]
+    public void Count_with_no_predicate_after_where()
+    {
+        int result = _db.Planets.Where(p => p.hasRings).Count();
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public void Count_with_predicate()
+    {
+        int result = _db.Planets.Count(p => p.hasRings);
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public void Count_with_predicate_after_where()
+    {
+        int result = _db.Planets.Where(p => p.orderFromSun > 5).Count(p => p.hasRings);
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task CountAsync_with_no_predicate()
+    {
+        int result = await _db.Planets.CountAsync();
+        Assert.Equal(8, result);
+    }
+
+
+    [Fact]
+    public async Task CountAsync_with_no_predicate_after_where()
+    {
+        int result = await _db.Planets.Where(p => p.hasRings).CountAsync();
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public async Task CountAsync_with_predicate()
+    {
+        int result = await _db.Planets.CountAsync(p => p.hasRings);
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public async Task CountAsync_with_predicate_after_where()
+    {
+        int result = await _db.Planets.Where(p => p.orderFromSun > 5).CountAsync(p => p.hasRings);
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public void LongCount_with_no_predicate()
+    {
+        long result = _db.Planets.LongCount();
+        Assert.Equal(8, result);
+    }
+
+    [Fact]
+    public void LongCount_with_no_predicate_after_where()
+    {
+        long result = _db.Planets.Where(p => p.hasRings).LongCount();
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public void LongCount_with_predicate()
+    {
+        long result = _db.Planets.LongCount(p => p.hasRings);
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public void LongCount_with_predicate_after_where()
+    {
+        long result = _db.Planets.Where(p => p.orderFromSun > 5).LongCount(p => p.hasRings);
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task LongCountAsync_with_no_predicate()
+    {
+        long result = await _db.Planets.LongCountAsync();
+        Assert.Equal(8, result);
+    }
+
+    [Fact]
+    public async Task LongCountAsync_with_no_predicate_after_where()
+    {
+        long result = await _db.Planets.Where(p => p.hasRings).LongCountAsync();
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public async Task LongCountAsync_with_predicate()
+    {
+        long result = await _db.Planets.LongCountAsync(p => p.hasRings);
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public async Task LongCountAsync_with_predicate_after_where()
+    {
+        long result = await _db.Planets.Where(p => p.orderFromSun > 6).LongCountAsync(p => p.hasRings);
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public void Any_with_no_predicate()
+    {
+        bool result = _db.Planets.Any();
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Any_with_no_predicate_after_where()
+    {
+        bool result = _db.Planets.Where(p => p.orderFromSun < 1).Any();
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Any_with_predicate()
+    {
+        bool result = _db.Planets.Any(p => p.hasRings);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Any_with_predicate_after_where()
+    {
+        bool result = _db.Planets.Where(p => p.orderFromSun < 5).Any(p => p.hasRings);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AnyAsync_with_no_predicate()
+    {
+        bool result = await _db.Planets.AnyAsync();
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task AnyAsync_with_no_predicate_after_where()
+    {
+        bool result = await _db.Planets.Where(p => p.orderFromSun < 1).AnyAsync();
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AnyAsync_with_predicate()
+    {
+        bool result = await _db.Planets.AnyAsync(p => p.hasRings);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task AnyAsync_with_predicate_after_where()
+    {
+        bool result = await _db.Planets.Where(p => p.orderFromSun < 5).AnyAsync(p => p.hasRings);
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
Fixes EF-61 in order to support some top-level operations such as Count, LongCount and Any.

Other operators like Sum, Max etc. are not able to be supported yet as we don't support projections which would be required.

Additionally All can not be supported as there is no non-predicate version available for us to use once we hoist the predicate up to a where clause.