### PR TITLE
Add support for MQL query logging

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -11,44 +11,45 @@ The attached notices are provided for information only.
 For any licenses that require disclosure of source, sources are available at
 https://github.com/mongodb/mongo-ef-core-provider.
 
-1. The following files: EnumerabloeMethods.cs, ProjectionExpression.cs, ObjectAccessExpression.cs,
+1. The following files: EnumerableMethods.cs, ProjectionExpression.cs, ObjectAccessExpression.cs,
    CollectionShaperExpression.cs, ObjectArrayProjectionExpression.cs, EntityProjectionExpression.cs,
-   and ProjectionBindingRemovingExpressionVisitorBase.cs are from the EFCore repository.
+   and ProjectionBindingRemovingExpressionVisitorBase.cs, NonCapturingLazyInitializer.cs
+   contain significant code from the Microsoft EF Core repository at https://github.com/dotnet/efcore
 
-   Original work: 
+   Original work:
      The MIT License (MIT)
-     
+
      Copyright (c) .NET Foundation and Contributors
-     
+
      All rights reserved.
-     
+
      Permission is hereby granted, free of charge, to any person obtaining a copy
      of this software and associated documentation files (the "Software"), to deal
      in the Software without restriction, including without limitation the rights
      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
      copies of the Software, and to permit persons to whom the Software is
      furnished to do so, subject to the following conditions:
-     
+
      The above copyright notice and this permission notice shall be included in all
      copies or substantial portions of the Software.
-     
+
      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-     SOFTWARE.     
+     SOFTWARE.
 
    Modified work:
      Copyright (c) 2023–present MongoDB Inc.
-  
+
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
      You may obtain a copy of the License at
-     
+
      http://www.apache.org/licenses/LICENSE-2.0
-     
+
      Unless required by applicable law or agreed to in writing, software
      distributed under the License is distributed on an "AS IS" BASIS,
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -422,10 +422,10 @@ axes:
   - id: driver
     display_name: MongoDB.Driver Version
     values:
-      - id: "2.22.0"
-        display_name: "2.22.0"
+      - id: "2.25.0"
+        display_name: "2.25.0"
         variables:
