### PR TITLE
Init primitive+owned entity collections when empty etc.

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/PrimitiveCollectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/PrimitiveCollectionTests.cs
@@ -1,0 +1,127 @@
+﻿using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+[XUnitCollection(nameof(SampleGuidesFixture))]
+public class PrimitiveCollectionTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture<TemporaryDatabaseFixture>
+{
+    class MissingPrimitiveList
+    {
+        public ObjectId _id { get; set; }
+    }
+
+    class NonNullablePrimitiveList
+    {
+        public ObjectId _id { get; set; }
+        public List<int> items { get; set; }
+    }
+
+    class NullablePrimitiveList
+    {
+        public ObjectId _id { get; set; }
+        public List<int>? items { get; set; }
+    }
+
+    class NonNullablePrimitiveArray
+    {
+        public ObjectId _id { get; set; }
+        public int[] items { get; set; }
+    }
+
+    class NullablePrimitiveArray
+    {
+        public ObjectId _id { get; set; }
+        public int[]? items { get; set; }
+    }
+
+    [Fact]
+    public void Non_nullable_primitive_list_is_empty_when_bson_empty()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<NonNullablePrimitiveList>();
+        collection.WriteTestDocs([
+            new NonNullablePrimitiveList
+            {
+                items = []
+            }
+        ]);
+        var db = SingleEntityDbContext.Create(collection);
+
+        var actual = db.Entitites.First();
+        Assert.Empty(actual.items);
+    }
+
+    [Fact]
+    public void Non_nullable_primitive_list_throws_when_bson_missing()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<MissingPrimitiveList>();
+        collection.WriteTestDocs([new MissingPrimitiveList()]);
+        var db = SingleEntityDbContext.Create<MissingPrimitiveList, NonNullablePrimitiveArray>(collection);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.First());
+        Assert.Contains("null", ex.Message);
+        Assert.Contains("non-nullable", ex.Message);
+        Assert.Contains(nameof(NonNullablePrimitiveList.items), ex.Message);
+    }
+
+    [Fact]
+    public void Non_nullable_primitive_list_throws_when_bson_null()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<NonNullablePrimitiveList>();
+        collection.WriteTestDocs([
+            new NonNullablePrimitiveList
+            {
+                items = null
+            }
+        ]);
+        var db = SingleEntityDbContext.Create(collection);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.First());
+        Assert.Contains("null", ex.Message);
+        Assert.Contains("non-nullable", ex.Message);
+        Assert.Contains(nameof(NonNullablePrimitiveList.items), ex.Message);
+    }
+
+    [Fact]
+    public void Nullable_primitive_list_is_null_when_bson_missing()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<MissingPrimitiveList>();
+        collection.WriteTestDocs([new MissingPrimitiveList()]);
+        var db = SingleEntityDbContext.Create<MissingPrimitiveList, NullablePrimitiveArray>(collection);
+
+        var actual = db.Entitites.First();
+        Assert.Null(actual.items);
+    }
+
+    [Fact]
+    public void Nullable_primitive_list_is_empty_when_bson_empty()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<NullablePrimitiveList>();
+        collection.WriteTestDocs([
+            new NullablePrimitiveList
+            {
+                items = []
+            }
+        ]);
+        var db = SingleEntityDbContext.Create(collection);
+
+        var actual = db.Entitites.First();
+        Assert.NotNull(actual.items);
+        Assert.Empty(actual.items);
+    }
+
+    [Fact]
+    public void Nullable_primitive_list_is_null_when_bson_null()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<NullablePrimitiveList>();
+        collection.WriteTestDocs([
+            new NullablePrimitiveList
+            {
+                items = null
+            }
+        ]);
+        var db = SingleEntityDbContext.Create(collection);
+
+        var actual = db.Entitites.First();
+        Assert.Null(actual.items);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BooleanSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BooleanSerializationTests.cs
@@ -31,7 +31,10 @@ public class BooleanSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new BooleanEntity {aBoolean = expected});
+            db.Entitites.Add(new BooleanEntity
+            {
+                aBoolean = expected
+            });
             db.SaveChanges();
         }
 
