### PR TITLE
allow models to have plain IEnumerable<T> collections

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Serializers/CollectionSerializationProvider.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/CollectionSerializationProvider.cs
@@ -54,8 +54,10 @@ internal class ListSerializationProvider : BsonSerializationProviderBase
 
     private IBsonSerializer? CreateCollectionSerializer(Type type, IBsonSerializerRegistry serializerRegistry)
     {
-        var enumerableInterface = type.GetInterfaces()
-            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+        var enumerableInterface = type.GetGenericTypeDefinition() == typeof(IEnumerable<>) ?
+            type :
+            type.GetInterfaces()
+                .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
 
         if (enumerableInterface == null) return null;
 


### PR DESCRIPTION
This patch enables models to have plain `IEnumerable<T>` properties and not just derived types (such as `List<T>`).

This is a follow-up on #57 by @damieng 