### PR TITLE
Support IEnumerable<T> props providing actually T[] or IList<T>

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/ChangeTracking/ListComparer.cs
+++ b/src/MongoDB.EntityFrameworkCore/ChangeTracking/ListComparer.cs
@@ -73,7 +73,7 @@ internal sealed class ListComparer<TElement>(ValueComparer<TElement> elementComp
         return hash.ToHashCode();
     }
 
-    private static IList<TElement> Snapshot(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)
+    private static IEnumerable<TElement> Snapshot(IEnumerable<TElement> source, ValueComparer<TElement> elementComparer)
     {
         // Common array case first
         if (source is TElement[] sourceArray)
@@ -113,8 +113,8 @@ internal sealed class ListComparer<TElement>(ValueComparer<TElement> elementComp
                 typeof(TElement).ShortDisplayName()}>' to it.");
     }
 
-    private static IList<TElement> CreateInstance(Type type, IEnumerable<TElement> parameter)
-        => (IList<TElement>)Activator.CreateInstance(type, parameter)!;
+    private static IEnumerable<TElement> CreateInstance(Type type, IEnumerable<TElement> parameter)
+        => (IEnumerable<TElement>)Activator.CreateInstance(type, parameter)!;
 
     private static bool HasConstructorWithSingleParameterOf<T>(IEnumerable<ConstructorInfo> constructors)
         => constructors.Any(c => c.GetParameters().Length == 1 && typeof(T).IsAssignableFrom(c.GetParameters()[0].ParameterType));

--- a/src/MongoDB.EntityFrameworkCore/Serializers/CollectionSerializationProvider.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/CollectionSerializationProvider.cs
@@ -54,8 +54,9 @@ internal class ListSerializationProvider : BsonSerializationProviderBase
 
     private IBsonSerializer? CreateCollectionSerializer(Type type, IBsonSerializerRegistry serializerRegistry)
     {
-        var enumerableInterface = type.GetInterfaces()
-            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+        var enumerableInterface = type.GetGenericTypeDefinition() == typeof(IEnumerable<>) ?
+            type :
+            type.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
 
         if (enumerableInterface == null) return null;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMappingSource.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMappingSource.cs
@@ -115,12 +115,13 @@ public class MongoTypeMappingSource(TypeMappingSourceDependencies dependencies)
     private static readonly Type[] supportedCollectionInterfaces =
     [
         typeof(IList<>),
-        typeof(IReadOnlyList<>)
+        typeof(IReadOnlyList<>),
+        typeof(IEnumerable<>)
     ];
 
-    public static ValueComparer? CreateComparer(CoreTypeMapping elementMapping, Type collectionType)
+    private static ValueComparer? CreateComparer(CoreTypeMapping elementMapping, Type collectionType)
     {
-        var elementType = collectionType.TryGetItemType(typeof(IEnumerable<>))!;
+        var elementType = collectionType.TryGetItemType(typeof(IEnumerable<>));
         var comparerType = typeof(ChangeTracking.ListComparer<>).MakeGenericType(elementType);
         return (ValueComparer?)Activator.CreateInstance(comparerType, elementMapping.Comparer.ToNullableComparer(elementType)!);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/EnumerableOnlyWrapper.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/EnumerableOnlyWrapper.cs
@@ -1,0 +1,30 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
+
+internal static class EnumerableOnlyWrapper
+{
+    public static EnumerableOnlyWrapper<T> Wrap<T>(IEnumerable<T> source)
+        => new(source);
+}
+
+internal class EnumerableOnlyWrapper<T>(IEnumerable<T> source) : IEnumerable<T>
+{
+    public IEnumerator<T> GetEnumerator() => source.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}


### PR DESCRIPTION
Expands support of the property declarations we support to include `IEnumerable<T>` not just `T[]` or `IList<T>` implementations.

Note: The actual concrete type of the class must still support `T[]` or `IList<T>` as these are requirements made by EF for the change tracking system.

Implements EF-111, supersedes #63 