### PR TITLE
Type serialization coverage + fixes

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
@@ -18,7 +18,8 @@ using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Mapping;
 
-public sealed class ClrTypeMappingTests : IClassFixture<TemporaryDatabaseFixture>
+[XUnitCollection("MappingTests")]
+public class ClrTypeMappingTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly Random _random = new();
     private readonly TemporaryDatabaseFixture _tempDatabase;
@@ -445,18 +446,18 @@ public sealed class ClrTypeMappingTests : IClassFixture<TemporaryDatabaseFixture
     [InlineData(typeof(TestByteEnum?), TestByteEnum.EnumValue0)]
     [InlineData(typeof(TestByteEnum?), TestByteEnum.EnumValue1)]
     [InlineData(typeof(int[]), null)]
-    [InlineData(typeof(int[]), new[] { -5, 0, 128, 10 })]
+    [InlineData(typeof(int[]), new[] {-5, 0, 128, 10})]
     // TODO: investigate and fix IEnumerable property support
     // [InlineData(typeof(IEnumerable<int>), new[] { -5, 0, 128, 10 })]
     [InlineData(typeof(IList<int>), null)]
-    [InlineData(typeof(IList<int>), new[] { -5, 0, 128, 10 })]
-    [InlineData(typeof(ICollection<int>), new[] { -5, 0, 128, 10 })]
-    [InlineData(typeof(IReadOnlyList<int>), new[] { -5, 0, 128, 10 })]
-    [InlineData(typeof(List<int>), new[] { -5, 0, 128, 10 })]
+    [InlineData(typeof(IList<int>), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(ICollection<int>), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(IReadOnlyList<int>), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(List<int>), new[] {-5, 0, 128, 10})]
     [InlineData(typeof(string[]), null)]
-    [InlineData(typeof(string[]), new[] { "one", "two" })]
+    [InlineData(typeof(string[]), new[] {"one", "two"})]
     [InlineData(typeof(IList<string>), null)]
-    [InlineData(typeof(List<string>), new[] { "one", "two" })]
+    [InlineData(typeof(List<string>), new[] {"one", "two"})]
     public void Type_mapping_test(Type valueType, object? value)
     {
         if (value != null && !value.GetType().IsAssignableTo(valueType))
@@ -465,7 +466,7 @@ public sealed class ClrTypeMappingTests : IClassFixture<TemporaryDatabaseFixture
         }
 
         var methodInfo = this.GetType().GetMethod(nameof(ClrTypeMappingTestImpl), BindingFlags.Instance | BindingFlags.NonPublic);
-        methodInfo.MakeGenericMethod(valueType).Invoke(this, new[] { value });
+        methodInfo.MakeGenericMethod(valueType).Invoke(this, new[] {value});
     }
 
     private enum TestEnum

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ElementNameTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ElementNameTests.cs
@@ -19,6 +19,7 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Mapping;
 
+[XUnitCollection("MappingTests")]
 public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
@@ -76,13 +77,15 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
             dbContext.SaveChanges();
         }
 
