### PR TITLE
Clean up update pipeline prior to logging

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -127,7 +127,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
     {
         var mongoQueryContext = (MongoQueryContext)queryContext;
         var serializer = (IBsonSerializer<TSource>)entitySerializerCache.GetOrCreateSerializer(entityType);
-        var collection = mongoQueryContext.MongoClient.Database.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
+        var collection = mongoQueryContext.MongoClient.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
         var source = collection.AsQueryable().As(serializer);
 
         var queryTranslator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression);
@@ -156,7 +156,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         ResultCardinality resultCardinality)
     {
         var mongoQueryContext = (MongoQueryContext)queryContext;
-        var collection = mongoQueryContext.MongoClient.Database.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
+        var collection = mongoQueryContext.MongoClient.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
         var source = collection.AsQueryable().As((IBsonSerializer<TSource>)entitySerializerCache.GetOrCreateSerializer(entityType));
 
         var queryTranslator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression);

--- a/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
@@ -15,24 +15,29 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
 
 /// <summary>
+/// For internal use only. Interface may change between minor versions.
 /// Provides the interface between the MongoDB Entity Framework provider
 /// and the underlying <see cref="IMongoClient"/>.
 /// </summary>
 public interface IMongoClientWrapper
 {
     /// <summary>
-    /// The <see cref="IMongoDatabase"/> this client is connected to.
+    /// Get an <see cref="IMongoCollection{T}"/> for the given <paramref name="collectionName"/>;
     /// </summary>
-    public IMongoDatabase Database { get; }
+    /// <param name="collectionName">The name of the collection to get a collection for.</param>
+    /// <typeparam name="T">The type of data that will be returned by the collection.</typeparam>
+    /// <returns>The <see cref="IMongoCollection{T}"/> </returns>
+    public IMongoCollection<T> GetCollection<T>(string collectionName);
 
     /// <summary>
-    /// For internal use only. Interface may change between minor versions.
     /// A query and the associated metadata and provider needed to execute that query.
     /// </summary>
     /// <param name="executableQuery">The <see cref="MongoExecutableQuery"/> that will be executed.</param>
@@ -41,5 +46,18 @@ public interface IMongoClientWrapper
     /// <returns>An <see cref="IEnumerable{T}"/> containing the results of the query.</returns>
     public IEnumerable<T> Execute<T>(MongoExecutableQuery executableQuery, out Action log);
 
-    // TODO: Add item update/delete/insert operations
+    /// <summary>
+    /// Save updates to a MongoDB database.
+    /// </summary>
+    /// <param name="updates">The updates to save to the database.</param>
+    /// <returns>The number of affected documents.</returns>
+    public long SaveUpdates(IEnumerable<MongoUpdate> updates);
+
+    /// <summary>
+    /// Save updates to a MongoDB database asynchronously.
+    /// </summary>
+    /// <param name="updates">The updates to save to the database.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A task that when completed gives the number of affected documents.</returns>
+    public Task<long> SaveUpdatesAsync(IEnumerable<MongoUpdate> updates, CancellationToken cancellationToken);
 }

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -132,7 +132,6 @@ public class MongoClientWrapper : IMongoClientWrapper
         return documentsAffected;
     }
 