-          DRIVER_VERSION: "2.22.0"
+          DRIVER_VERSION: "2.25.0"
       - id: "latest"
         display_name: "Latest"
         variables:

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
@@ -1,0 +1,54 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace MongoDB.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+/// Event IDs for MongoDB events that correspond to messages logged to an <see cref="ILogger" />
+/// and events sent to a <see cref="DiagnosticSource" />.
+/// </summary>
+/// <remarks>
+/// These IDs are also used with <see cref="WarningsConfigurationBuilder" /> to configure the behavior of warnings.
+/// </remarks>
+public static class MongoEventId
+{
+    // Warning: These values must not change between releases.
+    // Only add new values to the end of sections, never in the middle.
+    private enum Id
+    {
+        ExecutedMqlQuery = CoreEventId.ProviderDesignBaseId
+    }
+
+    /// <summary>
+    /// An MQL query has been executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.</para>
+    /// <para>
+    /// This event uses the <see cref="MongoQueryEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    /// </para>
+    /// </remarks>
+    public static readonly EventId ExecutedMqlQuery = MakeEventId(Id.ExecutedMqlQuery);
+
+    private static readonly string EventPrefix = DbLoggerCategory.Database.Command.Name + ".";
+
+    private static EventId MakeEventId(Id id)
+        => new((int)id, EventPrefix + id);
+}

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
@@ -1,0 +1,106 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+/// MongoDB-specific logging extensions.
+/// </summary>
+internal static class MongoLoggerExtensions
+{
+    public static void ExecutedMqlQuery(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        CollectionNamespace collectionNamespace,
+        BsonDocument[]? loggedStages)
+    {
+        var definition = LogExecutedMqlQuery(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            var logSensitiveData = diagnostics.ShouldLogSensitiveData();
+
+            // Ideally we would always log the query and only log the parameters
+            // when sensitive data is enabled but unfortunately the LINQ provider
+            // does not provide a layer for this.
+            if (logSensitiveData)
+            {
+                definition.Log(
+                    diagnostics,
+                    Environment.NewLine,
+                    collectionNamespace,
+                    LoggedStagesToMql(loggedStages));
+            }
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MongoQueryEventData(
+                definition,
+                ExecutedMqlQuery,
+                collectionNamespace,
+                LoggedStagesToMql(loggedStages),
+                diagnostics.ShouldLogSensitiveData());
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
+    private static string LoggedStagesToMql(BsonDocument[]? documents)
+        => documents == null
+            ? ""
+            : string.Join(", ", documents.Select(d => d.ToString()));
+
+    private static string ExecutedMqlQuery(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (EventDefinition<string, CollectionNamespace, string>)definition;
+        var p = (MongoQueryEventData)payload;
+        return d.GenerateMessage(
+            Environment.NewLine,
+            p.CollectionNamespace,
+            p.QueryMql);
+    }
+
+    private static EventDefinition<string, CollectionNamespace, string> LogExecutedMqlQuery(IDiagnosticsLogger logger)
+    {
+        var definition = ((MongoLoggingDefinitions)logger.Definitions).LogExecutedMqlQuery;
+        if (definition == null)
+        {
+            definition = NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutedMqlQuery,
+                logger,
+                static logger => new EventDefinition<string, CollectionNamespace, string>(
+                    logger.Options,
+                    MongoEventId.ExecutedMqlQuery,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutedMqlQuery",
+                    level => LoggerMessage.Define<string, CollectionNamespace, string>(
+                        level,
+                        MongoEventId.ExecutedMqlQuery,
+                        LogExecutedMqlQueryString)));
+        }
+
+        return (EventDefinition<string, CollectionNamespace, string>)definition;
+    }
+
+    private const string LogExecutedMqlQueryString = "Executed MQL query{newLine}{collectionNamespace}.aggregate([{queryMql}])";
+}

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
@@ -1,17 +1,17 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -22,5 +22,5 @@ namespace MongoDB.EntityFrameworkCore.Diagnostics;
 /// </summary>
 public class MongoLoggingDefinitions : LoggingDefinitions
 {
-    // TODO: Implement some additional MongoDB-specific logging definitions
+    public EventDefinitionBase? LogExecutedMqlQuery;
 }

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoQueryEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoQueryEventData.cs
@@ -1,0 +1,66 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+/// A <see cref="DiagnosticSource" /> event payload class for MongoDB query events.
+/// </summary>
+/// <remarks>
+/// See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public class MongoQueryEventData : EventData
+{
+    /// <summary>
+    /// Constructs the event payload.
+    /// </summary>
+    /// <param name="eventDefinition">The event definition.</param>
+    /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
+    /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> being queried.</param>
+    /// <param name="queryMql">The MQL representing the query.</param>
+    /// <param name="logSensitiveData">Indicates whether the application allows logging of sensitive data.</param>
+    public MongoQueryEventData(
+        EventDefinitionBase eventDefinition,
+        Func<EventDefinitionBase, EventData, string> messageGenerator,
+        CollectionNamespace collectionNamespace,
+        string queryMql,
+        bool logSensitiveData)
+        : base(eventDefinition, messageGenerator)
+    {
+        CollectionNamespace = collectionNamespace;
+        QueryMql = queryMql;
+        LogSensitiveData = logSensitiveData;
+    }
+
+    /// <summary>
+    /// The <see cref="CollectionNamespace"/> being queried.
+    /// </summary>
+    public virtual CollectionNamespace CollectionNamespace { get; }
+
+    /// <summary>
+    /// The MQL representing the query.
+    /// </summary>
+    public virtual string QueryMql { get; }
+
+    /// <summary>
+    /// Indicates whether the application allows logging of sensitive data.
+    /// </summary>
+    public virtual bool LogSensitiveData { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/NonCapturingLazyInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/NonCapturingLazyInitializer.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Originally from EFCore NonCapturingLazyInitializer.cs
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace MongoDB.EntityFrameworkCore.Diagnostics;
+
+internal static class NonCapturingLazyInitializer
+{
+    public static TValue EnsureInitialized<TParam, TValue>(
+        [NotNull] ref TValue? target,
+        TParam param,
+        Func<TParam, TValue> valueFactory)
+        where TValue : class
+    {
+        var tmp = Volatile.Read(ref target);
+        if (tmp != null)
+        {
+            return tmp;
+        }
+
+        Interlocked.CompareExchange(ref target, valueFactory(param), null);
+
+        return target;
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
+++ b/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.UnitTests" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
-    <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
     <PackageReference Remove="Microsoft.SourceLink.GitHub"/>
   </ItemGroup>
 </Project>

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
@@ -1,0 +1,31 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.Query;
+
+/// <summary>
+/// Internal use only.
+/// A query ready to be executed by the MongoDB LINQ provider.
+/// </summary>
+/// <param name="Query">A LINQ query <see cref="Expression"/> compatible with the MongoDB LINQ provider.</param>
+/// <param name="Cardinality">Whether many or a single result are expected (or enforced) as a <see cref="ResultCardinality"/>.</param>
+/// <param name="Provider">The MongoDB V3 LINQ <see cref="IQueryProvider"/> that will execute this query.</param>
+/// <param name="CollectionNamespace">The <see cref="CollectionNamespace"/> this query will run against.</param>
+public record MongoExecutableQuery(Expression Query, ResultCardinality Cardinality, IQueryProvider Provider, CollectionNamespace CollectionNamespace);

--- a/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
@@ -1,19 +1,22 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+using System;
+using System.Collections.Generic;
 using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
 
@@ -23,9 +26,20 @@ namespace MongoDB.EntityFrameworkCore.Storage;
 /// </summary>
 public interface IMongoClientWrapper
 {
-    // TODO: Consider hiding and providing functions that map to it as-required
+    /// <summary>
+    /// The <see cref="IMongoDatabase"/> this client is connected to.
+    /// </summary>
     public IMongoDatabase Database { get; }
 
-    // TODO: Add query execution operations
+    /// <summary>
+    /// For internal use only. Interface may change between minor versions.
+    /// A query and the associated metadata and provider needed to execute that query.
+    /// </summary>
+    /// <param name="executableQuery">The <see cref="MongoExecutableQuery"/> that will be executed.</param>
+    /// <param name="log">The <see cref="Action"/> that should be called upon evaluation of the query to log it.</param>
+    /// <typeparam name="T">The type of results being returned.</typeparam>
+    /// <returns>An <see cref="IEnumerable{T}"/> containing the results of the query.</returns>
+    public IEnumerable<T> Execute<T>(MongoExecutableQuery executableQuery, out Action log);
+
     // TODO: Add item update/delete/insert operations
 }

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -1,22 +1,28 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using MongoDB.EntityFrameworkCore.Diagnostics;
+using MongoDB.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
 
@@ -26,17 +32,42 @@ namespace MongoDB.EntityFrameworkCore.Storage;
 /// </summary>
 public class MongoClientWrapper : IMongoClientWrapper
 {
+    private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _commandLogger;
+
     /// <summary>
     /// Create a new instance of <see cref="MongoClientWrapper"/> with the supplied parameters.
     /// </summary>
     /// <param name="dbContextOptions">The <see cref="IDbContextOptions"/> that specify how this provider is configured.</param>
     /// <param name="serviceProvider">The <see cref="IServiceProvider"/> used to resolve dependencies.</param>
-    public MongoClientWrapper(IDbContextOptions dbContextOptions, IServiceProvider serviceProvider)
+    /// <param name="commandLogger">The <see cref="IDiagnosticsLogger"/> used to log diagnostics events.</param>
+    public MongoClientWrapper(
+        IDbContextOptions dbContextOptions,
+        IServiceProvider serviceProvider,
+        IDiagnosticsLogger<DbLoggerCategory.Database.Command> commandLogger)
     {
         var options = dbContextOptions.FindExtension<MongoOptionsExtension>();
+        _commandLogger = commandLogger;
 
         var client = GetOrCreateMongoClient(options, serviceProvider);
         Database = client.GetDatabase(options!.DatabaseName);
+    }
+
+    public IEnumerable<T> Execute<T>(MongoExecutableQuery executableQuery, out Action log)
+    {
+        log = () => { };
+
+        if (executableQuery.Cardinality != ResultCardinality.Enumerable)
+        {
+            // TODO: Figure out MQL capture for non-enumerable cardinality
+            return new[]
+            {
+                executableQuery.Provider.Execute<T>(executableQuery.Query)
+            };
+        }
+
+        var queryable = (IMongoQueryable<T>)executableQuery.Provider.CreateQuery<T>(executableQuery.Query);
+        log = () => _commandLogger.ExecutedMqlQuery(executableQuery.CollectionNamespace, queryable.LoggedStages);
+        return queryable;
     }
 
     private static IMongoClient GetOrCreateMongoClient(MongoOptionsExtension? options, IServiceProvider serviceProvider)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Entities/Guides/GuidesDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Entities/Guides/GuidesDbContext.cs
@@ -28,12 +28,13 @@ internal class GuidesDbContext(DbContextOptions options) : DbContext(options)
     public static GuidesDbContext Create(
         IMongoDatabase database,
         Action<string>? logAction = null,
-        ILoggerFactory? loggerFactory = null) =>
-        new (new DbContextOptionsBuilder<GuidesDbContext>()
+        ILoggerFactory? loggerFactory = null,
+        bool sensitiveDataLogging = true) =>
+        new(new DbContextOptionsBuilder<GuidesDbContext>()
             .UseMongoDB(database.Client, database.DatabaseNamespace.DatabaseName)
             .LogTo(l => logAction?.Invoke(l))
             .UseLoggerFactory(loggerFactory)
-            .EnableSensitiveDataLogging()
+            .EnableSensitiveDataLogging(sensitiveDataLogging)
             .Options);
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Entities/Guides/GuidesDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Entities/Guides/GuidesDbContext.cs
@@ -1,38 +1,40 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
 
-internal class GuidesDbContext : DbContext
+internal class GuidesDbContext(DbContextOptions options) : DbContext(options)
 {
     public DbSet<Moon> Moons { get; init; }
     public DbSet<Planet> Planets { get; init; }
 
-    public static GuidesDbContext Create(IMongoDatabase database) =>
+    public static GuidesDbContext Create(
+        IMongoDatabase database,
+        Action<string>? logAction = null,
+        ILoggerFactory? loggerFactory = null) =>
         new (new DbContextOptionsBuilder<GuidesDbContext>()
             .UseMongoDB(database.Client, database.DatabaseNamespace.DatabaseName)
+            .LogTo(l => logAction?.Invoke(l))
+            .UseLoggerFactory(loggerFactory)
+            .EnableSensitiveDataLogging()
             .Options);
-
-    public GuidesDbContext(DbContextOptions options)
-        : base(options)
-    {
-    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
@@ -26,7 +26,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     private readonly string DbName = fixture.MongoDatabase.DatabaseNamespace.DatabaseName;
 
     [Fact]
-    public void Query_writes_log_via_LogTo()
+    public void Query_writes_log_via_LogTo_with_mql_when_sensitive_logging()
     {
         List<string> logs = [];
         var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
@@ -39,11 +39,30 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.NotNull(item);
         Assert.Contains(logs, l => l.Contains("Executed MQL query"));
-        Assert.Contains(logs, l => l.Contains($"{DbName}.moons.aggregate([{{ \"$match\" : {{ \"yearOfDiscovery\" : {{ \"$gt\" : 1900 }} }} }}])"));
+        Assert.Contains(logs,
+            l => l.Contains($"{DbName}.moons.aggregate([{{ \"$match\" : {{ \"yearOfDiscovery\" : {{ \"$gt\" : 1900 }} }} }}])"));
     }
 
     [Fact]
-    public void Query_writes_event_via_LoggerFactory()
+    public void Query_writes_log_via_LogTo_without_mql_when_no_sensitive_logging()
+    {
+        List<string> logs = [];
+        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        {
+            logs.Add(s);
+            testOutputHelper.WriteLine(s);
+        }, sensitiveDataLogging: false);
+
+        var item = db.Moons.Where(m => m.yearOfDiscovery > 1900).ToArray();
+
+        Assert.NotNull(item);
+        Assert.Contains(logs, l => l.Contains("Executed MQL query"));
+        Assert.Contains(logs, l => l.Contains($"{DbName}.moons.aggregate([?])"));
+        Assert.DoesNotContain(logs, l => l.Contains("yearOfDiscovery"));
+    }
+
+    [Fact]
+    public void Query_writes_event_via_LoggerFactory_with_mql_when_sensitive_logging()
     {
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
         var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
@@ -60,7 +79,29 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         ).message;
 
         Assert.Contains("Executed MQL query", message);
-        Assert.Contains($"{DbName}.moons.aggregate([{{ \"$match\" : {{ \"yearOfDiscovery\" : {{ \"$gt\" : 1900 }} }} }}])", message);
+        Assert.Contains($"{DbName}.moons.aggregate([{{ \"$match\" : {{ \"yearOfDiscovery\" : {{ \"$gt\" : 1900 }} }} }}])",
+            message);
     }
 
+    [Fact]
+    public void Query_writes_event_via_LoggerFactory_without_mql_when_no_sensitive_logging()
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
+
+        var item = db.Moons.Where(m => m.yearOfDiscovery > 1900).ToArray();
+
+        Assert.NotNull(item);
+        var logger = Assert.Single(spyLogger.Loggers, s => s.Key == "Microsoft.EntityFrameworkCore.Database.Command").Value;
+
+        var message = Assert.Single(logger.Records, log =>
+            log.LogLevel == LogLevel.Information &&
+            log.EventId == MongoEventId.ExecutedMqlQuery &&
+            log.Exception == null
+        ).message;
+
+        Assert.Contains("Executed MQL query", message);
+        Assert.Contains($"{DbName}.moons.aggregate([?])", message);
+        Assert.DoesNotContain("yearOfDiscovery", message);
+    }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
@@ -1,0 +1,66 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.Extensions.Logging;
+using MongoDB.EntityFrameworkCore.Diagnostics;
+using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
+using Xunit.Abstractions;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests;
+
+[XUnitCollection(nameof(SampleGuidesFixture))]
+public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOutputHelper)
+{
+    private readonly string DbName = fixture.MongoDatabase.DatabaseNamespace.DatabaseName;
+
+    [Fact]
+    public void Query_writes_log_via_LogTo()
+    {
+        List<string> logs = [];
+        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        {
+            logs.Add(s);
+            testOutputHelper.WriteLine(s);
+        });
+
+        var item = db.Moons.Where(m => m.yearOfDiscovery > 1900).ToArray();
+
+        Assert.NotNull(item);
+        Assert.Contains(logs, l => l.Contains("Executed MQL query"));
+        Assert.Contains(logs, l => l.Contains($"{DbName}.moons.aggregate([{{ \"$match\" : {{ \"yearOfDiscovery\" : {{ \"$gt\" : 1900 }} }} }}])"));
+    }
+
+    [Fact]
+    public void Query_writes_event_via_LoggerFactory()
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
+
+        var item = db.Moons.Where(m => m.yearOfDiscovery > 1900).ToArray();
+
+        Assert.NotNull(item);
+        var logger = Assert.Single(spyLogger.Loggers, s => s.Key == "Microsoft.EntityFrameworkCore.Database.Command").Value;
+
+        var message = Assert.Single(logger.Records, log =>
+            log.LogLevel == LogLevel.Information &&
+            log.EventId == MongoEventId.ExecutedMqlQuery &&
+            log.Exception == null
+        ).message;
+
+        Assert.Contains("Executed MQL query", message);
+        Assert.Contains($"{DbName}.moons.aggregate([{{ \"$match\" : {{ \"yearOfDiscovery\" : {{ \"$gt\" : 1900 }} }} }}])", message);
+    }
+
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SpyLogging.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SpyLogging.cs
@@ -1,0 +1,56 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
+
+internal class SpyLoggerProvider : ILoggerProvider
+{
+    public static (LoggerFactory, SpyLoggerProvider) Create()
+    {
+        var loggerFactory = new LoggerFactory();
+        var spyLogger = new SpyLoggerProvider();
+        loggerFactory.AddProvider(spyLogger);
+        return (loggerFactory, spyLogger);
+    }
+
+    public readonly ConcurrentDictionary<string, SpyLogger> Loggers = [];
+
+    public void Dispose()
+    {
+    }
+
+    public ILogger CreateLogger(string categoryName)
+        => Loggers.GetOrAdd(categoryName, _ => new SpyLogger());
+}
+
+internal class SpyLogger : ILogger
+{
+    public readonly List<SpyLogRecord> Records = [];
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+        => Records.Add(new SpyLogRecord(logLevel, eventId, formatter(state, exception) , exception));
+
+    public bool IsEnabled(LogLevel logLevel)
+        => true;
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        => throw new NotImplementedException();
+}
+
+internal record SpyLogRecord(LogLevel LogLevel, EventId EventId, string message, Exception? Exception);


### PR DESCRIPTION
Fixes EF-50.

- Fair amount of logging infra as this is our first custom log
- MQL is only logged for enumerable sets not first/single (will address in another PR)
- MQL can only be logged with the parameters in place so queries only show if sensitive logging is enabled
- Logging of other operations in future PRs

