### PR TITLE
Implement bulk write logging

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
@@ -1,0 +1,90 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.Diagnostics;
+
+/// <summary>
+/// A <see cref="DiagnosticSource" /> event payload class for MongoDB bulk write events.
+/// </summary>
+/// <remarks>
+/// See <see href="https://aka.ms/efcore-docs-diagnostics">Logging, events, and diagnostics</see> for more information and examples.
+/// </remarks>
+public class MongoBulkWriteEventData : EventData
+{
+    /// <summary>
+    /// Constructs the event payload.
+    /// </summary>
+    /// <param name="eventDefinition">The event definition.</param>
+    /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
+    /// <param name="elapsed">The time elapsed since the command was sent to the database.</param>
+    /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> being queried.</param>
+    /// <param name="documentsCreated">The number of documents created by this bulk write operation.</param>
+    /// <param name="documentsDeleted">The number of documents deleted by this bulk write operation.</param>
+    /// <param name="documentsModified">The number of documents modified by this bulk write operation.</param>
+    /// <param name="logSensitiveData">Indicates whether the application allows logging of sensitive data.</param>
+    public MongoBulkWriteEventData(
+        EventDefinitionBase eventDefinition,
+        Func<EventDefinitionBase, EventData, string> messageGenerator,
+        TimeSpan elapsed,
+        CollectionNamespace collectionNamespace,
+        long documentsCreated,
+        long documentsDeleted,
+        long documentsModified,
+        bool logSensitiveData)
+        : base(eventDefinition, messageGenerator)
+    {
+        Elapsed = elapsed;
+        CollectionNamespace = collectionNamespace;
+        DocumentsCreated = documentsCreated;
+        DocumentsDeleted = documentsDeleted;
+        DocumentsModified = documentsModified;
+        LogSensitiveData = logSensitiveData;
+    }
+
+    /// <summary>
+    /// The time elapsed since the command was sent to the database.
+    /// </summary>
+    public virtual TimeSpan Elapsed { get; }
+
+    /// <summary>
+    /// The <see cref="CollectionNamespace"/> being queried.
+    /// </summary>
+    public virtual CollectionNamespace CollectionNamespace { get; }
+
+    /// <summary>
+    /// The number of documents created by this bulk write operation.
+    /// </summary>
+    public virtual long DocumentsCreated { get; }
+
+    /// <summary>
+    /// The number of documents deleted by this bulk write operation.
+    /// </summary>
+    public virtual long DocumentsDeleted { get; }
+
+    /// <summary>
+    /// The number of documents modified by this bulk write operation.
+    /// </summary>
+    public virtual long DocumentsModified { get; }
+
+    /// <summary>
+    /// Indicates whether the application allows logging of sensitive data.
+    /// </summary>
+    public virtual bool LogSensitiveData { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
@@ -35,7 +35,7 @@ public class MongoBulkWriteEventData : EventData
     /// <param name="messageGenerator">A delegate that generates a log message for this event.</param>
     /// <param name="elapsed">The time elapsed since the command was sent to the database.</param>
     /// <param name="collectionNamespace">The <see cref="CollectionNamespace"/> being queried.</param>
-    /// <param name="documentsCreated">The number of documents created by this bulk write operation.</param>
+    /// <param name="documentsInserted">The number of documents inserted by this bulk write operation.</param>
     /// <param name="documentsDeleted">The number of documents deleted by this bulk write operation.</param>
     /// <param name="documentsModified">The number of documents modified by this bulk write operation.</param>
     /// <param name="logSensitiveData">Indicates whether the application allows logging of sensitive data.</param>
@@ -44,7 +44,7 @@ public class MongoBulkWriteEventData : EventData
         Func<EventDefinitionBase, EventData, string> messageGenerator,
         TimeSpan elapsed,
         CollectionNamespace collectionNamespace,
-        long documentsCreated,
+        long documentsInserted,
         long documentsDeleted,
         long documentsModified,
         bool logSensitiveData)
@@ -52,7 +52,7 @@ public class MongoBulkWriteEventData : EventData
     {
         Elapsed = elapsed;
         CollectionNamespace = collectionNamespace;
-        DocumentsCreated = documentsCreated;
+        DocumentsInserted = documentsInserted;
         DocumentsDeleted = documentsDeleted;
         DocumentsModified = documentsModified;
         LogSensitiveData = logSensitiveData;
@@ -69,9 +69,9 @@ public class MongoBulkWriteEventData : EventData
     public virtual CollectionNamespace CollectionNamespace { get; }
 
     /// <summary>
-    /// The number of documents created by this bulk write operation.
+    /// The number of documents inserted by this bulk write operation.
     /// </summary>
-    public virtual long DocumentsCreated { get; }
+    public virtual long DocumentsInserted { get; }
 
     /// <summary>
     /// The number of documents deleted by this bulk write operation.

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
@@ -33,7 +33,8 @@ public static class MongoEventId
     // Only add new values to the end of sections, never in the middle.
     private enum Id
     {
-        ExecutedMqlQuery = CoreEventId.ProviderDesignBaseId
+        ExecutedMqlQuery = CoreEventId.ProviderDesignBaseId,
+        ExecutedBulkWrite
     }
 
     /// <summary>
@@ -46,6 +47,17 @@ public static class MongoEventId
     /// </para>
     /// </remarks>
     public static readonly EventId ExecutedMqlQuery = MakeEventId(Id.ExecutedMqlQuery);
+
+    /// <summary>
+    /// An bulk write has been executed.
+    /// </summary>
+    /// <remarks>
+    /// <para>This event is in the <see cref="DbLoggerCategory.Database.Command" /> category.</para>
+    /// <para>
+    /// This event uses the <see cref="MongoQueryEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+    /// </para>
+    /// </remarks>
+    public static readonly EventId ExecutedBulkWrite = MakeEventId(Id.ExecutedBulkWrite);
 
     private static readonly string EventPrefix = DbLoggerCategory.Database.Command.Name + ".";
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
@@ -23,6 +23,9 @@ using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 
+using MqlQueryEventDefinition = EventDefinition<string, CollectionNamespace, string>;
+using BulkWriteEventDefinition = EventDefinition<string, CollectionNamespace, long, long, long>;
+
 /// <summary>
 /// MongoDB-specific logging extensions.
 /// </summary>
@@ -62,6 +65,43 @@ internal static class MongoLoggerExtensions
         }
     }
 