-
     private static IMongoClient GetOrCreateMongoClient(MongoOptionsExtension? options, IServiceProvider serviceProvider)
     {
         var injectedClient = (IMongoClient?)serviceProvider.GetService(typeof(IMongoClient));

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -32,23 +32,29 @@ namespace MongoDB.EntityFrameworkCore.Storage;
 
 /// <summary>
 /// Represents an update to a MongoDB database by specifying the collection
-/// name and the appropriate document inside a writemodel which indicates
+/// name and the appropriate document inside a <see cref="WriteModel{BsonDocument}"/> which indicates
 /// the type of operation.
 /// </summary>
 /// <param name="collectionName">The name of the collection this update applies to.</param>
-/// <param name="model"></param>
+/// <param name="model">The <see cref="WriteModel{BsonDocument}"/> containing the update.</param>
 public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
 {
     /// <summary>
     /// The name of the collection this update applies to.
     /// </summary>
-    public string CollectionName { get => collectionName; }
+    public string CollectionName
+    {
+        get => collectionName;
+    }
 
     /// <summary>
     /// The <see cref="WriteModel{BsonDocument}"/> that contains both the document
     /// being modified and indication of the type of update being performed.
     /// </summary>
-    public WriteModel<BsonDocument> Model { get => model; }
+    public WriteModel<BsonDocument> Model
+    {
+        get => model;
+    }
 
     /// <summary>
     /// Create a enumeration of <see cref="MongoUpdate"/> from an enumeration of EF-supplied
@@ -108,7 +114,7 @@ public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
         using var writer = new BsonDocumentWriter(document);
         WriteEntity(writer, entry, p => p.IsPrimaryKey());
 
-        // MongoDB require primary key named as "_id";
+        // MongoDB requires primary key named as "_id";
         return Builders<BsonDocument>.Filter.Eq("_id", document["_id"]);
     }
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -1,0 +1,226 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Update;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Serializers;
+
+namespace MongoDB.EntityFrameworkCore.Storage;
+
+/// <summary>
+/// Represents an update to a MongoDB database by specifying the collection
+/// name and the appropriate document inside a writemodel which indicates
+/// the type of operation.
+/// </summary>
+/// <param name="collectionName">The name of the collection this update applies to.</param>
+/// <param name="model"></param>
+public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
+{
+    /// <summary>
+    /// The name of the collection this update applies to.
+    /// </summary>
+    public string CollectionName { get => collectionName; }
+
+    /// <summary>
+    /// The <see cref="WriteModel{BsonDocument}"/> that contains both the document
+    /// being modified and indication of the type of update being performed.
+    /// </summary>
+    public WriteModel<BsonDocument> Model { get => model; }
+
+    /// <summary>
+    /// Create a enumeration of <see cref="MongoUpdate"/> from an enumeration of EF-supplied
+    /// <see cref="IUpdateEntry"/>.
+    /// </summary>
+    /// <param name="entries">The EF-supplied <see cref="IUpdateEntry"/> to process.</param>
+    /// <returns>An enumeration of <see cref="MongoUpdate"/> that corresponds to these updates.</returns>
+    public static IEnumerable<MongoUpdate> CreateAll(IEnumerable<IUpdateEntry> entries)
+        => entries.Select(Create).OfType<MongoUpdate>();
+
+    private static MongoUpdate? Create(IUpdateEntry entry)
+        => entry.EntityState switch
+        {
+            EntityState.Added => ConvertAdded(entry),
+            EntityState.Deleted => ConvertDeleted(entry),
+            EntityState.Modified => ConvertModified(entry),
+            EntityState.Detached => null,
+            EntityState.Unchanged => null,
+            _ => throw new NotSupportedException($"Unexpected entity state: {entry.EntityState}.")
+        };
+
+    private static MongoUpdate ConvertAdded(IUpdateEntry entry)
+    {
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        WriteEntity(writer, entry);
+
+        var model = new InsertOneModel<BsonDocument>(document);
+        return new MongoUpdate(entry.EntityType.GetCollectionName(), model);
+    }
+
+    private static MongoUpdate ConvertDeleted(IUpdateEntry entry)
+    {
+        var model = new DeleteOneModel<BsonDocument>(CreateIdFilter(entry));
+        return new MongoUpdate(entry.EntityType.GetCollectionName(), model);
+    }
+
+    private static MongoUpdate ConvertModified(IUpdateEntry entry)
+    {
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        WriteEntity(writer, entry);
+
+        var updateDocument = new BsonDocument("$set", document);
+        var updateDefinition = new BsonDocumentUpdateDefinition<BsonDocument>(updateDocument);
+
+        var model = new UpdateOneModel<BsonDocument>(CreateIdFilter(entry), updateDefinition);
+        return new MongoUpdate(entry.EntityType.GetCollectionName(), model);
+    }
+
+    private static FilterDefinition<BsonDocument> CreateIdFilter(IUpdateEntry entry)
+    {
+        _ = entry.EntityType.FindPrimaryKey() ??
+            throw new InvalidOperationException($"Cannot find the primary key for the entity: {entry.EntityType.Name}");
+
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        WriteEntity(writer, entry, p => p.IsPrimaryKey());
+
+        // MongoDB require primary key named as "_id";
+        return Builders<BsonDocument>.Filter.Eq("_id", document["_id"]);
+    }
+
+    private static void WriteEntity(IBsonWriter writer, IUpdateEntry entry, Func<IProperty, bool>? propertyFilter = null)
+    {
+        if (propertyFilter == null && entry.EntityState == EntityState.Modified)
+        {
+            propertyFilter = entry.IsModified;
+        }
+
+        AcceptTemporaryValues(entry);
+
+        writer.WriteStartDocument();
+
+        WriteKeyProperties(writer, entry);
+        WriteNonKeyProperties(writer, entry, propertyFilter);
+
+        foreach (var navigation in entry.EntityType.GetNavigations())
+        {
+            if (!navigation.IsEmbedded())
+            {
+                continue;
+            }
+
+            writer.WriteName(navigation.TargetEntityType.GetContainingElementName());
+            object? embeddedValue = entry.GetCurrentValue(navigation);
+
+            if (embeddedValue == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                if (navigation.IsCollection)
+                {
+                    writer.WriteStartArray();
+                    foreach (object dependent in (IEnumerable)embeddedValue)
+                    {
+                        var embeddedEntry =
+                            ((InternalEntityEntry)entry).StateManager.TryGetEntry(dependent,
+                                navigation.ForeignKey.DeclaringEntityType)!;
+                        WriteEntity(writer, embeddedEntry, _ => true);
+                    }
+
+                    writer.WriteEndArray();
+                }
+                else
+                {
+                    var embeddedEntry =
+                        ((InternalEntityEntry)entry).StateManager.TryGetEntry(embeddedValue,
+                            navigation.ForeignKey.DeclaringEntityType)!;
+                    WriteEntity(writer, embeddedEntry, _ => true);
+                }
+            }
+        }
+
+        writer.WriteEndDocument();
+    }
+
+    private static void AcceptTemporaryValues(IUpdateEntry entry)
+    {
+        foreach (var property in entry.EntityType.GetProperties())
+        {
+            if (entry.HasTemporaryValue(property))
+                entry.SetStoreGeneratedValue(property, entry.GetCurrentValue(property));
+        }
+    }
+
+    private static void WriteKeyProperties(IBsonWriter writer, IUpdateEntry entry)
+    {
+        var keyProperties = entry.EntityType.FindPrimaryKey()?
+            .Properties
+            .Where(p => !p.IsShadowProperty() && p.GetElementName() != "").ToArray() ?? [];
+
+        if (!keyProperties.Any()) return;
+
+        bool compoundKey = keyProperties.Length > 1;
+        if (compoundKey)
+        {
+            writer.WriteName("_id");
+            writer.WriteStartDocument();
+        }
+
+        foreach (var property in keyProperties)
+        {
+            var serializationInfo = SerializationHelper.GetPropertySerializationInfo(property);
+            string? elementName = serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName;
+            writer.WriteName(elementName);
+            var root = BsonSerializationContext.CreateRoot(writer);
+            serializationInfo.Serializer.Serialize(root, entry.GetCurrentValue(property));
+        }
+
+        if (compoundKey)
+        {
+            writer.WriteEndDocument();
+        }
+    }
+
+    internal static void WriteNonKeyProperties(IBsonWriter writer, IUpdateEntry entry, Func<IProperty, bool>? propertyFilter = null)
+    {
+        var properties = entry.EntityType.GetProperties()
+            .Where(p => !p.IsShadowProperty() && !p.IsPrimaryKey() && p.GetElementName() != "")
+            .Where(p => propertyFilter == null || propertyFilter(p))
+            .ToArray();
+
+        foreach (var property in properties)
+        {
+            var serializationInfo = SerializationHelper.GetPropertySerializationInfo(property);
+            string? elementName = serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName;
+            writer.WriteName(elementName);
+            var root = BsonSerializationContext.CreateRoot(writer);
+            serializationInfo.Serializer.Serialize(root, entry.GetCurrentValue(property));
+        }
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdateBatch.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdateBatch.cs
@@ -1,0 +1,58 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.Storage;
+
+internal class MongoUpdateBatch(string collectionName, List<WriteModel<BsonDocument>> models)
+{
+    public string CollectionName { get => collectionName; }
+    public List<WriteModel<BsonDocument>> Models { get => models; }
+
+    public static IEnumerable<MongoUpdateBatch> CreateBatches(IEnumerable<MongoUpdate> updates)
+    {
+        MongoUpdateBatch? batch = null;
+        foreach (var update in updates)
+        {
+            if (batch == null)
+            {
+                batch = Create(update);
+            }
+            else
+            {
+                if (batch.CollectionName == update.CollectionName)
+                {
+                    batch.Models.Add(update.Model);
+                }
+                else
+                {
+                    yield return batch;
+                    batch = Create(update);
+                }
+            }
+        }
+
+        if (batch != null)
+        {
+            yield return batch;
+        }
+    }
+
+    public static MongoUpdateBatch Create(MongoUpdate update)
+        => new(update.CollectionName, [update.Model]);
+}


### PR DESCRIPTION
The update code was somewhat tangled and lead to exposure of parts we didn't really want such as IMongoDatabase on the wrapper. Instead, now:

- `MongoUpdate` - contains the collection + WriteModel for each document update & doc writing code
- `MongoBatchUpdate` - groups the MongoUpdate operations into per-collection batches
- `SerializationHelper` - loses the document writing that only MongoUpdate needed
- `IMongoClientWrapper` - stops exposing the whole of IMongoDatabase, trading it for GetCollection and SaveUpdates/Async
- `MongoClientWrapper` - implements the interface changes
- `MongoDatabaseWrapper` - Delegates out functionality to MongoUpdate and the MongoBatchUpdate

This leaves the pieces with a clear, specific focus and makes it easier for the logging of bulk operations to happen in next PR.