@@ -49,7 +52,7 @@ public class BooleanSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<BooleanEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class BooleanEntity : BaseIdEntity
@@ -68,7 +71,10 @@ public class BooleanSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableBooleanEntity {aNullableBoolean = expected});
+            db.Entitites.Add(new NullableBooleanEntity
+            {
+                aNullableBoolean = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
@@ -31,7 +31,10 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new IntArrayEntity {anIntArray = expected});
+            db.Entitites.Add(new IntArrayEntity
+            {
+                anIntArray = expected
+            });
             db.SaveChanges();
         }
 
@@ -49,7 +52,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<IntArrayEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class IntArrayEntity : BaseIdEntity
@@ -63,11 +66,16 @@ public class CollectionSerializationTests : BaseSerializationTests
     [InlineData(2, 4, 8, 16, 32, 64)]
     public void Nullable_int_array_round_trips(params int[] expected)
     {
-        var collection = TempDatabase.CreateTemporaryCollection<NullableIntArrayEntity>(nameof(Nullable_int_array_round_trips) + expected.Length);
+        var collection =
+            TempDatabase.CreateTemporaryCollection<NullableIntArrayEntity>(nameof(Nullable_int_array_round_trips)
+                                                                           + expected.Length);
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableIntArrayEntity {anIntArray = expected});
+            db.Entitites.Add(new NullableIntArrayEntity
+            {
+                anIntArray = expected
+            });
             db.SaveChanges();
         }
 
@@ -106,7 +114,10 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new StringArrayEntity {aStringArray = expected});
+            db.Entitites.Add(new StringArrayEntity
+            {
+                aStringArray = expected
+            });
             db.SaveChanges();
         }
 
@@ -124,7 +135,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<StringArrayEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class StringArrayEntity : BaseIdEntity
@@ -139,11 +150,15 @@ public class CollectionSerializationTests : BaseSerializationTests
     public void Nullable_string_array_round_trips(params string[] expected)
     {
         var collection =
-            TempDatabase.CreateTemporaryCollection<NullableStringArrayEntity>(nameof(Nullable_string_array_round_trips) + expected.Length);
+            TempDatabase.CreateTemporaryCollection<NullableStringArrayEntity>(nameof(Nullable_string_array_round_trips)
+                                                                              + expected.Length);
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableStringArrayEntity {aStringArray = expected});
+            db.Entitites.Add(new NullableStringArrayEntity
+            {
+                aStringArray = expected
+            });
             db.SaveChanges();
         }
 
@@ -181,7 +196,10 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new ListEntity {aList = new List<int>(expected)});
+            db.Entitites.Add(new ListEntity
+            {
+                aList = new List<int>(expected)
+            });
             db.SaveChanges();
         }
 
@@ -199,7 +217,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ListEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class ListEntity : BaseIdEntity
@@ -217,7 +235,10 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableListEntity {aList = new List<int>(expected)});
+            db.Entitites.Add(new NullableListEntity
+            {
+                aList = new List<int>(expected)
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
@@ -32,7 +32,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DateTimeEntity {aDateTime = expected});
+            db.Entitites.Add(new DateTimeEntity
+            {
+                aDateTime = expected
+            });
             db.SaveChanges();
         }
 
@@ -53,7 +56,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         {
             using var db = SingleEntityDbContext.Create(collection,
                 model => model.Entity<DateTimeEntity>().Property(e => e.aDateTime).HasDateTimeKind(DateTimeKind.Local));
-            db.Entitites.Add(new DateTimeEntity {aDateTime = expected});
+            db.Entitites.Add(new DateTimeEntity
+            {
+                aDateTime = expected
+            });
             db.SaveChanges();
         }
 
@@ -72,7 +78,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DateTimeEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class DateTimeEntity : BaseIdEntity
@@ -88,7 +94,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeEntity {aNullableDateTime = expected});
+            db.Entitites.Add(new NullableDateTimeEntity
+            {
+                aNullableDateTime = expected
+            });
             db.SaveChanges();
         }
 
@@ -108,7 +117,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeEntity {aNullableDateTime = expected});
+            db.Entitites.Add(new NullableDateTimeEntity
+            {
+                aNullableDateTime = expected
+            });
             db.SaveChanges();
         }
 