+    public static void ExecutedBulkWrite(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        TimeSpan elapsed,
+        CollectionNamespace collectionNamespace,
+        long documentsCreated,
+        long documentedDeleted,
+        long documentsModified)
+    {
+        var definition = LogExecutedBulkWrite(diagnostics);
+
+        if (diagnostics.ShouldLog(definition))
+        {
+            definition.Log(
+                diagnostics,
+                elapsed.TotalMilliseconds.ToString(),
+                collectionNamespace,
+                documentsCreated,
+                documentedDeleted,
+                documentsModified);
+        }
+
+        if (diagnostics.NeedsEventData(definition, out var diagnosticSourceEnabled, out var simpleLogEnabled))
+        {
+            var eventData = new MongoBulkWriteEventData(
+                definition,
+                ExecutedBulkWrite,
+                elapsed,
+                collectionNamespace,
+                documentsCreated,
+                documentedDeleted,
+                documentsModified,
+                diagnostics.ShouldLogSensitiveData());
+
+            diagnostics.DispatchEventData(definition, eventData, diagnosticSourceEnabled, simpleLogEnabled);
+        }
+    }
+
     private static string LoggedStagesToMql(BsonDocument[]? documents)
         => documents == null
             ? ""
@@ -69,7 +109,7 @@ internal static class MongoLoggerExtensions
 
     private static string ExecutedMqlQuery(EventDefinitionBase definition, EventData payload)
     {
-        var d = (EventDefinition<string, CollectionNamespace, string>)definition;
+        var d = (MqlQueryEventDefinition)definition;
         var p = (MongoQueryEventData)payload;
         return d.GenerateMessage(
             Environment.NewLine,
@@ -77,7 +117,19 @@ internal static class MongoLoggerExtensions
             p.LogSensitiveData ? p.QueryMql : "?");
     }
 
-    private static EventDefinition<string, CollectionNamespace, string> LogExecutedMqlQuery(IDiagnosticsLogger logger)
+    private static string ExecutedBulkWrite(EventDefinitionBase definition, EventData payload)
+    {
+        var d = (BulkWriteEventDefinition)definition;
+        var p = (MongoBulkWriteEventData)payload;
+        return d.GenerateMessage(
+            p.Elapsed.Milliseconds.ToString(),
+            p.CollectionNamespace,
+            p.DocumentsCreated,
+            p.DocumentsDeleted,
+            p.DocumentsModified);
+    }
+
+    private static MqlQueryEventDefinition LogExecutedMqlQuery(IDiagnosticsLogger logger)
     {
         var definition = ((MongoLoggingDefinitions)logger.Definitions).LogExecutedMqlQuery;
         if (definition == null)
@@ -85,7 +137,7 @@ internal static class MongoLoggerExtensions
             definition = NonCapturingLazyInitializer.EnsureInitialized(
                 ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutedMqlQuery,
                 logger,
-                static logger => new EventDefinition<string, CollectionNamespace, string>(
+                static logger => new MqlQueryEventDefinition(
                     logger.Options,
                     MongoEventId.ExecutedMqlQuery,
                     LogLevel.Information,
@@ -96,8 +148,34 @@ internal static class MongoLoggerExtensions
                         LogExecutedMqlQueryString)));
         }
 
