### PR TITLE
Fix anonymous & tuple projections

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
@@ -22,7 +22,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Query;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -40,7 +40,7 @@ public class ProjectionTests
         });
     }
 
-    [Fact(Skip = "Require to implement the missed case in BsonBinding.CreateGetValueExpression method")]
+    [Fact]
     public void Select_projection_to_anonymous()
     {
         var results = _planets.Select(p => new {Name = p.name, Order = p.orderFromSun});
@@ -62,7 +62,7 @@ public class ProjectionTests
         });
     }
 
-    [Fact(Skip = "Requires Select projection rewriting")]
+    [Fact]
     public void Select_projection_to_tuple()
     {
         var results = _planets.Select(p => Tuple.Create(p.name, p.orderFromSun, p.hasRings));
@@ -86,7 +86,6 @@ public class ProjectionTests
         var results = _planets.Select(p => new NamedContainer<Planet>(p, p.name));
         Assert.All(results, r => { Assert.Equal(r.Name, r?.Item?.name); });
     }
-
 
     [Fact(Skip = "Requires Select projection rewriting")]
     public void Select_projection_to_constructor_params_and_initializer()


### PR DESCRIPTION
We planned to originally support a couple of projection types in preview 1 but they didn't make the cut-off and were limited to only Tuple and anonymous anyway.

Just fixing them here as a refresher before evolving how we do projections to support more scenarios.