@@ -144,7 +156,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DateTimeOffsetEntity {aDateTimeOffset = expected});
+            db.Entitites.Add(new DateTimeOffsetEntity
+            {
+                aDateTimeOffset = expected
+            });
             db.SaveChanges();
         }
 
@@ -162,7 +177,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DateTimeOffsetEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class DateTimeOffsetEntity : BaseIdEntity
@@ -178,7 +193,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeOffsetEntity {aNullableDateTimeOffset = expected});
+            db.Entitites.Add(new NullableDateTimeOffsetEntity
+            {
+                aNullableDateTimeOffset = expected
+            });
             db.SaveChanges();
         }
 
@@ -198,7 +216,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeOffsetEntity {aNullableDateTimeOffset = expected});
+            db.Entitites.Add(new NullableDateTimeOffsetEntity
+            {
+                aNullableDateTimeOffset = expected
+            });
             db.SaveChanges();
         }
 
@@ -235,7 +256,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new TimeSpanEntity {aTimeSpan = expected});
+            db.Entitites.Add(new TimeSpanEntity
+            {
+                aTimeSpan = expected
+            });
             db.SaveChanges();
         }
 
@@ -253,7 +277,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<TimeSpanEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class TimeSpanEntity : BaseIdEntity
@@ -274,7 +298,10 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableTimeSpanEntity {aNullableTimeSpan = expected});
+            db.Entitites.Add(new NullableTimeSpanEntity
+            {
+                aNullableTimeSpan = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
@@ -33,7 +33,10 @@ public class DecimalSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DecimalEntity {aDecimal = expected});
+            db.Entitites.Add(new DecimalEntity
+            {
+                aDecimal = expected
+            });
             db.SaveChanges();
         }
 
@@ -51,7 +54,7 @@ public class DecimalSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DecimalEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class DecimalEntity : BaseIdEntity
@@ -73,7 +76,10 @@ public class DecimalSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDecimalEntity {aNullableDecimal = expected});
+            db.Entitites.Add(new NullableDecimalEntity
+            {
+                aNullableDecimal = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/FloatingSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/FloatingSerializationTests.cs
@@ -32,7 +32,10 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new FloatEntity {aFloat = expected});
+            db.Entitites.Add(new FloatEntity
+            {
+                aFloat = expected
+            });
             db.SaveChanges();
         }
 
@@ -50,7 +53,7 @@ public class FloatingSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<FloatEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class FloatEntity : BaseIdEntity
@@ -69,7 +72,10 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableFloatEntity {aNullableFloat = expected});
+            db.Entitites.Add(new NullableFloatEntity
+            {
+                aNullableFloat = expected
+            });
             db.SaveChanges();
         }
 
@@ -107,7 +113,10 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DoubleEntity {aDouble = expected});
+            db.Entitites.Add(new DoubleEntity
+            {
+                aDouble = expected
+            });
             db.SaveChanges();
         }
 
@@ -125,7 +134,7 @@ public class FloatingSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DoubleEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class DoubleEntity : BaseIdEntity
@@ -145,7 +154,10 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDoubleEntity {aNullableDouble = expected});
+            db.Entitites.Add(new NullableDoubleEntity
+            {
+                aNullableDouble = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
@@ -35,7 +35,10 @@ public class GuidSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new GuidEntity {aGuid = expected});
+            db.Entitites.Add(new GuidEntity
+            {
+                aGuid = expected
+            });
             db.SaveChanges();
         }
 
@@ -53,7 +56,7 @@ public class GuidSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<GuidEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class GuidEntity : BaseIdEntity
@@ -75,7 +78,10 @@ public class GuidSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableGuidEntity {aNullableGuid = expected});
+            db.Entitites.Add(new NullableGuidEntity
+            {
+                aNullableGuid = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
@@ -32,7 +32,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new IntEntity {anInt = expected});
+            db.Entitites.Add(new IntEntity
+            {
+                anInt = expected
+            });
             db.SaveChanges();
         }
 
@@ -50,7 +53,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<IntEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class IntEntity : BaseIdEntity
@@ -69,7 +72,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableIntEntity {aNullableInt = expected});
+            db.Entitites.Add(new NullableIntEntity
+            {
+                aNullableInt = expected
+            });
             db.SaveChanges();
         }
 