-        return (EventDefinition<string, CollectionNamespace, string>)definition;
+        return (MqlQueryEventDefinition)definition;
+    }
+
+
+    private static BulkWriteEventDefinition LogExecutedBulkWrite(IDiagnosticsLogger logger)
+    {
+        var definition = ((MongoLoggingDefinitions)logger.Definitions).LogExecutedBulkWrite;
+        if (definition == null)
+        {
+            definition = NonCapturingLazyInitializer.EnsureInitialized(
+                ref ((MongoLoggingDefinitions)logger.Definitions).LogExecutedBulkWrite,
+                logger,
+                static logger => new BulkWriteEventDefinition(
+                    logger.Options,
+                    MongoEventId.ExecutedBulkWrite,
+                    LogLevel.Information,
+                    "MongoEventId.ExecutedBulkWrite",
+                    level => LoggerMessage.Define<string, CollectionNamespace, long, long, long>(
+                        level,
+                        MongoEventId.ExecutedBulkWrite,
+                        LogExecuteBulkWriteString)));
+        }
+
+        return (BulkWriteEventDefinition)definition;
     }
 
     private const string LogExecutedMqlQueryString = "Executed MQL query{newLine}{collectionNamespace}.aggregate([{queryMql}])";
+
+    private const string LogExecuteBulkWriteString =
+        "Executed Bulk Write ({elapsed} ms) Collection='{colllectionNamespace}', Created={created}, Deleted={deleted}, Modified={modified}";
 }

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
@@ -69,7 +69,7 @@ internal static class MongoLoggerExtensions
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         TimeSpan elapsed,
         CollectionNamespace collectionNamespace,
-        long documentsCreated,
+        long documentsInserted,
         long documentedDeleted,
         long documentsModified)
     {
@@ -81,7 +81,7 @@ internal static class MongoLoggerExtensions
                 diagnostics,
                 elapsed.TotalMilliseconds.ToString(),
                 collectionNamespace,
-                documentsCreated,
+                documentsInserted,
                 documentedDeleted,
                 documentsModified);
         }
@@ -93,7 +93,7 @@ internal static class MongoLoggerExtensions
                 ExecutedBulkWrite,
                 elapsed,
                 collectionNamespace,
-                documentsCreated,
+                documentsInserted,
                 documentedDeleted,
                 documentsModified,
                 diagnostics.ShouldLogSensitiveData());
@@ -124,7 +124,7 @@ internal static class MongoLoggerExtensions
         return d.GenerateMessage(
             p.Elapsed.Milliseconds.ToString(),
             p.CollectionNamespace,
-            p.DocumentsCreated,
+            p.DocumentsInserted,
             p.DocumentsDeleted,
             p.DocumentsModified);
     }
@@ -177,5 +177,5 @@ internal static class MongoLoggerExtensions
     private const string LogExecutedMqlQueryString = "Executed MQL query{newLine}{collectionNamespace}.aggregate([{queryMql}])";
 
     private const string LogExecuteBulkWriteString =
-        "Executed Bulk Write ({elapsed} ms) Collection='{colllectionNamespace}', Created={created}, Deleted={deleted}, Modified={modified}";
+        "Executed Bulk Write ({elapsed} ms) Collection='{collectionNamespace}', Inserted={inserted}, Deleted={deleted}, Modified={modified}";
 }

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
@@ -23,4 +23,5 @@ namespace MongoDB.EntityFrameworkCore.Diagnostics;
 public class MongoLoggingDefinitions : LoggingDefinitions
 {
     public EventDefinitionBase? LogExecutedMqlQuery;
+    public EventDefinitionBase? LogExecutedBulkWrite;
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
@@ -104,4 +104,67 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         Assert.Contains($"{DbName}.moons.aggregate([?])", message);
         Assert.DoesNotContain("yearOfDiscovery", message);
     }
