### PR TITLE
Handle cluster connection strings in the UseMongoDb overload.

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
@@ -148,9 +148,9 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
     {
         if (connectionString == null) return null;
 
-        var uriBuilder = new UriBuilder(connectionString);
-        uriBuilder.Password = string.IsNullOrWhiteSpace(uriBuilder.Password) ? uriBuilder.Password : "redacted";
-        return uriBuilder.ToString();
+        var builder = new MongoUrlBuilder(connectionString);
+        builder.Password = string.IsNullOrWhiteSpace(builder.Password) ? builder.Password : "redacted";
+        return builder.ToString();
     }
 
     private sealed class ExtensionInfo : DbContextOptionsExtensionInfo

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
@@ -1,17 +1,17 @@
 /* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -25,6 +25,7 @@ public static class MongoDbContextOptionsExtensionsTest
 {
     [Theory]
     [InlineData("mongodb://localhost:1234", "myDatabaseName")]
+    [InlineData("mongodb://localhost:1234,localhost:27017", "clusters")]
     public static void Can_configure_connection_string_and_database_name(string connectionString, string databaseName)
     {
         var serviceCollection = new ServiceCollection();


### PR DESCRIPTION
The `.UseMongoDb` overload that takes a connection string does not handle the MongoDB cluster format.

This is because they are not a technically valid Uri and the code was using `UriBuilder` to check for the presence of a password to ensure it is sanitized for logging purposes.

This PR switches it from `UriBuilder` to `MongoUriBuilder` which does handle the cluster format and adds test coverage.