@@ -107,7 +113,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new LongEntity {aLong = expected});
+            db.Entitites.Add(new LongEntity
+            {
+                aLong = expected
+            });
             db.SaveChanges();
         }
 
@@ -125,7 +134,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<LongEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class LongEntity : BaseIdEntity
@@ -144,7 +153,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableLongEntity {aNullableLong = expected});
+            db.Entitites.Add(new NullableLongEntity
+            {
+                aNullableLong = expected
+            });
             db.SaveChanges();
         }
 
@@ -182,7 +194,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new ShortEntity {aShort = expected});
+            db.Entitites.Add(new ShortEntity
+            {
+                aShort = expected
+            });
             db.SaveChanges();
         }
 
@@ -200,7 +215,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ShortEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class ShortEntity : BaseIdEntity
@@ -219,7 +234,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableShortEntity {aNullableShort = expected});
+            db.Entitites.Add(new NullableShortEntity
+            {
+                aNullableShort = expected
+            });
             db.SaveChanges();
         }
 
@@ -258,7 +276,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new SByteEntity {aByte = expected});
+            db.Entitites.Add(new SByteEntity
+            {
+                aByte = expected
+            });
             db.SaveChanges();
         }
 
@@ -276,7 +297,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<SByteEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class SByteEntity : BaseIdEntity
@@ -297,7 +318,10 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableSByteEntity {aNullableSByte = expected});
+            db.Entitites.Add(new NullableSByteEntity
+            {
+                aNullableSByte = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
@@ -34,7 +34,10 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new ObjectIdEntity {anObjectId = expected});
+            db.Entitites.Add(new ObjectIdEntity
+            {
+                anObjectId = expected
+            });
             db.SaveChanges();
         }
 
@@ -52,7 +55,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ObjectIdEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class ObjectIdEntity : BaseIdEntity
@@ -72,7 +75,10 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableObjectIdEntity {aNullableObjectId = expected});
+            db.Entitites.Add(new NullableObjectIdEntity
+            {
+                aNullableObjectId = expected
+            });
             db.SaveChanges();
         }
 
@@ -111,7 +117,10 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new Decimal128Entity {anDecimal128 = expected});
+            db.Entitites.Add(new Decimal128Entity
+            {
+                anDecimal128 = expected
+            });
             db.SaveChanges();
         }
 
@@ -129,7 +138,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<Decimal128Entity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class Decimal128Entity : BaseIdEntity
@@ -151,7 +160,10 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDecimal128Entity {aNullableDecimal128 = expected});
+            db.Entitites.Add(new NullableDecimal128Entity
+            {
+                aNullableDecimal128 = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
@@ -40,7 +40,10 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new StringEntity {aString = expected});
+            db.Entitites.Add(new StringEntity
+            {
+                aString = expected
+            });
             db.SaveChanges();
         }
 
@@ -81,7 +84,10 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new CharEntity {aChar = expected});
+            db.Entitites.Add(new CharEntity
+            {
+                aChar = expected
+            });
             db.SaveChanges();
         }
 
@@ -99,7 +105,7 @@ public class StringSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<CharEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class CharEntity : BaseIdEntity
@@ -123,7 +129,10 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableCharEntity {aNullableChar = expected});
+            db.Entitites.Add(new NullableCharEntity
+            {
+                aNullableChar = expected
+            });
             db.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