-        { // Find with CSharpDriver
+        {
+            // Find with CSharpDriver
             var actual = collection.Database.GetCollection<StoredKeyElement>(collection.CollectionNamespace.CollectionName);
             var found = actual.Find(f => f._id == id).Single();
             Assert.Equal(expectedName, found.Name);
         }
 
-        { // Find with EF
+        {
+            // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
             var found = dbContext.Entitites.Single(f => f.PrimaryKey == id);
             Assert.Equal(expectedName, found.Name);
@@ -111,14 +114,16 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
             dbContext.SaveChanges();
         }
 
-        { // Find with CSharpDriver
+        {
+            // Find with CSharpDriver
             var actual = collection.Database.GetCollection<StoredNonKeyElements>(collection.CollectionNamespace.CollectionName);
             var found = actual.Find(f => f._id == id).Single();
             Assert.Equal(expectedFirstName, found.forename);
             Assert.Equal(expectedLastName, found.surname);
         }
 
-        { // Find with EF
+        {
+            // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
             var found = dbContext.Entitites.Single(f => f._id == id);
             Assert.Equal(expectedFirstName, found.FirstName);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/CamelCasePropertyNameConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/CamelCasePropertyNameConventionTests.cs
@@ -24,7 +24,8 @@ using MongoDB.EntityFrameworkCore.Metadata.Conventions;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Metadata.Conventions;
 
-public sealed class CamelCasePropertyNameConventionTests : IClassFixture<TemporaryDatabaseFixture>
+[XUnitCollection("ConventionsTests")]
+public class CamelCasePropertyNameConventionTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
 
@@ -52,7 +53,9 @@ public sealed class CamelCasePropertyNameConventionTests : IClassFixture<Tempora
 
         protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
         {
-            configurationBuilder.Conventions.Add(serviceProvider => new CamelCasePropertyNameConvention(serviceProvider.GetRequiredService<ProviderConventionSetBuilderDependencies>()));
+            configurationBuilder.Conventions.Add(serviceProvider =>
+                new CamelCasePropertyNameConvention(serviceProvider
+                    .GetRequiredService<ProviderConventionSetBuilderDependencies>()));
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -76,8 +79,7 @@ public sealed class CamelCasePropertyNameConventionTests : IClassFixture<Tempora
 
     class RemappedEntity
     {
-        [Column("_id")]
-        public ObjectId _id { get; set; }
+        [Column("_id")] public ObjectId _id { get; set; }
 
         public string unchanged { get; set; }
         public string alsoUnchanged { get; set; }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
@@ -19,7 +19,8 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Metadata.Conventions;
 
-public sealed class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFixture>
+[XUnitCollection("ConventionsTests")]
+public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
 
@@ -39,14 +40,12 @@ public sealed class ColumnAttributeConventionTests : IClassFixture<TemporaryData
     {
         public ObjectId _id { get; set; }
 
-        [Column("name")]
-        public string RemapThisToName { get; set; }
+        [Column("name")] public string RemapThisToName { get; set; }
     }
 
     class KeyRemappingEntity
     {
-        [Column("_id")]
-        public ObjectId _id { get; set; }
+        [Column("_id")] public ObjectId _id { get; set; }
 
         public string name { get; set; }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
@@ -19,7 +19,8 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Metadata.Conventions;
 
-public sealed class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDatabaseFixture>
+[XUnitCollection("ConventionsTests")]
+public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
 
@@ -44,8 +45,7 @@ public sealed class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<Temp
 
     class ColumnAttributedIdProperty
     {
-        [Column("_id")]
-        public ObjectId MyPrimaryKey { get; set; }
+        [Column("_id")] public ObjectId MyPrimaryKey { get; set; }
 
         public string name { get; set; }
     }
@@ -65,7 +65,6 @@ public sealed class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<Temp
     [Fact]
     public void PrimaryKeyDiscovery_discovers_underscore_id_named_property()
     {
-
         var collection = _tempDatabase.CreateTemporaryCollection<UnderscoreIdNamedProperty>();
 
         var id = ObjectId.GenerateNewId();
@@ -77,13 +76,16 @@ public sealed class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<Temp
             dbContext.SaveChanges();
         }
 
-        { // Find with CSharpDriver
-            var actual = collection.Database.GetCollection<UnderscoreIdNamedProperty>(collection.CollectionNamespace.CollectionName);
+        {
+            // Find with CSharpDriver
+            var actual = collection.Database.GetCollection<UnderscoreIdNamedProperty>(collection.CollectionNamespace
+                .CollectionName);
             var directFound = actual.Find(f => f._id == id).Single();
             Assert.Equal(name, directFound.name);
         }
 
-        { // Find with EF
+        {
+            // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
             var found = dbContext.Entitites.Single(f => f._id == id);
             Assert.Equal(name, found.name);
@@ -104,13 +106,15 @@ public sealed class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<Temp
             dbContext.SaveChanges();
         }
 
-        { // Find with CSharpDriver
+        {
+            // Find with CSharpDriver
             var actual = collection.Database.GetCollection<IdNamedProperty>(collection.CollectionNamespace.CollectionName);
             var directFound = actual.Find(f => f.Id == id).Single();
             Assert.Equal(name, directFound.name);
         }
 
-        { // Find with EF
+        {
+            // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
             var found = dbContext.Entitites.Single(f => f.Id == id);
             Assert.Equal(name, found.name);
@@ -132,13 +136,16 @@ public sealed class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<Temp
             dbContext.SaveChanges();
         }
 
-        { // Find with CSharpDriver
-            var actual = collection.Database.GetCollection<UnderscoreIdNamedProperty>(collection.CollectionNamespace.CollectionName);
+        {
+            // Find with CSharpDriver
+            var actual = collection.Database.GetCollection<UnderscoreIdNamedProperty>(collection.CollectionNamespace
+                .CollectionName);
             var found = actual.Find(f => f._id == id).Single();
             Assert.Equal(name, found.name);
         }
 
-        { // Find with EF
+        {
+            // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
             var found = dbContext.Entitites.Single(f => f.MyPrimaryKey == id);
             Assert.Equal(name, found.name);
@@ -160,13 +167,15 @@ public sealed class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<Temp
             dbContext.SaveChanges();
         }
 
-        { // Find with CSharpDriver
+        {
+            // Find with CSharpDriver
             var actual = collection.Database.GetCollection<StoredProduct>(collection.CollectionNamespace.CollectionName);
             var found = actual.Find(f => f._id == id).Single();
             Assert.Equal(name, found.name);
         }
 
-        { // Find with EF
+        {
+            // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
             var found = dbContext.Entitites.Single(f => f.ProductId == id);
             Assert.Equal(name, found.name);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CollectionsResponseTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CollectionsResponseTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
-using XUnitCollection = Xunit.CollectionAttribute;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
@@ -1,23 +1,24 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
+[XUnitCollection(nameof(SampleGuidesFixture))]
 public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _temporaryDatabase;
@@ -70,8 +71,7 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
             context.Entitites.AddRange(
                 new[]
                 {
-                    new Entity {Key1 = "one", Key2 = 1},
-                    new Entity {Key1 = "two", Key2 = 2},
+                    new Entity {Key1 = "one", Key2 = 1}, new Entity {Key1 = "two", Key2 = 2},
                     new Entity {Key1 = "two", Key2 = 3},
                 });
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FindTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FindTests.cs
@@ -16,7 +16,6 @@
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
-using XUnitCollection = Xunit.CollectionAttribute;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FirstSingleTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FirstSingleTests.cs
@@ -1,21 +1,20 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
-using XUnitCollection = Xunit.CollectionAttribute;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -18,6 +18,7 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
+[XUnitCollection(nameof(SampleGuidesFixture))]
 public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
@@ -184,7 +185,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_with_two_owned_entities_creates()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
-        var expected = new PersonWithTwoLocations { name = "Elizabeth", first = __location2, second = __location1};
+        var expected = new PersonWithTwoLocations {name = "Elizabeth", first = __location2, second = __location1};
 
         {
             var db = SingleEntityDbContext.Create(collection);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -1,20 +1,19 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
-using XUnitCollection = Xunit.CollectionAttribute;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SkipTakeOrderingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SkipTakeOrderingTests.cs
@@ -1,20 +1,19 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
-using XUnitCollection = Xunit.CollectionAttribute;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
-using XUnitCollection = Xunit.CollectionAttribute;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
@@ -1,22 +1,21 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
-using XUnitCollection = Xunit.CollectionAttribute;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BaseSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BaseSerializationTests.cs
@@ -19,6 +19,7 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
 
+[XUnitCollection("SerializationTests")]
 public abstract class BaseSerializationTests : IClassFixture<TemporaryDatabaseFixture>
 {
     protected readonly TemporaryDatabaseFixture TempDatabase;

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BaseSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BaseSerializationTests.cs
@@ -1,0 +1,42 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public abstract class BaseSerializationTests : IClassFixture<TemporaryDatabaseFixture>
+{
+    protected readonly TemporaryDatabaseFixture TempDatabase;
+
+    protected BaseSerializationTests(TemporaryDatabaseFixture tempDatabase)
+    {
+        TempDatabase = tempDatabase;
+    }
+
+    protected class BaseIdEntity
+    {
+        public ObjectId id { get; set; }
+    }
+
+    protected IMongoCollection<T> SetupIdOnlyCollection<T>([CallerMemberName] string? methodName = null)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<BaseIdEntity>(methodName);
+        collection.WriteTestDocs(new[] {new BaseIdEntity()});
+        return TempDatabase.MongoDatabase.GetCollection<T>(collection.CollectionNamespace.CollectionName);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BooleanSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BooleanSerializationTests.cs
@@ -1,0 +1,98 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class BooleanSerializationTests : BaseSerializationTests
+{
+    public BooleanSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Boolean_round_trips(bool expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<BooleanEntity>(nameof(Boolean_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new BooleanEntity {aBoolean = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aBoolean);
+        }
+    }
+
+    [Fact]
+    public void Missing_bool_throws()
+    {
+        var collection = SetupIdOnlyCollection<BooleanEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class BooleanEntity : BaseIdEntity
+    {
+        public Boolean aBoolean { get; set; }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    [InlineData(null)]
+    public void Nullable_bool_round_trips(bool? expected)
+    {
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableBooleanEntity>(nameof(Nullable_bool_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableBooleanEntity {aNullableBoolean = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableBoolean);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_bool_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableBooleanEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableBoolean);
+    }
+
+    class NullableBooleanEntity : BaseIdEntity
+    {
+        public Boolean? aNullableBoolean { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
@@ -84,12 +84,12 @@ public class CollectionSerializationTests : BaseSerializationTests
     [Fact]
     public void Missing_string_array_defaults_to_null()
     {
-        var collection = SetupIdOnlyCollection<IntArrayEntity>();
+        var collection = SetupIdOnlyCollection<StringArrayEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
         var result = db.Entitites.FirstOrDefault();
         Assert.NotNull(result);
-        Assert.Null(result.anIntArray);
+        Assert.Null(result.aStringArray);
     }
 
     class StringArrayEntity : BaseIdEntity

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
@@ -1,0 +1,115 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class CollectionSerializationTests : BaseSerializationTests
+{
+    public CollectionSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData(2, 4, 8, 16, 32, 64)]
+    [InlineData]
+    public void Int_array_round_trips(params int[] expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<IntArrayEntity>(nameof(Int_array_round_trips) + expected.Length);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new IntArrayEntity {anIntArray = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.anIntArray);
+        }
+    }
+
+    [Fact]
+    public void Missing_int_array_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<IntArrayEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.anIntArray);
+    }
+
+    class IntArrayEntity : BaseIdEntity
+    {
+        public int[] anIntArray { get; set; }
+    }
+
+    [Theory]
+    [InlineData("abc", "def", "ghi", "and the rest")]
+    [InlineData]
+    public void String_array_round_trips(params string[] expected)
+    {
+        var collection =
+            TempDatabase.CreateTemporaryCollection<StringArrayEntity>(nameof(String_array_round_trips) + expected.Length);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new StringArrayEntity {aStringArray = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aStringArray);
+        }
+    }
+
+    [Fact]
+    public void Missing_string_array_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<IntArrayEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.anIntArray);
+    }
+
+    class StringArrayEntity : BaseIdEntity
+    {
+        public string[] aStringArray { get; set; }
+    }
+
+    [Fact]
+    public void Missing_list_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<ListEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aList);
+    }
+
+    class ListEntity : BaseIdEntity
+    {
+        public List<decimal> aList { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
@@ -1,0 +1,280 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class DateAndTimeSerializationTests : BaseSerializationTests
+{
+    public DateAndTimeSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Fact]
+    public void DateTime_round_trips_as_utc_with_expected_precision()
+    {
+        DateTime expected = DateTime.UtcNow;
+        var collection = TempDatabase.CreateTemporaryCollection<DateTimeEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new DateTimeEntity {aDateTime = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToExpectedPrecision(), result.aDateTime.ToExpectedPrecision());
+        }
+    }
+
+    [Fact]
+    public void Missing_DateTime_throws()
+    {
+        var collection = SetupIdOnlyCollection<DateTimeEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class DateTimeEntity : BaseIdEntity
+    {
+        public DateTime aDateTime { get; set; }
+    }
+
+    [Fact]
+    public void Nullable_DateTime_round_trips_as_utc_with_expected_precision()
+    {
+        DateTime? expected = DateTime.UtcNow;
+        var collection = TempDatabase.CreateTemporaryCollection<NullableDateTimeEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableDateTimeEntity {aNullableDateTime = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected.Value.ToExpectedPrecision(), result.aNullableDateTime.Value.ToExpectedPrecision());
+        }
+    }
+
+    [Fact]
+    public void Nullable_DateTime_round_trips_as_null()
+    {
+        DateTime? expected = null;
+        var collection = TempDatabase.CreateTemporaryCollection<NullableDateTimeEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableDateTimeEntity {aNullableDateTime = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Null(result.aNullableDateTime);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_DateTime_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableDateTimeEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableDateTime);
+    }
+
+    class NullableDateTimeEntity : BaseIdEntity
+    {
+        public DateTime? aNullableDateTime { get; set; }
+    }
+
+    [Fact]
+    public void DateTimeOffset_round_trips()
+    {
+        DateTimeOffset expected = DateTimeOffset.Now;
+        var collection = TempDatabase.CreateTemporaryCollection<DateTimeOffsetEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new DateTimeOffsetEntity {aDateTimeOffset = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aDateTimeOffset);
+        }
+    }
+
+    [Fact]
+    public void Missing_DateTimeOffset_throws()
+    {
+        var collection = SetupIdOnlyCollection<DateTimeOffsetEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class DateTimeOffsetEntity : BaseIdEntity
+    {
+        public DateTimeOffset aDateTimeOffset { get; set; }
+    }
+
+    [Fact]
+    public void Nullable_DateTimeOffset_round_trips_as_utc_with_expected_precision()
+    {
+        DateTimeOffset? expected = DateTimeOffset.Now;
+        var collection = TempDatabase.CreateTemporaryCollection<NullableDateTimeOffsetEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableDateTimeOffsetEntity {aNullableDateTimeOffset = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected.Value, result.aNullableDateTimeOffset.Value);
+        }
+    }
+
+    [Fact]
+    public void Nullable_DateTimeOffset_round_trips_as_null()
+    {
+        DateTimeOffset? expected = null;
+        var collection = TempDatabase.CreateTemporaryCollection<NullableDateTimeOffsetEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableDateTimeOffsetEntity {aNullableDateTimeOffset = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Null(result.aNullableDateTimeOffset);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_DateTimeOffset_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableDateTimeOffsetEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableDateTimeOffset);
+    }
+
+    class NullableDateTimeOffsetEntity : BaseIdEntity
+    {
+        public DateTimeOffset? aNullableDateTimeOffset { get; set; }
+    }
+
+
+    [Fact]
+    public void TimeSpan_round_trips()
+    {
+        TimeSpan expected = TimeSpan.FromTicks(Random.Shared.NextInt64());
+        var collection = TempDatabase.CreateTemporaryCollection<TimeSpanEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new TimeSpanEntity {aTimeSpan = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aTimeSpan);
+        }
+    }
+
+    [Fact]
+    public void Missing_TimeSpan_throws()
+    {
+        var collection = SetupIdOnlyCollection<TimeSpanEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class TimeSpanEntity : BaseIdEntity
+    {
+        public TimeSpan aTimeSpan { get; set; }
+    }
+
+    [Theory]
+    [InlineData(1234567L)]
+    [InlineData(-1234L)]
+    [InlineData(null)]
+    public void Nullable_TimeSpan_round_trips(long? expectedTicks)
+    {
+        TimeSpan? expected = expectedTicks == null ? null : TimeSpan.FromTicks(expectedTicks.Value);
+
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableTimeSpanEntity>(nameof(Nullable_TimeSpan_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableTimeSpanEntity {aNullableTimeSpan = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableTimeSpan);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_TimeSpan_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableTimeSpanEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableTimeSpan);
+    }
+
+    class NullableTimeSpanEntity : BaseIdEntity
+    {
+        public TimeSpan? aNullableTimeSpan { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
@@ -1,0 +1,103 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class DecimalSerializationTests : BaseSerializationTests
+{
+    public DecimalSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData("12345.678")]
+    [InlineData("-912345.6781")]
+    [InlineData("0")]
+    public void Decimal_round_trips(string expectedString)
+    {
+        Decimal expected = Decimal.Parse(expectedString);
+        var collection = TempDatabase.CreateTemporaryCollection<DecimalEntity>(nameof(Decimal_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new DecimalEntity {aDecimal = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aDecimal);
+        }
+    }
+
+    [Fact]
+    public void Missing_decimal_throws()
+    {
+        var collection = SetupIdOnlyCollection<DecimalEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class DecimalEntity : BaseIdEntity
+    {
+        public decimal aDecimal { get; set; }
+    }
+
+    [Theory]
+    [InlineData("12345.678")]
+    [InlineData("-912345.6781")]
+    [InlineData("0")]
+    [InlineData(null)]
+    public void Nullable_Decimal_round_trips(string expectedString)
+    {
+        Decimal? expected = Decimal.TryParse(expectedString, out Decimal parsedDecimal) ? parsedDecimal : null;
+
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableDecimalEntity>(nameof(Nullable_Decimal_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableDecimalEntity {aNullableDecimal = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableDecimal);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_decimal_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableDecimalEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableDecimal);
+    }
+
+    class NullableDecimalEntity : BaseIdEntity
+    {
+        public decimal? aNullableDecimal { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/FloatingSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/FloatingSerializationTests.cs
@@ -1,0 +1,175 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class FloatingSerializationTests : BaseSerializationTests
+{
+    public FloatingSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData(1234.56f)]
+    [InlineData(-4587.498f)]
+    [InlineData(0f)]
+    public void Float_round_trips(float expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<FloatEntity>(nameof(Float_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new FloatEntity {aFloat = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aFloat);
+        }
+    }
+
+    [Fact]
+    public void Missing_float_throws()
+    {
+        var collection = SetupIdOnlyCollection<FloatEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class FloatEntity : BaseIdEntity
+    {
+        public float aFloat { get; set; }
+    }
+
+    [Theory]
+    [InlineData(1234.56f)]
+    [InlineData(-4587.498f)]
+    [InlineData(0f)]
+    [InlineData(null)]
+    public void Nullable_Float_round_trips(float? expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<NullableFloatEntity>(nameof(Nullable_Float_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableFloatEntity {aNullableFloat = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableFloat);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_float_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableFloatEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableFloat);
+    }
+
+    class NullableFloatEntity : BaseIdEntity
+    {
+        public float? aNullableFloat { get; set; }
+    }
+
+    [Theory]
+    [InlineData(1234.56)]
+    [InlineData(-4587.498)]
+    [InlineData(0.0)]
+    public void Double_round_trips(double expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<DoubleEntity>(nameof(Double_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new DoubleEntity {aDouble = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aDouble);
+        }
+    }
+
+    [Fact]
+    public void Missing_double_throws()
+    {
+        var collection = SetupIdOnlyCollection<DoubleEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class DoubleEntity : BaseIdEntity
+    {
+        public double aDouble { get; set; }
+    }
+
+    [Theory]
+    [InlineData(1234.56)]
+    [InlineData(-4587.498)]
+    [InlineData(0.0)]
+    [InlineData(null)]
+    public void Nullable_Double_round_trips(double? expected)
+    {
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableDoubleEntity>(nameof(Nullable_Double_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableDoubleEntity {aNullableDouble = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableDouble);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_double_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableDoubleEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableDouble);
+    }
+
+    class NullableDoubleEntity : BaseIdEntity
+    {
+        public double? aNullableDouble { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
@@ -1,0 +1,103 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class GuidSerializationTests : BaseSerializationTests
+{
+    public GuidSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData("dd2838d8-66bf-11ee-8c99-0242ac120002")]
+    [InlineData("305b397d-98d3-4f4e-aff6-5e4693d59f6a")]
+    [InlineData("d04381cb-2988-50f0-8bca-43fbc99146ad")]
+    [InlineData("00ccebbc-13e0-7000-8b18-6150ad2d0c01")]
+    public void Guid_round_trips(string expectedString)
+    {
+        Guid expected = Guid.Parse(expectedString);
+        var collection = TempDatabase.CreateTemporaryCollection<GuidEntity>(nameof(Guid_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new GuidEntity {aGuid = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aGuid);
+        }
+    }
+
+    [Fact]
+    public void Missing_guid_throws()
+    {
+        var collection = SetupIdOnlyCollection<GuidEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class GuidEntity : BaseIdEntity
+    {
+        public Guid aGuid { get; set; }
+    }
+
+    [Theory]
+    [InlineData("dd2838d8-66bf-11ee-8c99-0242ac120002")]
+    [InlineData("305b397d-98d3-4f4e-aff6-5e4693d59f6a")]
+    [InlineData("d04381cb-2988-50f0-8bca-43fbc99146ad")]
+    [InlineData("00ccebbc-13e0-7000-8b18-6150ad2d0c01")]
+    [InlineData(null)]
+    public void Nullable_guid_round_trips(string? expectedString)
+    {
+        Guid? expected = expectedString == null ? null : Guid.Parse(expectedString);
+        var collection = TempDatabase.CreateTemporaryCollection<NullableGuidEntity>(nameof(Nullable_guid_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableGuidEntity {aNullableGuid = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableGuid);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_guid_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableGuidEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableGuid);
+    }
+
+    class NullableGuidEntity : BaseIdEntity
+    {
+        public Guid? aNullableGuid { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
@@ -27,6 +27,7 @@ public class GuidSerializationTests : BaseSerializationTests
     [InlineData("305b397d-98d3-4f4e-aff6-5e4693d59f6a")]
     [InlineData("d04381cb-2988-50f0-8bca-43fbc99146ad")]
     [InlineData("00ccebbc-13e0-7000-8b18-6150ad2d0c01")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
     public void Guid_round_trips(string expectedString)
     {
         Guid expected = Guid.Parse(expectedString);
@@ -65,6 +66,7 @@ public class GuidSerializationTests : BaseSerializationTests
     [InlineData("305b397d-98d3-4f4e-aff6-5e4693d59f6a")]
     [InlineData("d04381cb-2988-50f0-8bca-43fbc99146ad")]
     [InlineData("00ccebbc-13e0-7000-8b18-6150ad2d0c01")]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
     [InlineData(null)]
     public void Nullable_guid_round_trips(string? expectedString)
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
@@ -287,12 +287,12 @@ public class IntegerSerializationTests : BaseSerializationTests
     [Theory]
     [InlineData(0)]
     [InlineData(67)]
-    [InlineData(-67)]
-    [InlineData(128)]
+    [InlineData(-128)]
+    [InlineData(127)]
     [InlineData(null)]
     public void Nullable_sbyte_round_trips(int? expectedInt)
     {
-        sbyte? expected = expectedInt == null ? null : (sbyte)expectedInt;
+        sbyte? expected = expectedInt == null ? null : Convert.ToSByte(expectedInt);
         var collection = TempDatabase.CreateTemporaryCollection<NullableSByteEntity>(nameof(Nullable_sbyte_round_trips) + expected);
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
@@ -1,0 +1,327 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class IntegerSerializationTests : BaseSerializationTests
+{
+    public IntegerSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData(78910)]
+    [InlineData(-123)]
+    [InlineData(0)]
+    public void Int_round_trips(int expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<IntEntity>(nameof(Int_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new IntEntity {anInt = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.anInt);
+        }
+    }
+
+    [Fact]
+    public void Missing_int_throws()
+    {
+        var collection = SetupIdOnlyCollection<IntEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class IntEntity : BaseIdEntity
+    {
+        public int anInt { get; set; }
+    }
+
+    [Theory]
+    [InlineData(78910)]
+    [InlineData(-123)]
+    [InlineData(0)]
+    [InlineData(null)]
+    public void Nullable_int_round_trips(int? expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<NullableIntEntity>(nameof(Nullable_int_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableIntEntity {aNullableInt = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableInt);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_int_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableIntEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableInt);
+    }
+
+    class NullableIntEntity : BaseIdEntity
+    {
+        public int? aNullableInt { get; set; }
+    }
+
+    [Theory]
+    [InlineData(78910L)]
+    [InlineData(-123L)]
+    [InlineData(0L)]
+    public void Long_round_trips(long expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<LongEntity>(nameof(Long_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new LongEntity {aLong = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aLong);
+        }
+    }
+
+    [Fact]
+    public void Missing_long_throws()
+    {
+        var collection = SetupIdOnlyCollection<LongEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class LongEntity : BaseIdEntity
+    {
+        public long aLong { get; set; }
+    }
+
+    [Theory]
+    [InlineData(78910L)]
+    [InlineData(-123L)]
+    [InlineData(0L)]
+    [InlineData(null)]
+    public void Nullable_long_round_trips(long? expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<NullableLongEntity>(nameof(Nullable_long_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableLongEntity {aNullableLong = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableLong);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_long_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableLongEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableLong);
+    }
+
+    class NullableLongEntity : BaseIdEntity
+    {
+        public long? aNullableLong { get; set; }
+    }
+
+    [Theory]
+    [InlineData(7890)]
+    [InlineData(-123)]
+    [InlineData(0)]
+    public void Short_round_trips(short expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<ShortEntity>(nameof(Short_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new ShortEntity {aShort = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aShort);
+        }
+    }
+
+    [Fact]
+    public void Missing_short_throws()
+    {
+        var collection = SetupIdOnlyCollection<ShortEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class ShortEntity : BaseIdEntity
+    {
+        public short aShort { get; set; }
+    }
+
+    [Theory]
+    [InlineData(7890)]
+    [InlineData(-123)]
+    [InlineData(0)]
+    public void Nullable_short_round_trips(int? expectedInt)
+    {
+        var expected = Convert.ToInt16(expectedInt);
+        var collection = TempDatabase.CreateTemporaryCollection<NullableShortEntity>(nameof(Nullable_short_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableShortEntity {aNullableShort = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableShort);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_short_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableShortEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableShort);
+    }
+
+    class NullableShortEntity : BaseIdEntity
+    {
+        public short? aNullableShort { get; set; }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(67)]
+    [InlineData(-128)]
+    [InlineData(127)]
+    public void Sbyte_round_trips(sbyte expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<SByteEntity>(nameof(Sbyte_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new SByteEntity {aByte = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aByte);
+        }
+    }
+
+    [Fact]
+    public void Missing_sbyte_throws()
+    {
+        var collection = SetupIdOnlyCollection<SByteEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class SByteEntity : BaseIdEntity
+    {
+        public sbyte aByte { get; set; }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(67)]
+    [InlineData(-67)]
+    [InlineData(128)]
+    [InlineData(null)]
+    public void Nullable_sbyte_round_trips(int? expectedInt)
+    {
+        sbyte? expected = expectedInt == null ? null : (sbyte)expectedInt;
+        var collection = TempDatabase.CreateTemporaryCollection<NullableSByteEntity>(nameof(Nullable_sbyte_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableSByteEntity {aNullableSByte = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableSByte);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_sbyte_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableSByteEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableSByte);
+    }
+
+    class NullableSByteEntity : BaseIdEntity
+    {
+        public sbyte? aNullableSByte { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
@@ -1,0 +1,181 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class MongoTypeSerializationTests : BaseSerializationTests
+{
+    public MongoTypeSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData("652446393021fe289cf2c197")]
+    [InlineData("64a8583aa1ee84d292c009dd")]
+    public void ObjectId_round_trips(string expectedString)
+    {
+        ObjectId expected = ObjectId.Parse(expectedString);
+        var collection = TempDatabase.CreateTemporaryCollection<ObjectIdEntity>(nameof(ObjectId_round_trips) + expectedString);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new ObjectIdEntity {anObjectId = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.anObjectId);
+        }
+    }
+
+    [Fact]
+    public void Missing_ObjectId_throws()
+    {
+        var collection = SetupIdOnlyCollection<ObjectIdEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class ObjectIdEntity : BaseIdEntity
+    {
+        public ObjectId anObjectId { get; set; }
+    }
+
+    [Theory]
+    [InlineData("652446393021fe289cf2c197")]
+    [InlineData("64a8583aa1ee84d292c009dd")]
+    [InlineData(null)]
+    public void Nullable_ObjectId_round_trips(string? expectedString)
+    {
+        ObjectId? expected = expectedString == null ? null : ObjectId.Parse(expectedString);
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableObjectIdEntity>(nameof(Nullable_ObjectId_round_trips) + expectedString);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableObjectIdEntity {aNullableObjectId = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableObjectId);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_ObjectId_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableObjectIdEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableObjectId);
+    }
+
+    class NullableObjectIdEntity : BaseIdEntity
+    {
+        public ObjectId? aNullableObjectId { get; set; }
+    }
+
+    [Theory]
+    [InlineData("123456789.12345")]
+    [InlineData("0")]
+    [InlineData("-987654321.01234")]
+    public void Decimal128_round_trips(string expectedString)
+    {
+        Decimal128 expected = Decimal128.Parse(expectedString);
+        var collection = TempDatabase.CreateTemporaryCollection<Decimal128Entity>(nameof(Decimal128_round_trips) + expectedString);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new Decimal128Entity {anDecimal128 = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.anDecimal128);
+        }
+    }
+
+    [Fact]
+    public void Missing_Decimal128_throws()
+    {
+        var collection = SetupIdOnlyCollection<Decimal128Entity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class Decimal128Entity : BaseIdEntity
+    {
+        public Decimal128 anDecimal128 { get; set; }
+    }
+
+    [Theory]
+    [InlineData("123456789.12345")]
+    [InlineData("0")]
+    [InlineData("-987654321.01234")]
+    [InlineData(null)]
+    public void Nullable_Decimal128_round_trips(string? expectedString)
+    {
+        Decimal128? expected = expectedString == null ? null : Decimal128.Parse(expectedString);
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableDecimal128Entity>(nameof(Nullable_Decimal128_round_trips) +
+                                                                             expectedString);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableDecimal128Entity {aNullableDecimal128 = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableDecimal128);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_Decimal128_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableDecimal128Entity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableDecimal128);
+    }
+
+    class NullableDecimal128Entity : BaseIdEntity
+    {
+        public Decimal128? aNullableDecimal128 { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
@@ -1,0 +1,154 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class StringSerializationTests : BaseSerializationTests
+{
+    private static long __collectionCounter;
+    private static readonly object __collectionCounterLock = new();
+
+    public StringSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData("A sample string")]
+    [InlineData("")]
+    [InlineData("\nWith\nNewlines")]
+    [InlineData("With unicode \ud83d\ude0d")]
+    [InlineData(null)]
+    public void String_round_trips(string? expected)
+    {
+        IMongoCollection<StringEntity> collection;
+        lock (__collectionCounterLock)
+            collection = TempDatabase.CreateTemporaryCollection<StringEntity>(nameof(String_round_trips) + __collectionCounter++);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new StringEntity {aString = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aString);
+        }
+    }
+
+    [Fact]
+    public void Missing_string_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<StringEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aString);
+    }
+
+    class StringEntity : BaseIdEntity
+    {
+        public string? aString { get; set; }
+    }
+
+    [Theory]
+    [InlineData(' ')]
+    [InlineData('A')]
+    [InlineData('<')]
+    [InlineData('{')]
+    [InlineData('\n')]
+    [InlineData('\x0169')]
+    public void Char_round_trips(char expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<CharEntity>(nameof(Char_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new CharEntity {aChar = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aChar);
+        }
+    }
+
+    [Fact]
+    public void Missing_char_throws()
+    {
+        var collection = SetupIdOnlyCollection<CharEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class CharEntity : BaseIdEntity
+    {
+        public char aChar { get; set; }
+    }
+
+    [Theory]
+    [InlineData(' ')]
+    [InlineData('A')]
+    [InlineData('<')]
+    [InlineData('{')]
+    [InlineData('\n')]
+    [InlineData('\x0169')]
+    [InlineData(null)]
+    public void Nullable_char_round_trips(char? expected)
+    {
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableCharEntity>(nameof(Nullable_char_round_trips) +
+                                                                       expected?.ToString().Replace(' ', '_'));
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableCharEntity {aNullableChar = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableChar);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_char_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableCharEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableChar);
+    }
+
+    class NullableCharEntity : BaseIdEntity
+    {
+        public char? aNullableChar { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
@@ -20,7 +20,6 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
 public class StringSerializationTests : BaseSerializationTests
 {
     private static long __collectionCounter;
-    private static readonly object __collectionCounterLock = new();
 
     public StringSerializationTests(TemporaryDatabaseFixture tempDatabase)
         : base(tempDatabase)
@@ -35,9 +34,9 @@ public class StringSerializationTests : BaseSerializationTests
     [InlineData(null)]
     public void String_round_trips(string? expected)
     {
-        IMongoCollection<StringEntity> collection;
-        lock (__collectionCounterLock)
-            collection = TempDatabase.CreateTemporaryCollection<StringEntity>(nameof(String_round_trips) + __collectionCounter++);
+        long counter = Interlocked.Increment(ref __collectionCounter);
+        IMongoCollection<StringEntity> collection =
+            TempDatabase.CreateTemporaryCollection<StringEntity>(nameof(String_round_trips) + counter);
 
         {
             using var db = SingleEntityDbContext.Create(collection);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
@@ -205,11 +205,10 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
     [Theory]
     [InlineData(7890)]
-    [InlineData(-123)]
     [InlineData(0)]
     public void Nullable_ushort_round_trips(int? expectedInt)
     {
-        ushort? expected = expectedInt == null ? null : (ushort)expectedInt;
+        ushort? expected = expectedInt == null ? null : Convert.ToUInt16(expectedInt);
         var collection =
             TempDatabase.CreateTemporaryCollection<NullableShortEntity>(nameof(Nullable_ushort_round_trips) + expected);
 
@@ -286,7 +285,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
     [InlineData(null)]
     public void Nullable_byte_round_trips(int? expectedInt)
     {
-        byte? expected = expectedInt == null ? null : (byte)expectedInt;
+        byte? expected = expectedInt == null ? null : Convert.ToByte(expectedInt);
         var collection = TempDatabase.CreateTemporaryCollection<NullableByteEntity>(nameof(Nullable_byte_round_trips) + expected);
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
@@ -1,0 +1,321 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class UnsignedIntegerSerializationTests : BaseSerializationTests
+{
+    public UnsignedIntegerSerializationTests(TemporaryDatabaseFixture tempDatabase)
+        : base(tempDatabase)
+    {
+    }
+
+    [Theory]
+    [InlineData(78910u)]
+    [InlineData(0u)]
+    public void Uint_round_trips(uint expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<UIntEntity>(nameof(Uint_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new UIntEntity {aUint = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aUint);
+        }
+    }
+
+    [Fact]
+    public void Missing_uint_throws()
+    {
+        var collection = SetupIdOnlyCollection<UIntEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class UIntEntity : BaseIdEntity
+    {
+        public uint aUint { get; set; }
+    }
+
+    [Theory]
+    [InlineData(78910U)]
+    [InlineData(0U)]
+    [InlineData(null)]
+    public void Nullable_uint_round_trips(uint? expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<NullableUIntEntity>(nameof(Nullable_uint_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableUIntEntity {aNullableUint = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableUint);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_uint_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableUIntEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableUint);
+    }
+
+    class NullableUIntEntity : BaseIdEntity
+    {
+        public uint? aNullableUint { get; set; }
+    }
+
+    [Theory]
+    [InlineData(78910UL)]
+    [InlineData(0L)]
+    public void Ulong_round_trips(ulong expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<UlongEntity>(nameof(Ulong_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new UlongEntity {aUlong = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aUlong);
+        }
+    }
+
+    [Fact]
+    public void Missing_ulong_throws()
+    {
+        var collection = SetupIdOnlyCollection<UlongEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class UlongEntity : BaseIdEntity
+    {
+        public ulong aUlong { get; set; }
+    }
+
+    [Theory]
+    [InlineData(78910UL)]
+    [InlineData(0UL)]
+    [InlineData(null)]
+    public void Nullable_ulong_round_trips(ulong? expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<NullableUlongEntity>(nameof(Nullable_ulong_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableUlongEntity {aNullableUlong = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableUlong);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_ulong_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableUlongEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableUlong);
+    }
+
+    class NullableUlongEntity : BaseIdEntity
+    {
+        public ulong? aNullableUlong { get; set; }
+    }
+
+    [Theory]
+    [InlineData(7890U)]
+    [InlineData(0)]
+    public void Ushort_round_trips(ushort expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<UshortEntity>(nameof(Ushort_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new UshortEntity {aUshort = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aUshort);
+        }
+    }
+
+    [Fact]
+    public void Missing_ushort_throws()
+    {
+        var collection = SetupIdOnlyCollection<UshortEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class UshortEntity : BaseIdEntity
+    {
+        public ushort aUshort { get; set; }
+    }
+
+    [Theory]
+    [InlineData(7890)]
+    [InlineData(-123)]
+    [InlineData(0)]
+    public void Nullable_ushort_round_trips(int? expectedInt)
+    {
+        ushort? expected = expectedInt == null ? null : (ushort)expectedInt;
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableShortEntity>(nameof(Nullable_ushort_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableShortEntity {aNullableUshort = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableUshort);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_ushort_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableShortEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableUshort);
+    }
+
+    class NullableShortEntity : BaseIdEntity
+    {
+        public ushort? aNullableUshort { get; set; }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(67)]
+    [InlineData(255)]
+    public void Byte_round_trips(byte expected)
+    {
+        var collection = TempDatabase.CreateTemporaryCollection<ByteEntity>(nameof(Byte_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new ByteEntity {aByte = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aByte);
+        }
+    }
+
+    [Fact]
+    public void Missing_byte_throws()
+    {
+        var collection = SetupIdOnlyCollection<ByteEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+    }
+
+    class ByteEntity : BaseIdEntity
+    {
+        public byte aByte { get; set; }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(67)]
+    [InlineData(255)]
+    [InlineData(null)]
+    public void Nullable_byte_round_trips(int? expectedInt)
+    {
+        byte? expected = expectedInt == null ? null : (byte)expectedInt;
+        var collection = TempDatabase.CreateTemporaryCollection<NullableByteEntity>(nameof(Nullable_byte_round_trips) + expected);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entitites.Add(new NullableByteEntity {aNullableByte = expected});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entitites.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.aNullableByte);
+        }
+    }
+
+    [Fact]
+    public void Missing_nullable_byte_defaults_to_null()
+    {
+        var collection = SetupIdOnlyCollection<NullableByteEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var result = db.Entitites.FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Null(result.aNullableByte);
+    }
+
+    class NullableByteEntity : BaseIdEntity
+    {
+        public byte? aNullableByte { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
@@ -19,7 +19,8 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
-public sealed class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
+[XUnitCollection("UpdateTests")]
+public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private static readonly Random __random = new();
     private readonly TemporaryDatabaseFixture _tempDatabase;
@@ -189,20 +190,19 @@ public sealed class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [InlineData(typeof(TestEnum?), null)]
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue0)]
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue1)]
-
     [InlineData(typeof(int[]), null)]
-    [InlineData(typeof(int[]), new[] { -5, 0, 128, 10 })]
+    [InlineData(typeof(int[]), new[] {-5, 0, 128, 10})]
     // TODO: investigate and fix IEnumerable property support
     // [InlineData(typeof(IEnumerable<int>), new[] { -5, 0, 128, 10 })]
     [InlineData(typeof(IList<int>), null)]
-    [InlineData(typeof(IList<int>), new[] { -5, 0, 128, 10 })]
-    [InlineData(typeof(ICollection<int>), new[] { -5, 0, 128, 10 })]
-    [InlineData(typeof(IReadOnlyList<int>), new[] { -5, 0, 128, 10 })]
-    [InlineData(typeof(List<int>), new[] { -5, 0, 128, 10 })]
+    [InlineData(typeof(IList<int>), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(ICollection<int>), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(IReadOnlyList<int>), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(List<int>), new[] {-5, 0, 128, 10})]
     [InlineData(typeof(string[]), null)]
-    [InlineData(typeof(string[]), new[] { "one", "two" })]
+    [InlineData(typeof(string[]), new[] {"one", "two"})]
     [InlineData(typeof(IList<string>), null)]
-    [InlineData(typeof(List<string>), new[] { "one", "two" })]
+    [InlineData(typeof(List<string>), new[] {"one", "two"})]
     public void Entity_add_tests(Type valueType, object? value)
     {
         if (value != null && !value.GetType().IsAssignableTo(valueType))
@@ -211,7 +211,7 @@ public sealed class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         }
 
         var methodInfo = this.GetType().GetMethod(nameof(EntityAddTestImpl), BindingFlags.Instance | BindingFlags.NonPublic);
-        methodInfo.MakeGenericMethod(valueType).Invoke(this, new[] { value });
+        methodInfo.MakeGenericMethod(valueType).Invoke(this, new[] {value});
     }
 
     private enum TestEnum
@@ -226,11 +226,7 @@ public sealed class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new Entity<TValue>
-            {
-                _id = ObjectId.GenerateNewId(),
-                Value = value
-            });
+            dbContext.Entitites.Add(new Entity<TValue> {_id = ObjectId.GenerateNewId(), Value = value});
             dbContext.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/CompositeKeyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/CompositeKeyCrudTests.cs
@@ -1,23 +1,24 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
+[XUnitCollection("UpdateTests")]
 public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
@@ -31,7 +32,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     public void Should_insert_composite_key_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
-        var entity = new Entity { Id1 = "key", Id2 = 2, Data = "some text" };
+        var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, builder =>
@@ -58,7 +59,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     public void Should_read_composite_key_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
-        var entity = new Entity { Id1 = "key", Id2 = 2, Data = "some text" };
+        var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, builder =>
@@ -89,7 +90,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     public void Should_update_composite_key_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
-        var entity = new Entity { Id1 = "key", Id2 = 2, Data = "some text" };
+        var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, builder =>
@@ -125,7 +126,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
-            var entity = new Entity { Id1 = "key", Id2 = 2, Data = "some text" };
+            var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
             dbContext.Entitites.Add(entity);
             dbContext.SaveChanges();
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
@@ -1,23 +1,24 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
-public sealed class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
+[XUnitCollection("UpdateTests")]
+public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
 
@@ -109,5 +110,4 @@ public sealed class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         Assert.Empty(dbContext.Entitites);
     }
-
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
@@ -18,6 +18,7 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
+[XUnitCollection("UpdateTests")]
 public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
@@ -34,7 +35,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity { Id = 1, Name = "John" };
+            var person = new PersonWithCity {Id = 1, Name = "John"};
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -58,14 +59,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {
-                Id = 1,
-                Name = "John",
-                City = new City
-                {
-                    Id = 1,
-                    Name = "New York"
-                }};
+            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -89,14 +83,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {
-                Id = 1,
-                Name = "John",
-                City = new City
-                {
-                    Id = 1,
-                    Name = "New York"
-                }};
+            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -123,19 +110,12 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {
-                Id = 1,
-                Name = "John",
-                City = new City
-                {
-                    Id = 1,
-                    Name = "New York"
-                }};
+            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
 
             db.Entitites.Add(person);
             db.SaveChanges();
 
-            person.City = new City { Id = 2, Name = "Washington"};
+            person.City = new City {Id = 2, Name = "Washington"};
             db.SaveChanges();
         }
 
@@ -157,14 +137,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {
-                Id = 1,
-                Name = "John",
-                City = new City
-                {
-                    Id = 1,
-                    Name = "New York"
-                }};
+            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -191,7 +164,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCities { Id = 1, Name = "John" };
+            var person = new PersonWithCities {Id = 1, Name = "John"};
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -215,21 +188,12 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCities {
+            var person = new PersonWithCities
+            {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {
-                    new City
-                    {
-                        Id = 1,
-                        Name = "New York"
-                    },
-                    new City
-                    {
-                        Id = 2,
-                        Name = "Washington"
-                    }
-                }};
+                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -241,7 +205,9 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 .Project(Builders<PersonWithCities>.Projection.As<BsonDocument>())
                 .Single();
 
-            var expected = BsonDocument.Parse("{ _id : 1, Name: 'John', Cities: [{ Id: 1, Name: 'New York' }, { Id: 2, Name: 'Washington' }] }");
+            var expected =
+                BsonDocument.Parse(
+                    "{ _id : 1, Name: 'John', Cities: [{ Id: 1, Name: 'New York' }, { Id: 2, Name: 'Washington' }] }");
             Assert.Equivalent(expected, actual);
         }
     }
@@ -253,21 +219,12 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCities {
+            var person = new PersonWithCities
+            {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {
-                    new City
-                    {
-                        Id = 1,
-                        Name = "New York"
-                    },
-                    new City
-                    {
-                        Id = 2,
-                        Name = "Washington"
-                    }
-                }};
+                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+            };
 
 
             db.Entitites.Add(person);
@@ -295,26 +252,17 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCities {
+            var person = new PersonWithCities
+            {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {
-                    new City
-                    {
-                        Id = 1,
-                        Name = "New York"
-                    },
-                    new City
-                    {
-                        Id = 2,
-                        Name = "Washington"
-                    }
-                }};
+                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
 
-            person.Cities = person.Cities.Concat(new List<City> { new City { Id = 3, Name = "Denver" } }).ToList();
+            person.Cities = person.Cities.Concat(new List<City> {new City {Id = 3, Name = "Denver"}}).ToList();
             db.SaveChanges();
         }
 
@@ -324,7 +272,9 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 .Project(Builders<PersonWithCities>.Projection.As<BsonDocument>())
                 .Single();
 
-            var expected = BsonDocument.Parse("{ _id : 1, Name: 'John',  Cities: [{ Id: 1, Name: 'New York' }, { Id: 2, Name: 'Washington' }, { Id: 3, Name: 'Denver' }] }");
+            var expected =
+                BsonDocument.Parse(
+                    "{ _id : 1, Name: 'John',  Cities: [{ Id: 1, Name: 'New York' }, { Id: 2, Name: 'Washington' }, { Id: 3, Name: 'Denver' }] }");
             Assert.Equivalent(expected, actual);
         }
     }
@@ -336,21 +286,12 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCities {
+            var person = new PersonWithCities
+            {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {
-                    new City
-                    {
-                        Id = 1,
-                        Name = "New York"
-                    },
-                    new City
-                    {
-                        Id = 2,
-                        Name = "Washington"
-                    }
-                }};
+                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -377,21 +318,12 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCities {
+            var person = new PersonWithCities
+            {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {
-                    new City
-                    {
-                        Id = 1,
-                        Name = "New York"
-                    },
-                    new City
-                    {
-                        Id = 2,
-                        Name = "Washington"
-                    }
-                }};
+                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -406,7 +338,9 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 .Project(Builders<PersonWithCities>.Projection.As<BsonDocument>())
                 .Single();
 
-            var expected = BsonDocument.Parse("{ _id : 1, Name: 'John',  Cities: [{ Id: 1, Name: 'Denver' }, { Id: 2, Name: 'Washington' }] }");
+            var expected =
+                BsonDocument.Parse(
+                    "{ _id : 1, Name: 'John',  Cities: [{ Id: 1, Name: 'Denver' }, { Id: 2, Name: 'Washington' }] }");
             Assert.Equivalent(expected, actual);
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SimpleKeyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SimpleKeyCrudTests.cs
@@ -1,23 +1,24 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
+[XUnitCollection("UpdateTests")]
 public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
@@ -31,7 +32,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     public void Should_insert_composite_key_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
-        var entity = new Entity { Id = "key", Data = "some text" };
+        var entity = new Entity {Id = "key", Data = "some text"};
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, builder =>
@@ -58,7 +59,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     public void Should_read_composite_key_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
-        var entity = new Entity { Id = "key", Data = "some text" };
+        var entity = new Entity {Id = "key", Data = "some text"};
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, builder =>
@@ -88,7 +89,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     public void Should_update_composite_key_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
-        var entity = new Entity { Id = "key", Data = "some text" };
+        var entity = new Entity {Id = "key", Data = "some text"};
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, builder =>
@@ -124,7 +125,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
-            var entity = new Entity { Id = "key", Data = "some text" };
+            var entity = new Entity {Id = "key", Data = "some text"};
             dbContext.Entitites.Add(entity);
             dbContext.SaveChanges();
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
@@ -18,7 +18,8 @@ using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
-public sealed class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
+[XUnitCollection("UpdateTests")]
+public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
 {
     private readonly TemporaryDatabaseFixture _tempDatabase;
 
@@ -107,7 +108,7 @@ public sealed class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void Entity_update_tests(Type valueType, object initialValue, object updatedValue)
     {
         var methodInfo = this.GetType().GetMethod(nameof(EntityAddTestImpl), BindingFlags.Instance | BindingFlags.NonPublic);
-        methodInfo.MakeGenericMethod(valueType).Invoke(this, new[] { initialValue, updatedValue });
+        methodInfo.MakeGenericMethod(valueType).Invoke(this, new[] {initialValue, updatedValue});
     }
 
     private enum TestEnum
@@ -118,11 +119,12 @@ public sealed class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
     private void EntityAddTestImpl<TValue>(TValue initialValue, TValue updatedValue)
     {
-        var collection = _tempDatabase.CreateTemporaryCollection<Entity<TValue>>("EntityUpdateTest", typeof(TValue), initialValue, updatedValue);
+        var collection =
+            _tempDatabase.CreateTemporaryCollection<Entity<TValue>>("EntityUpdateTest", typeof(TValue), initialValue, updatedValue);
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            var entity = new Entity<TValue> { _id = ObjectId.GenerateNewId(), Value = initialValue };
+            var entity = new Entity<TValue> {_id = ObjectId.GenerateNewId(), Value = initialValue};
             dbContext.Entitites.Add(entity);
             dbContext.SaveChanges();
             entity.Value = updatedValue;

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Usings.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Usings.cs
@@ -1,17 +1,18 @@
 /* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 global using Xunit;
+global using XUnitCollection = Xunit.CollectionAttribute;
 global using MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;


### PR DESCRIPTION
Adds much-needed test coverage for ensuring serialization and deserialization of types including a couple of fixes:

- Nullable types do not throw if no element in doc (includes arrays/lists)
- Non-nullable types continue to throw (exception to be revised later)
- TimeSpan now supported