+
+    [Fact]
+    public void BulkWrite_writes_log_via_LogTo_with_counts()
+    {
+        List<string> logs = [];
+
+        using var guidesFixture = new SampleGuidesFixture();
+        var db = GuidesDbContext.Create(guidesFixture.MongoDatabase, s =>
+        {
+            logs.Add(s);
+            testOutputHelper.WriteLine(s);
+        });
+
+        db.Planets.RemoveRange(db.Planets.Where(m => m.name.StartsWith("M")));
+        foreach (var planet in  db.Planets.Where(m => m.hasRings))
+        {
+            planet.hasRings = false;
+        }
+        db.Planets.Add(new Planet
+        {
+            name = "Proxima Centauri d", hasRings = false, orderFromSun = -1
+        });
+
+        Assert.Equal(7, db.SaveChanges());
+
+        var log = Assert.Single(logs, l => l.Contains("MongoEventId.ExecutedBulkWrite"));
+
+        Assert.Contains("Executed Bulk Write", log);
+        Assert.Contains($"Collection='{guidesFixture.MongoDatabase.DatabaseNamespace.DatabaseName}.planets'", log);
+        Assert.Contains("Created=1, Deleted=2, Modified=4", log);
+    }
+
+    [Fact]
+    public void BulkWrite_writes_event_via_LoggerFactory_with_counts()
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+
+        using var guidesFixture = new SampleGuidesFixture();
+        var db = GuidesDbContext.Create(guidesFixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
+
+        db.Planets.RemoveRange(db.Planets.Where(m => m.name.StartsWith("M")));
+        foreach (var planet in  db.Planets.Where(m => m.hasRings))
+        {
+            planet.hasRings = false;
+        }
+        db.Planets.Add(new Planet
+        {
+            name = "Proxima Centauri d", hasRings = false, orderFromSun = -1
+        });
+
+        Assert.Equal(7, db.SaveChanges());
+
+        var logger = Assert.Single(spyLogger.Loggers, s => s.Key == "Microsoft.EntityFrameworkCore.Database.Command").Value;
+        var log = Assert.Single(logger.Records, log =>
+            log.LogLevel == LogLevel.Information &&
+            log.EventId == MongoEventId.ExecutedBulkWrite &&
+            log.Exception == null
+        ).message;
+
+        Assert.Contains("Executed Bulk Write", log);
+        Assert.Contains($"Collection='{guidesFixture.MongoDatabase.DatabaseNamespace.DatabaseName}.planets'", log);
+        Assert.Contains("Created=1, Deleted=2, Modified=4", log);
+    }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
@@ -118,10 +118,11 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         });
 
         db.Planets.RemoveRange(db.Planets.Where(m => m.name.StartsWith("M")));
-        foreach (var planet in  db.Planets.Where(m => m.hasRings))
+        foreach (var planet in db.Planets.Where(m => m.hasRings))
         {
             planet.hasRings = false;
         }
+
         db.Planets.Add(new Planet
         {
             name = "Proxima Centauri d", hasRings = false, orderFromSun = -1
@@ -133,7 +134,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.Contains("Executed Bulk Write", log);
         Assert.Contains($"Collection='{guidesFixture.MongoDatabase.DatabaseNamespace.DatabaseName}.planets'", log);
-        Assert.Contains("Created=1, Deleted=2, Modified=4", log);
+        Assert.Contains("Inserted=1, Deleted=2, Modified=4", log);
     }
 
     [Fact]
@@ -145,10 +146,11 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         var db = GuidesDbContext.Create(guidesFixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
 
         db.Planets.RemoveRange(db.Planets.Where(m => m.name.StartsWith("M")));
-        foreach (var planet in  db.Planets.Where(m => m.hasRings))
+        foreach (var planet in db.Planets.Where(m => m.hasRings))
         {
             planet.hasRings = false;
         }
+
         db.Planets.Add(new Planet
         {
             name = "Proxima Centauri d", hasRings = false, orderFromSun = -1
@@ -165,6 +167,6 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.Contains("Executed Bulk Write", log);
         Assert.Contains($"Collection='{guidesFixture.MongoDatabase.DatabaseNamespace.DatabaseName}.planets'", log);
-        Assert.Contains("Created=1, Deleted=2, Modified=4", log);
+        Assert.Contains("Inserted=1, Deleted=2, Modified=4", log);
     }
 }


### PR DESCRIPTION
Fixes EF-110.

Provides a log message/log event for bulk write operations as we use them instead of sequential serialized individual updates.

Note that these bulk writes are batched but preserve EF-supplied ordering so you may see multiple bulk operations for the same collection name with other intermediate bulk write operations between them.

This PR also adds using type aliases for the two generic EventDefinition signatures in order to reduce noise and improve clarity.