@@ -49,7 +49,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<UIntEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class UIntEntity : BaseIdEntity
@@ -122,7 +122,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<UlongEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class UlongEntity : BaseIdEntity
@@ -195,7 +195,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<UshortEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class UshortEntity : BaseIdEntity
@@ -270,7 +270,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ByteEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<KeyNotFoundException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
     }
 
     class ByteEntity : BaseIdEntity

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SingleEntityDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SingleEntityDbContext.cs
@@ -26,12 +26,12 @@ internal static class SingleEntityDbContext
 {
     private static readonly ConcurrentDictionary<object, DbContextOptions> __collectionOptionsCache = new();
 
-    private static DbContextOptions<SingleEntityDbContext<T>> GetOrCreateOptionsBuilder<T>(IMongoCollection<T> collection) where T:class
+    private static DbContextOptions<SingleEntityDbContext<T2>> GetOrCreateOptionsBuilder<T1, T2>(IMongoCollection<T1> collection) where T1:class where T2:class
     {
         if (__collectionOptionsCache.TryGetValue(collection, out var existingOptions))
-            return  (DbContextOptions<SingleEntityDbContext<T>>) existingOptions;
+            return (DbContextOptions<SingleEntityDbContext<T2>>) existingOptions;
 
-        var newOptions = new DbContextOptionsBuilder<SingleEntityDbContext<T>>()
+        var newOptions = new DbContextOptionsBuilder<SingleEntityDbContext<T2>>()
             .UseMongoDB(collection.Database.Client, collection.Database.DatabaseNamespace.DatabaseName)
             .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
             .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
@@ -43,7 +43,10 @@ internal static class SingleEntityDbContext
     }
 
     public static SingleEntityDbContext<T> Create<T>(IMongoCollection<T> collection, Action<ModelBuilder>? modelBuilderAction = null) where T:class =>
-        new (GetOrCreateOptionsBuilder(collection), collection.CollectionNamespace.CollectionName, modelBuilderAction);
+        new (GetOrCreateOptionsBuilder<T, T>(collection), collection.CollectionNamespace.CollectionName, modelBuilderAction);
+
+    public static SingleEntityDbContext<T2> Create<T1, T2>(IMongoCollection<T1> collection, Action<ModelBuilder>? modelBuilderAction = null) where T1:class where T2:class
+        => new (GetOrCreateOptionsBuilder<T1, T2>(collection), collection.CollectionNamespace.CollectionName, modelBuilderAction);
 
     private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
     {

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Serializers/SerializationHelperTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Serializers/SerializationHelperTests.cs
@@ -22,10 +22,9 @@ public class SerializationHelperTests
     {
         var document = BsonDocument.Parse("{ property: 12 }");
 
-        var exception = Record.Exception(() => SerializationHelper.GetElementValue<int>(document, "missedElementName"));
+        var ex = Assert.Throws<InvalidOperationException>(() => SerializationHelper.GetElementValue<int>(document, "missedElementName"));
 
-        Assert.IsType<KeyNotFoundException>(exception);
-        Assert.Contains("missedElementName", exception.Message);
+        Assert.Contains("missedElementName", ex.Message);
     }
 
     [Fact]
@@ -65,10 +64,8 @@ public class SerializationHelperTests
         var property = entity.GetProperty(nameof(TestEntity.IntProperty));
         var document = BsonDocument.Parse("{ property: 12 }");
 
-        var exception = Record.Exception(() => SerializationHelper.GetPropertyValue<int>(document, property));
-
-        Assert.IsType<KeyNotFoundException>(exception);
-        Assert.Contains("IntProperty", exception.Message);
+        var ex = Assert.Throws<InvalidOperationException>(() => SerializationHelper.GetPropertyValue<int>(document, property));
+        Assert.Contains("IntProperty", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
How we initialize collections was inconsistent and difficult to use. This PR attempts to improve this although some scenarios are still less than ideal due to the limitations with EF8. Fixes [EF-105](https://jira.mongodb.org/browse/EF-105).

## Primitive collections (e.g. List<int>)

- Empty BSON array: Initialize as empty
- Null BSON element: Throw if non-nullable, set to null if nullable
- Missing element: Throw if non-nullable, set to null if nullable

## Owned entity collections (e.g. List<Address>)

- Empty BSON array: Initialize as empty
- Null BSON element: Initialize as null
- Missing BSON element: Throws InvalidOperation exception letting the user know

## Rationale

The inconsistency is because EF collect the nullability metadata from the nullable reference type annotations Roslyn emits only for properties and 1-1 based navigations not collections. We could consider doing this ourselves in the future or see what EF9 does.

We could also visit add some configuration options as initializing missing keys would be useful for migrations. This might interplay with the default value work.

FWIW the Cosmos provider in EF8 is even more inconsistent with it's handling of empty, null and missing of owned entity collections.

## Additional

Changed the "missing BSON" exception to InvalidOperation to be consistent with the other exceptions rather than letting the KeyNotFound exception leak out from the Mongo C# Driver BSON code.