### PR TITLE
Handle no BSON element for nullable child docs

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -89,9 +89,9 @@ internal static class BsonBinding
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
             .Single(mi => mi.Name == nameof(GetBsonDocument));
 
-    private static BsonDocument? GetBsonDocument(BsonValue parent, string name, bool required, IEntityType entityType)
+    private static BsonDocument? GetBsonDocument(BsonDocument parent, string name, bool required, IReadOnlyTypeBase entityType)
     {
-        BsonValue? value = parent[name];
+        BsonValue? value = parent.GetValue(name, BsonNull.Value);
 
         if (value == BsonNull.Value && required)
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -41,6 +41,20 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     }
 
     [Fact]
+    public void OwnedEntity_missing_document_element_does_not_throw()
+    {
+        _tempDatabase.CreateTemporaryCollection<Person>("personNoLocation").WriteTestDocs([new Person { name = "Bill" }]);
+
+        var collection = _tempDatabase.MongoDatabase.GetCollection<PersonWithOptionalLocation>("personNoLocation");
+        var db = SingleEntityDbContext.Create(collection);
+
+        var person = db.Entitites.First();
+        Assert.NotNull(person);
+        Assert.Equal("Bill", person.name);
+        Assert.Null(person.location);
+    }
+
+    [Fact]
     public void OwnedEntity_nested_one_level_allows_nested_where()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
@@ -284,6 +298,11 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         public ObjectId _id { get; set; }
         public string name { get; set; }
+    }
+
+    private class PersonWithOptionalLocation : Person
+    {
+        public Location? location { get; set; }
     }
 
     private class PersonWithLocation : Person


### PR DESCRIPTION
Ensure that we support loading BSON documents where a child document element is entirely missing from the BSON providing the element is nullable in the entity.

Fixes EF-101