### PR TITLE
Clean-up of warnings and best suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,9 +46,9 @@ dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
-csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -67,8 +67,7 @@ dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
 dotnet_naming_symbols.static_fields.applicable_kinds = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-dotnet_naming_style.static_prefix_style.required_prefix = __
-dotnet_naming_style.static_prefix_style.capitalization = camel_case
+dotnet_naming_style.static_prefix_style.capitalization = pascal_case
 
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion

--- a/src/MongoDB.EntityFrameworkCore/ChangeTracking/ListComparer.cs
+++ b/src/MongoDB.EntityFrameworkCore/ChangeTracking/ListComparer.cs
@@ -40,7 +40,7 @@ internal sealed class ListComparer<TElement>(ValueComparer<TElement> elementComp
         {
             if (aList.Count != bList.Count) return false;
 
-            for (int i = 0; i < aList.Count; i++)
+            for (var i = 0; i < aList.Count; i++)
             {
                 var (el1, el2) = (aList[i], bList[i]);
                 if (el1 is null)
@@ -79,7 +79,7 @@ internal sealed class ListComparer<TElement>(ValueComparer<TElement> elementComp
         if (source is TElement[] sourceArray)
         {
             var snapshot = new TElement[sourceArray.Length];
-            for (int i = 0; i < sourceArray.Length; i++)
+            for (var i = 0; i < sourceArray.Length; i++)
                 snapshot[i] = elementComparer.Snapshot(sourceArray[i]);
             return snapshot;
         }

--- a/src/MongoDB.EntityFrameworkCore/EnumerableMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/EnumerableMethods.cs
@@ -22,22 +22,22 @@ internal static class EnumerableMethods
 
         GetMethod(
             nameof(Enumerable.All), 1,
-            types => new[]
-            {
+            types =>
+            [
                 typeof(IEnumerable<>).MakeGenericType(types[0]), typeof(Func<,>).MakeGenericType(types[0], typeof(bool))
-            });
+            ]);
 
-        Cast = GetMethod(nameof(Enumerable.Cast), 1, _ => new[]
-        {
+        Cast = GetMethod(nameof(Enumerable.Cast), 1, _ =>
+        [
             typeof(IEnumerable)
-        });
+        ]);
 
         SelectWithOrdinal = GetMethod(
             nameof(Enumerable.Select), 2,
-            types => new[]
-            {
+            types =>
+            [
                 typeof(IEnumerable<>).MakeGenericType(types[0]), typeof(Func<,,>).MakeGenericType(types[0], typeof(int), types[1])
-            });
+            ]);
 
         MethodInfo GetMethod(string name, int genericParameterCount, Func<Type[], Type[]> parameterGenerator)
         {

--- a/src/MongoDB.EntityFrameworkCore/EnumerableMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/EnumerableMethods.cs
@@ -15,7 +15,7 @@ internal static class EnumerableMethods
 {
     static EnumerableMethods()
     {
-        Dictionary<string, List<MethodInfo>>? queryableMethodGroups = typeof(Enumerable)
+        var queryableMethodGroups = typeof(Enumerable)
             .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
             .GroupBy(mi => mi.Name)
             .ToDictionary(e => e.Key, l => l.ToList());
@@ -27,14 +27,16 @@ internal static class EnumerableMethods
                 typeof(IEnumerable<>).MakeGenericType(types[0]), typeof(Func<,>).MakeGenericType(types[0], typeof(bool))
             });
 
-        Cast = GetMethod(nameof(Enumerable.Cast), 1, _ => new[] {typeof(IEnumerable)});
+        Cast = GetMethod(nameof(Enumerable.Cast), 1, _ => new[]
+        {
+            typeof(IEnumerable)
+        });
 
         SelectWithOrdinal = GetMethod(
             nameof(Enumerable.Select), 2,
             types => new[]
             {
-                typeof(IEnumerable<>).MakeGenericType(types[0]),
-                typeof(Func<,,>).MakeGenericType(types[0], typeof(int), types[1])
+                typeof(IEnumerable<>).MakeGenericType(types[0]), typeof(Func<,,>).MakeGenericType(types[0], typeof(int), types[1])
             });
 
         MethodInfo GetMethod(string name, int genericParameterCount, Func<Type[], Type[]> parameterGenerator)

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
@@ -82,7 +82,7 @@ public static class MongoEntityTypeExtensions
            ?? GetDefaultContainingElementName(entityType);
 
     private static string? GetDefaultContainingElementName(IReadOnlyEntityType entityType)
-        => entityType.FindOwnership() is IReadOnlyForeignKey ownership
+        => entityType.FindOwnership() is { } ownership
             ? ownership.PrincipalToDependent!.Name
             : null;
 

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
@@ -38,7 +38,7 @@ public static class MongoPropertyExtensions
 
     private static string GetDefaultElementName(IReadOnlyProperty property)
     {
-        var entityType = property.DeclaringEntityType;
+        var entityType = (IReadOnlyEntityType)property.DeclaringType;
         var ownership = entityType.FindOwnership();
 
         if (ownership != null && !entityType.IsDocumentRoot())
@@ -58,7 +58,7 @@ public static class MongoPropertyExtensions
 
     public static bool IsOwnedTypeKey(this IProperty property)
     {
-        var entityType = property.DeclaringEntityType;
+        var entityType = (IReadOnlyEntityType)property.DeclaringType;
         if (entityType.IsDocumentRoot())
         {
             return false;
@@ -119,7 +119,8 @@ public static class MongoPropertyExtensions
     {
         if (property.ClrType != typeof(DateTime) && property.ClrType != typeof(DateTime?))
         {
-            throw new InvalidOperationException($"Cannot apply DateTimeKind annotation for non-DateTime field {property.Name} of {property.DeclaringEntityType.Name} entity.");
+            throw new InvalidOperationException($"Cannot apply DateTimeKind annotation for non-DateTime field {property.Name} of {
+                property.DeclaringType.Name} entity.");
         }
 
         property.SetAnnotation(MongoAnnotationNames.DateTimeKind, dateTimeKind);
@@ -135,7 +136,8 @@ public static class MongoPropertyExtensions
     {
         if (property.ClrType != typeof(DateTime) && property.ClrType != typeof(DateTime?))
         {
-            throw new InvalidOperationException($"Cannot apply DateTimeKind annotation for non-DateTime field {property.Name} of {property.DeclaringEntityType.Name} entity.");
+            throw new InvalidOperationException($"Cannot apply DateTimeKind annotation for non-DateTime field {property.Name} of {
+                property.DeclaringType.Name} entity.");
         }
 
         property.SetAnnotation(MongoAnnotationNames.DateTimeKind, dateTimeKind);

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
@@ -33,10 +33,10 @@ namespace MongoDB.EntityFrameworkCore.Infrastructure;
 /// </summary>
 public class MongoModelValidator : ModelValidator
 {
-    private static readonly Type[] __unsupportedConstructorAttributes = [typeof(BsonConstructorAttribute)];
-    private static readonly Type[] __unsupportedMethodAttributes = [typeof(BsonFactoryMethodAttribute)];
+    private static readonly Type[] UnsupportedConstructorAttributes = [typeof(BsonConstructorAttribute)];
+    private static readonly Type[] UnsupportedMethodAttributes = [typeof(BsonFactoryMethodAttribute)];
 
-    private static readonly Type[] __unsupportedClassAttributes =
+    private static readonly Type[] UnsupportedClassAttributes =
     [
         typeof(BsonDictionaryOptionsAttribute),
         typeof(BsonDiscriminatorAttribute),
@@ -97,7 +97,7 @@ public class MongoModelValidator : ModelValidator
     /// <exception cref="NotSupportedException">When an unsupported attribute is encountered on the type.</exception>
     private static void ValidateNoUnsupportedClassAttributes(IReadOnlyTypeBase entityType)
     {
-        var unsupported = FindUndefinedAttribute(entityType.ClrType.GetCustomAttributes(), __unsupportedClassAttributes);
+        var unsupported = FindUndefinedAttribute(entityType.ClrType.GetCustomAttributes(), UnsupportedClassAttributes);
         if (unsupported == null) return;
 
         var attributeTypeName = unsupported.GetType().ShortDisplayName();
@@ -114,7 +114,7 @@ public class MongoModelValidator : ModelValidator
     {
         foreach (var constructor in entityType.ClrType.GetConstructors())
         {
-            var unsupported = FindUndefinedAttribute(constructor.GetCustomAttributes(), __unsupportedConstructorAttributes);
+            var unsupported = FindUndefinedAttribute(constructor.GetCustomAttributes(), UnsupportedConstructorAttributes);
             if (unsupported == null) continue;
 
             var attributeTypeName = unsupported.GetType().ShortDisplayName();
@@ -133,7 +133,7 @@ public class MongoModelValidator : ModelValidator
     {
         foreach (var method in entityType.ClrType.GetMethods())
         {
-            var unsupported = FindUndefinedAttribute(method.GetCustomAttributes(), __unsupportedMethodAttributes);
+            var unsupported = FindUndefinedAttribute(method.GetCustomAttributes(), UnsupportedMethodAttributes);
             if (unsupported == null) continue;
 
             var attributeTypeName = unsupported.GetType().ShortDisplayName();

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
@@ -100,7 +100,7 @@ public class MongoModelValidator : ModelValidator
         var unsupported = FindUndefinedAttribute(entityType.ClrType.GetCustomAttributes(), __unsupportedClassAttributes);
         if (unsupported == null) return;
 
-        string attributeTypeName = unsupported.GetType().ShortDisplayName();
+        var attributeTypeName = unsupported.GetType().ShortDisplayName();
         throw new NotSupportedException($"Entity '{entityType.DisplayName()}' is annotated with unsupported attribute '{
             attributeTypeName}'.");
     }
@@ -117,7 +117,7 @@ public class MongoModelValidator : ModelValidator
             var unsupported = FindUndefinedAttribute(constructor.GetCustomAttributes(), __unsupportedConstructorAttributes);
             if (unsupported == null) continue;
 
-            string attributeTypeName = unsupported.GetType().ShortDisplayName();
+            var attributeTypeName = unsupported.GetType().ShortDisplayName();
             throw new NotSupportedException(
                 $"Entity '{entityType.DisplayName()}' has a constructor annotated with unsupported attribute '{attributeTypeName
                 }'.");
@@ -136,7 +136,7 @@ public class MongoModelValidator : ModelValidator
             var unsupported = FindUndefinedAttribute(method.GetCustomAttributes(), __unsupportedMethodAttributes);
             if (unsupported == null) continue;
 
-            string attributeTypeName = unsupported.GetType().ShortDisplayName();
+            var attributeTypeName = unsupported.GetType().ShortDisplayName();
             throw new NotSupportedException(
                 $"Method '{entityType.DisplayName()}.{method.Name}' is annotated with unsupported attribute '{attributeTypeName
                 }'.");
@@ -159,7 +159,7 @@ public class MongoModelValidator : ModelValidator
         {
             if (property.FindAnnotation(MongoAnnotationNames.NotSupportedAttributes) is {Value: Attribute unsupported})
             {
-                string attributeTypeName = unsupported.GetType().ShortDisplayName();
+                var attributeTypeName = unsupported.GetType().ShortDisplayName();
                 throw new NotSupportedException(
                     $"Property '{entityType.DisplayName()}.{property.Name}' is annotated with unsupported attribute '{
                         attributeTypeName}'.");
@@ -216,7 +216,7 @@ public class MongoModelValidator : ModelValidator
         {
             // The primary key must map to "_id"
             var primaryKeyProperty = primaryKey.Properties[0];
-            string primaryKeyElementName = primaryKeyProperty.GetElementName();
+            var primaryKeyElementName = primaryKeyProperty.GetElementName();
             if (primaryKeyElementName != "_id")
             {
                 throw new InvalidOperationException(
@@ -237,7 +237,7 @@ public class MongoModelValidator : ModelValidator
 
         foreach (var property in entityType.GetProperties())
         {
-            string elementName = property.GetElementName();
+            var elementName = property.GetElementName();
             if (string.IsNullOrWhiteSpace(elementName)) continue;
 
             if (elementName.StartsWith("$"))
@@ -269,7 +269,7 @@ public class MongoModelValidator : ModelValidator
 
         foreach (var navigation in entityType.GetNavigations().Where(n => n.IsEmbedded()))
         {
-            string? elementName = navigation.TargetEntityType.GetContainingElementName();
+            var elementName = navigation.TargetEntityType.GetContainingElementName();
             if (elementName != null)
             {
                 if (elementName.StartsWith("$"))

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConvention.cs
@@ -82,8 +82,8 @@ public sealed class BsonIgnoreAttributeConvention : IEntityTypeAddedConvention, 
 
     private static string GetMemberName(MemberInfo member)
     {
-        string name = member.Name;
-        int index = member.Name.LastIndexOf('.');
+        var name = member.Name;
+        var index = member.Name.LastIndexOf('.');
         return index >= 0 ? name[(index + 1)..] : name;
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CollectionNameFromDbSetConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CollectionNameFromDbSetConvention.cs
@@ -70,7 +70,7 @@ public class CollectionNameFromDbSetConvention : IEntityTypeAddedConvention
     {
         var entityType = entityTypeBuilder.Metadata;
         if (!entityType.HasSharedClrType
-            && _sets.TryGetValue(entityType.ClrType, out string? setName))
+            && _sets.TryGetValue(entityType.ClrType, out var setName))
         {
             entityTypeBuilder.ToCollection(setName);
         }

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoValueGenerationConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoValueGenerationConvention.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024-present MongoDB Inc.
+﻿/* Copyright 2023-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -80,7 +79,10 @@ public class PrimaryKeyDiscoveryConvention : KeyDiscoveryConvention
                                           entityProperties.FirstOrDefault(p => p.Name == "_id");
         if (underscoreIdElementProperty != null)
         {
-            entityTypeBuilder.PrimaryKey(new[] {underscoreIdElementProperty});
+            entityTypeBuilder.PrimaryKey(new[]
+            {
+                underscoreIdElementProperty
+            });
             return;
         }
 

--- a/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
@@ -37,7 +37,7 @@ public static partial class NamingHelperMethods
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        string[] words = WordSplitRegex.Split(input);
+        var words = WordSplitRegex.Split(input);
 
         var result = new char[input.Length];
         var outIndex = 0;
@@ -78,7 +78,7 @@ public static partial class NamingHelperMethods
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        string[] words = WordSplitRegex.Split(input);
+        var words = WordSplitRegex.Split(input);
 
         var result = new char[input.Length];
         var outIndex = 0;

--- a/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
@@ -39,12 +39,12 @@ public static partial class NamingHelperMethods
 
         string[] words = __wordSplitRegex.Split(input);
 
-        char[] result = new char[input.Length];
-        int outIndex = 0;
+        var result = new char[input.Length];
+        var outIndex = 0;
 
-        for (int inIndex = 0; inIndex < words.Length; inIndex++)
+        for (var inIndex = 0; inIndex < words.Length; inIndex++)
         {
-            string w = words[inIndex];
+            var w = words[inIndex];
             if (w.Length == 0) continue;
 
             if (inIndex == 0)
@@ -80,12 +80,12 @@ public static partial class NamingHelperMethods
 
         string[] words = __wordSplitRegex.Split(input);
 
-        char[] result = new char[input.Length];
-        int outIndex = 0;
+        var result = new char[input.Length];
+        var outIndex = 0;
 
-        for (int inIndex = 0; inIndex < words.Length; inIndex++)
+        for (var inIndex = 0; inIndex < words.Length; inIndex++)
         {
-            string w = words[inIndex];
+            var w = words[inIndex];
             if (w.Length == 0) continue;
 
             result[outIndex] = char.ToUpper(w[0], culture);

--- a/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
@@ -37,7 +37,7 @@ public static partial class NamingHelperMethods
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        var words = WordSplitRegex.Split(input);
+        var words = WordSplitRegex().Split(input);
 
         var result = new char[input.Length];
         var outIndex = 0;
@@ -78,7 +78,7 @@ public static partial class NamingHelperMethods
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        var words = WordSplitRegex.Split(input);
+        var words = WordSplitRegex().Split(input);
 
         var result = new char[input.Length];
         var outIndex = 0;
@@ -100,6 +100,6 @@ public static partial class NamingHelperMethods
     // Find word boundaries.
     // Word boundaries are considered spaces, non-alphanumeric, a transition from lower to upper,
     // a transition from multiple uppers to lowercase, and a transition from number to non-number.
-    private static readonly Regex WordSplitRegex =
-        new(@"(?<=[a-z])(?=[A-Z])|[\s\p{P}]|(?<=\p{Lu})(?=\p{Lu}\p{Ll})|(?<=\p{N})(?=\P{N})");
+    [GeneratedRegex(@"(?<=[a-z])(?=[A-Z])|[\s\p{P}]|(?<=\p{Lu})(?=\p{Lu}\p{Ll})|(?<=\p{N})(?=\P{N})")]
+    private static partial Regex WordSplitRegex();
 }

--- a/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
@@ -37,7 +37,7 @@ public static partial class NamingHelperMethods
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        string[] words = __wordSplitRegex.Split(input);
+        string[] words = WordSplitRegex.Split(input);
 
         var result = new char[input.Length];
         var outIndex = 0;
@@ -78,7 +78,7 @@ public static partial class NamingHelperMethods
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        string[] words = __wordSplitRegex.Split(input);
+        string[] words = WordSplitRegex.Split(input);
 
         var result = new char[input.Length];
         var outIndex = 0;
@@ -100,6 +100,6 @@ public static partial class NamingHelperMethods
     // Find word boundaries.
     // Word boundaries are considered spaces, non-alphanumeric, a transition from lower to upper,
     // a transition from multiple uppers to lowercase, and a transition from number to non-number.
-    private static readonly Regex __wordSplitRegex =
+    private static readonly Regex WordSplitRegex =
         new(@"(?<=[a-z])(?=[A-Z])|[\s\p{P}]|(?<=\p{Lu})(?=\p{Lu}\p{Ll})|(?<=\p{N})(?=\P{N})");
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/EntityProjectionExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/EntityProjectionExpression.cs
@@ -74,7 +74,7 @@ internal sealed class EntityProjectionExpression : EntityTypedExpression, IPrint
                 $"Unable to bind 'navigation' '{navigation.Name}' to an entity projection of '{EntityType.DisplayName()}'.");
         }
 
-        if (!_navigationExpressionsMap.TryGetValue(navigation, out IAccessExpression? expression))
+        if (!_navigationExpressionsMap.TryGetValue(navigation, out var expression))
         {
             expression = navigation.IsCollection
                 ? new ObjectArrayProjectionExpression(navigation, ParentAccessExpression)
@@ -119,14 +119,14 @@ internal sealed class EntityProjectionExpression : EntityTypedExpression, IPrint
         Type? entityClrType,
         out IPropertyBase? propertyBase)
     {
-        IEntityType entityType = EntityType;
+        var entityType = EntityType;
         if (entityClrType != null
             && !entityClrType.IsAssignableFrom(entityType.ClrType))
         {
             entityType = entityType.GetDerivedTypes().First(e => entityClrType.IsAssignableFrom(e.ClrType));
         }
 
-        IProperty? property = member.MemberInfo == null
+        var property = member.MemberInfo == null
             ? entityType.FindProperty(member.Name)
             : entityType.FindProperty(member.MemberInfo);
 
@@ -136,7 +136,7 @@ internal sealed class EntityProjectionExpression : EntityTypedExpression, IPrint
             return BindProperty(property);
         }
 
-        INavigation? navigation = member.MemberInfo == null
+        var navigation = member.MemberInfo == null
             ? entityType.FindNavigation(member.Name)
             : entityType.FindNavigation(member.MemberInfo);
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.cs
@@ -61,16 +61,16 @@ internal sealed class MongoQueryExpression : Expression
 
     public int AddToProjection(Expression expression, string? alias = null)
     {
-        int existingIndex = _projection.FindIndex(pe => pe.Expression.Equals(expression));
+        var existingIndex = _projection.FindIndex(pe => pe.Expression.Equals(expression));
         if (existingIndex != -1)
         {
             return existingIndex;
         }
 
-        string? baseAlias = alias ?? (expression as IAccessExpression)?.Name;
+        var baseAlias = alias ?? (expression as IAccessExpression)?.Name;
 
-        string? currentAlias = baseAlias;
-        int counter = 0;
+        var currentAlias = baseAlias;
+        var counter = 0;
         while (_projection.Any(pe => string.Equals(pe.Alias, currentAlias, StringComparison.OrdinalIgnoreCase)))
         {
             currentAlias = $"{baseAlias}{counter++}";

--- a/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
@@ -169,7 +169,7 @@ internal sealed class QueryingEnumerable<TSource, TTarget> : IAsyncEnumerable<TT
                 _queryContext.InitializeStateManager(_standAloneStateManager);
             }
 
-            bool hasNext = _enumerator.MoveNext();
+            var hasNext = _enumerator.MoveNext();
 
             logAction?.Invoke();
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/FinalPredicateHoistingVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/FinalPredicateHoistingVisitor.cs
@@ -27,7 +27,7 @@ namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 /// </summary>
 internal class FinalPredicateHoistingVisitor : ExpressionVisitor
 {
-    private static readonly FinalPredicateHoistingVisitor __instance = new();
+    private static readonly FinalPredicateHoistingVisitor Instance = new();
 
     private FinalPredicateHoistingVisitor()
     {
@@ -41,7 +41,7 @@ internal class FinalPredicateHoistingVisitor : ExpressionVisitor
     /// <returns>A hoisted version of the LINQ query expression if required, otherwise the original expression.</returns>
     public static Expression Hoist(Expression expression)
     {
-        return __instance.Visit(expression);
+        return Instance.Visit(expression);
     }
 
     /// <inheritdoc/>

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -69,7 +69,7 @@ internal sealed class MongoEFToLinqTranslatingExpressionVisitor : ExpressionVisi
         Expression query,
         BsonDocumentSerializer resultSerializer)
     {
-        var asMethodInfo = __asMethodInfo.MakeGenericMethod(query.Type.GenericTypeArguments[0], typeof(BsonDocument));
+        var asMethodInfo = AsMethodInfo.MakeGenericMethod(query.Type.GenericTypeArguments[0], typeof(BsonDocument));
         var cast = Expression.Convert(query, typeof(IMongoQueryable<>).MakeGenericType(query.Type.GenericTypeArguments[0]));
         var serializerExpression = Expression.Constant(resultSerializer, resultSerializer.GetType());
 
@@ -140,7 +140,7 @@ internal sealed class MongoEFToLinqTranslatingExpressionVisitor : ExpressionVisi
             ? unaryExpression.Operand
             : expression;
 
-    private static readonly MethodInfo __asMethodInfo = typeof(MongoQueryable)
+    private static readonly MethodInfo AsMethodInfo = typeof(MongoQueryable)
         .GetMethods()
         .First(mi => mi is {Name: nameof(MongoQueryable.As), IsPublic: true, IsStatic: true} && mi.GetParameters().Length == 2);
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -111,15 +111,15 @@ internal sealed class MongoProjectionBindingExpressionVisitor : ExpressionVisito
     {
         switch (extensionExpression)
         {
-            case StructuralTypeShaperExpression StructuralTypeShaperExpression:
+            case StructuralTypeShaperExpression structuralTypeShaperExpression:
                 {
                     var projectionBindingExpression =
-                        (ProjectionBindingExpression)StructuralTypeShaperExpression.ValueBufferExpression;
+                        (ProjectionBindingExpression)structuralTypeShaperExpression.ValueBufferExpression;
 
                     var entityProjection = (EntityProjectionExpression)_queryExpression.GetMappedProjection(
                         projectionBindingExpression.ProjectionMember);
 
-                    return StructuralTypeShaperExpression.Update(
+                    return structuralTypeShaperExpression.Update(
                         new ProjectionBindingExpression(
                             _queryExpression, _queryExpression.AddToProjection(entityProjection), typeof(ValueBuffer)));
                 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -153,7 +153,7 @@ internal sealed class MongoProjectionBindingExpressionVisitor : ExpressionVisito
     /// <inheritdoc />
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
-        if (methodCallExpression.TryGetEFPropertyArguments(out var source, out string memberName))
+        if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var memberName))
         {
             var visitedSource = Visit(source);
 
@@ -241,7 +241,7 @@ internal sealed class MongoProjectionBindingExpressionVisitor : ExpressionVisito
 
         var newObject = Visit(methodCallExpression.Object);
         var newArguments = new Expression[methodCallExpression.Arguments.Count];
-        for (int i = 0; i < newArguments.Length; i++)
+        for (var i = 0; i < newArguments.Length; i++)
         {
             var argument = methodCallExpression.Arguments[i];
             var newArgument = Visit(argument);
@@ -273,10 +273,10 @@ internal sealed class MongoProjectionBindingExpressionVisitor : ExpressionVisito
     protected override Expression VisitNew(NewExpression newExpression)
     {
         if (newExpression.Arguments.Count == 0) return newExpression;
-        bool hasMembers = newExpression.Members != null;
+        var hasMembers = newExpression.Members != null;
 
         var newArguments = new Expression[newExpression.Arguments.Count];
-        for (int i = 0; i < newArguments.Length; i++)
+        for (var i = 0; i < newArguments.Length; i++)
         {
             var argument = newExpression.Arguments[i];
 
@@ -327,7 +327,7 @@ internal sealed class MongoProjectionBindingExpressionVisitor : ExpressionVisito
         }
 
         var newBindings = new MemberBinding[memberInitExpression.Bindings.Count];
-        for (int i = 0; i < newBindings.Length; i++)
+        for (var i = 0; i < newBindings.Length; i++)
         {
             if (memberInitExpression.Bindings[i].BindingType != MemberBindingType.Assignment)
             {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -70,15 +70,15 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ProjectionBindi
         Type type,
         CoreTypeMapping? typeMapping = null)
     {
-        IEntityType entityType = docExpression switch
+        var entityType = docExpression switch
         {
             RootReferenceExpression rootReferenceExpression => rootReferenceExpression.EntityType,
             ObjectAccessExpression docAccessExpression => docAccessExpression.Navigation.TargetEntityType,
             _ => _rootEntityType
         };
 
-        Expression? innerExpression = docExpression;
-        if (ProjectionBindings.TryGetValue(docExpression, out ParameterExpression? innerVariable))
+        var innerExpression = docExpression;
+        if (ProjectionBindings.TryGetValue(docExpression, out var innerVariable))
         {
             innerExpression = innerVariable;
         }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -72,7 +72,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         {
             // We are relying on raw/scalar values coming back from LINQ V3 provider for now - no shaper required
             return Expression.Call(null,
-                __translateAndExecuteUnshapedQuery.MakeGenericMethod(rootEntityType.ClrType,
+                TranslateAndExecuteUnshapedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType,
                     shapedQueryExpression.ShaperExpression.Type),
                 QueryCompilationContext.QueryContextParameter,
                 Expression.Constant(rootEntityType),
@@ -104,7 +104,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
                                      QueryTrackingBehavior.NoTrackingWithIdentityResolution;
 
         return Expression.Call(null,
-            __translateAndExecuteQuery.MakeGenericMethod(rootEntityType.ClrType, projectedType),
+            TranslateAndExecuteQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType, projectedType),
             QueryCompilationContext.QueryContextParameter,
             Expression.Constant(rootEntityType),
             Expression.Constant(_entitySerializerCache),
@@ -133,7 +133,8 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         var queryTranslator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression);
         var translatedQuery = queryTranslator.Visit(queryExpression.CapturedExpression)!;
 
-        var executableQuery = new MongoExecutableQuery(translatedQuery, resultCardinality, source.Provider, collection.CollectionNamespace);
+        var executableQuery =
+            new MongoExecutableQuery(translatedQuery, resultCardinality, source.Provider, collection.CollectionNamespace);
 
         return new QueryingEnumerable<TResult, TResult>(
             mongoQueryContext,
@@ -162,7 +163,8 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         var queryTranslator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression);
         var translatedQuery = queryTranslator.Translate(queryExpression.CapturedExpression, resultCardinality);
 
-        var executableQuery = new MongoExecutableQuery(translatedQuery, resultCardinality, source.Provider, collection.CollectionNamespace);
+        var executableQuery =
+            new MongoExecutableQuery(translatedQuery, resultCardinality, source.Provider, collection.CollectionNamespace);
 
         return new QueryingEnumerable<BsonDocument, TResult>(
             mongoQueryContext,
@@ -173,13 +175,14 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             threadSafetyChecksEnabled);
     }
 
-    private static readonly MethodInfo __translateAndExecuteQuery = typeof(MongoShapedQueryCompilingExpressionVisitor)
+    private static readonly MethodInfo TranslateAndExecuteQueryMethodInfo = typeof(MongoShapedQueryCompilingExpressionVisitor)
         .GetTypeInfo()
         .DeclaredMethods
         .Single(m => m.Name == nameof(TranslateAndExecuteQuery));
 
-    private static readonly MethodInfo __translateAndExecuteUnshapedQuery = typeof(MongoShapedQueryCompilingExpressionVisitor)
-        .GetTypeInfo()
-        .DeclaredMethods
-        .Single(m => m.Name == nameof(TranslateAndExecuteUnshapedQuery));
+    private static readonly MethodInfo TranslateAndExecuteUnshapedQueryMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(TranslateAndExecuteUnshapedQuery));
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -84,7 +84,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         }
 
         var bsonDocParameter = Expression.Parameter(typeof(BsonDocument), "bsonDoc");
-        bool trackQueryResults = QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+        var trackQueryResults = QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
 
         var shaperBody = shapedQueryExpression.ShaperExpression;
         shaperBody = new BsonDocumentInjectingExpressionVisitor().Visit(shaperBody);
@@ -100,8 +100,8 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         var compiledShaper = shaperLambda.Compile();
 
         var projectedType = shaperLambda.ReturnType;
-        bool standAloneStateManager = QueryCompilationContext.QueryTrackingBehavior ==
-                                      QueryTrackingBehavior.NoTrackingWithIdentityResolution;
+        var standAloneStateManager = QueryCompilationContext.QueryTrackingBehavior ==
+                                     QueryTrackingBehavior.NoTrackingWithIdentityResolution;
 
         return Expression.Call(null,
             __translateAndExecuteQuery.MakeGenericMethod(rootEntityType.ClrType, projectedType),

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
@@ -31,7 +31,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
     protected readonly Dictionary<Expression, ParameterExpression> ProjectionBindings = new();
     private readonly Dictionary<Expression, (IEntityType EntityType, Expression BsonDocExpression)> _ownerMappings = new();
     private readonly Dictionary<Expression, Expression> _ordinalParameterBindings = new();
-    private List<IncludeExpression> _pendingIncludes = new();
+    private List<IncludeExpression> _pendingIncludes = [];
 
     protected ProjectionBindingRemovingExpressionVisitor(
         ParameterExpression docParameter,
@@ -127,7 +127,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
                     var shaperBlock = (BlockExpression)bsonDocCondition.IfFalse;
                     shaperBlock = AddIncludes(shaperBlock);
 
-                    List<Expression> jObjectExpressions = new(bsonDocBlock.Expressions);
+                    List<Expression> jObjectExpressions = [..bsonDocBlock.Expressions];
                     jObjectExpressions.RemoveAt(jObjectExpressions.Count - 1);
 
                     jObjectExpressions.Add(
@@ -360,12 +360,12 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
             return shaperBlock;
         }
 
-        List<Expression> shaperExpressions = new(shaperBlock.Expressions);
+        List<Expression> shaperExpressions = [..shaperBlock.Expressions];
         var instanceVariable = shaperExpressions[^1];
         shaperExpressions.RemoveAt(shaperExpressions.Count - 1);
 
         var includesToProcess = _pendingIncludes;
-        _pendingIncludes = new List<IncludeExpression>();
+        _pendingIncludes = [];
 
         foreach (var include in includesToProcess)
         {
@@ -534,12 +534,12 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
     {
         var entityParameter = Expression.Parameter(entityType);
         var relatedEntityParameter = Expression.Parameter(relatedEntityType);
-        List<Expression> expressions = new()
-        {
+        List<Expression> expressions =
+        [
             navigation.IsCollection
                 ? AddToCollectionNavigation(entityParameter, relatedEntityParameter, navigation)
                 : AssignReferenceNavigation(entityParameter, relatedEntityParameter, navigation)
-        };
+        ];
 
         if (inverseNavigation != null)
         {
@@ -575,10 +575,9 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
             .GetDeclaredMethod(nameof(PopulateCollection));
 
     private static readonly MethodInfo IsAssignableFromMethodInfo
-        = typeof(IReadOnlyEntityType).GetMethod(nameof(IReadOnlyEntityType.IsAssignableFrom), new[]
-        {
+        = typeof(IReadOnlyEntityType).GetMethod(nameof(IReadOnlyEntityType.IsAssignableFrom), [
             typeof(IReadOnlyEntityType)
-        })!;
+        ])!;
 
     private static TCollection PopulateCollection<TEntity, TCollection>(
         IClrCollectionAccessor accessor,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
@@ -282,7 +282,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
     {
         if (property.IsOwnedTypeKey())
         {
-            var entityType = property.DeclaringEntityType;
+            var entityType = (IReadOnlyEntityType)property.DeclaringType;
             if (!entityType.IsDocumentRoot())
             {
                 var ownership = entityType.FindOwnership();

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitorBase.cs
@@ -47,7 +47,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
         {
             case ProjectionBindingExpression projectionBindingExpression:
                 {
-                    ProjectionExpression projection = GetProjection(projectionBindingExpression);
+                    var projection = GetProjection(projectionBindingExpression);
 
                     return CreateGetValueExpression(
                         DocParameter,
@@ -62,7 +62,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
                     switch (collectionShaperExpression.Projection)
                     {
                         case ProjectionBindingExpression projectionBindingExpression:
-                            ProjectionExpression projection = GetProjection(projectionBindingExpression);
+                            var projection = GetProjection(projectionBindingExpression);
                             objectArrayProjection = (ObjectArrayProjectionExpression)projection.Expression;
                             break;
                         case ObjectArrayProjectionExpression objectArrayProjectionExpression:
@@ -72,29 +72,29 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
                             throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
                     }
 
-                    ParameterExpression bsonArray = ProjectionBindings[objectArrayProjection];
-                    ParameterExpression jObjectParameter = Expression.Parameter(typeof(BsonDocument), bsonArray.Name + "Object");
-                    ParameterExpression ordinalParameter = Expression.Parameter(typeof(int), bsonArray.Name + "Ordinal");
+                    var bsonArray = ProjectionBindings[objectArrayProjection];
+                    var jObjectParameter = Expression.Parameter(typeof(BsonDocument), bsonArray.Name + "Object");
+                    var ordinalParameter = Expression.Parameter(typeof(int), bsonArray.Name + "Ordinal");
 
-                    Expression accessExpression = objectArrayProjection.InnerProjection.ParentAccessExpression;
+                    var accessExpression = objectArrayProjection.InnerProjection.ParentAccessExpression;
                     ProjectionBindings[accessExpression] = jObjectParameter;
                     _ownerMappings[accessExpression] =
                         (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
                     _ordinalParameterBindings[accessExpression] = Expression.Add(
                         ordinalParameter, Expression.Constant(1, typeof(int)));
 
-                    BlockExpression innerShaper = (BlockExpression)Visit(collectionShaperExpression.InnerShaper);
+                    var innerShaper = (BlockExpression)Visit(collectionShaperExpression.InnerShaper);
 
                     innerShaper = AddIncludes(innerShaper);
 
-                    MethodCallExpression entities = Expression.Call(
+                    var entities = Expression.Call(
                         EnumerableMethods.SelectWithOrdinal.MakeGenericMethod(typeof(BsonDocument), innerShaper.Type),
                         Expression.Call(
                             EnumerableMethods.Cast.MakeGenericMethod(typeof(BsonDocument)),
                             bsonArray),
                         Expression.Lambda(innerShaper, jObjectParameter, ordinalParameter));
 
-                    INavigationBase navigation = collectionShaperExpression.Navigation;
+                    var navigation = collectionShaperExpression.Navigation;
                     return Expression.Call(
                         PopulateCollectionMethodInfo.MakeGenericMethod(navigation.TargetEntityType.ClrType, navigation.ClrType),
                         Expression.Constant(navigation.GetCollectionAccessor()),
@@ -112,19 +112,19 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
                             }' is not supported as the navigation is not embedded in same resource.");
                     }
 
-                    bool isFirstInclude = _pendingIncludes.Count == 0;
+                    var isFirstInclude = _pendingIncludes.Count == 0;
                     _pendingIncludes.Add(includeExpression);
 
-                    BlockExpression bsonDocBlock = Visit(includeExpression.EntityExpression) as BlockExpression;
+                    var bsonDocBlock = Visit(includeExpression.EntityExpression) as BlockExpression;
 
                     if (!isFirstInclude)
                     {
                         return bsonDocBlock;
                     }
 
-                    ConditionalExpression bsonDocCondition = (ConditionalExpression)bsonDocBlock.Expressions[^1];
+                    var bsonDocCondition = (ConditionalExpression)bsonDocBlock.Expressions[^1];
 
-                    BlockExpression shaperBlock = (BlockExpression)bsonDocCondition.IfFalse;
+                    var shaperBlock = (BlockExpression)bsonDocCondition.IfFalse;
                     shaperBlock = AddIncludes(shaperBlock);
 
                     List<Expression> jObjectExpressions = new(bsonDocBlock.Expressions);
@@ -153,12 +153,12 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
             if (parameterExpression.Type == typeof(BsonDocument) || parameterExpression.Type == typeof(BsonArray))
             {
                 string fieldName = null;
-                bool fieldRequired = true;
+                var fieldRequired = true;
 
-                Expression projectionExpression = ((UnaryExpression)binaryExpression.Right).Operand;
+                var projectionExpression = ((UnaryExpression)binaryExpression.Right).Operand;
                 if (projectionExpression is ProjectionBindingExpression projectionBindingExpression)
                 {
-                    ProjectionExpression projection = GetProjection(projectionBindingExpression);
+                    var projection = GetProjection(projectionBindingExpression);
                     projectionExpression = projection.Expression;
                     fieldName = projection.Alias;
                 }
@@ -177,8 +177,8 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
                 }
                 else
                 {
-                    EntityProjectionExpression entityProjectionExpression = (EntityProjectionExpression)projectionExpression;
-                    Expression accessExpression = entityProjectionExpression.ParentAccessExpression;
+                    var entityProjectionExpression = (EntityProjectionExpression)projectionExpression;
+                    var accessExpression = entityProjectionExpression.ParentAccessExpression;
                     ProjectionBindings[accessExpression] = parameterExpression;
                     fieldName ??= entityProjectionExpression.Name;
 
@@ -199,7 +199,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
                     }
                 }
 
-                Expression valueExpression =
+                var valueExpression =
                     CreateGetValueExpression(innerAccessExpression, fieldName, fieldRequired, parameterExpression.Type);
 
                 return Expression.MakeBinary(ExpressionType.Assign, binaryExpression.Left, valueExpression);
@@ -207,23 +207,23 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
 
             if (parameterExpression.Type == typeof(MaterializationContext))
             {
-                NewExpression newExpression = (NewExpression)binaryExpression.Right;
+                var newExpression = (NewExpression)binaryExpression.Right;
 
                 EntityProjectionExpression entityProjectionExpression;
                 if (newExpression.Arguments[0] is ProjectionBindingExpression projectionBindingExpression)
                 {
-                    ProjectionExpression projection = GetProjection(projectionBindingExpression);
+                    var projection = GetProjection(projectionBindingExpression);
                     entityProjectionExpression = (EntityProjectionExpression)projection.Expression;
                 }
                 else
                 {
-                    Expression projection = ((UnaryExpression)((UnaryExpression)newExpression.Arguments[0]).Operand).Operand;
+                    var projection = ((UnaryExpression)((UnaryExpression)newExpression.Arguments[0]).Operand).Operand;
                     entityProjectionExpression = (EntityProjectionExpression)projection;
                 }
 
                 _materializationContextBindings[parameterExpression] = entityProjectionExpression.ParentAccessExpression;
 
-                NewExpression updatedExpression = Expression.New(
+                var updatedExpression = Expression.New(
                     newExpression.Constructor,
                     Expression.Constant(ValueBuffer.Empty),
                     newExpression.Arguments[1]);
@@ -243,8 +243,8 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
     /// <returns>A <see cref="Expression"/> to replace the original method call with.</returns>
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
-        MethodInfo method = methodCallExpression.Method;
-        MethodInfo genericMethod = method.IsGenericMethod ? method.GetGenericMethodDefinition() : null;
+        var method = methodCallExpression.Method;
+        var genericMethod = method.IsGenericMethod ? method.GetGenericMethodDefinition() : null;
 
         // Ensure ".AsQueryable" is not injected around collections as sometimes they are null and will throw
         if (method.DeclaringType == typeof(Queryable) && genericMethod == QueryableMethods.AsQueryable)
@@ -254,11 +254,11 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
 
         if (genericMethod == ExpressionExtensions.ValueBufferTryReadValueMethod)
         {
-            IProperty property = methodCallExpression.Arguments[2].GetConstantValue<IProperty>();
+            var property = methodCallExpression.Arguments[2].GetConstantValue<IProperty>();
             Expression innerExpression;
             if (methodCallExpression.Arguments[0] is ProjectionBindingExpression projectionBindingExpression)
             {
-                ProjectionExpression projection = GetProjection(projectionBindingExpression);
+                var projection = GetProjection(projectionBindingExpression);
                 innerExpression =
                     CreateGetValueExpression(DocParameter, projection.Alias, projection.Required, typeof(BsonDocument));
             }
@@ -282,13 +282,13 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
     {
         if (property.IsOwnedTypeKey())
         {
-            IEntityType entityType = property.DeclaringEntityType;
+            var entityType = property.DeclaringEntityType;
             if (!entityType.IsDocumentRoot())
             {
-                IForeignKey ownership = entityType.FindOwnership();
+                var ownership = entityType.FindOwnership();
                 if (ownership?.IsUnique == false && property.IsOwnedCollectionShadowKey())
                 {
-                    Expression readExpression = _ordinalParameterBindings[docExpression];
+                    var readExpression = _ordinalParameterBindings[docExpression];
                     if (readExpression.Type != type)
                     {
                         readExpression = Expression.Convert(readExpression, type);
@@ -297,12 +297,12 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
                     return readExpression;
                 }
 
-                IProperty principalProperty = property.FindFirstPrincipal();
+                var principalProperty = property.FindFirstPrincipal();
                 if (principalProperty != null)
                 {
                     Expression ownerBsonDocExpression = null;
                     if (_ownerMappings.TryGetValue(docExpression,
-                            out (IEntityType EntityType, Expression BsonDocExpression) ownerInfo))
+                            out var ownerInfo))
                     {
                         ownerBsonDocExpression = ownerInfo.BsonDocExpression;
                     }
@@ -361,13 +361,13 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
         }
 
         List<Expression> shaperExpressions = new(shaperBlock.Expressions);
-        Expression instanceVariable = shaperExpressions[^1];
+        var instanceVariable = shaperExpressions[^1];
         shaperExpressions.RemoveAt(shaperExpressions.Count - 1);
 
-        List<IncludeExpression> includesToProcess = _pendingIncludes;
+        var includesToProcess = _pendingIncludes;
         _pendingIncludes = new List<IncludeExpression>();
 
-        foreach (IncludeExpression include in includesToProcess)
+        foreach (var include in includesToProcess)
         {
             AddInclude(shaperExpressions, include, shaperBlock, instanceVariable);
         }
@@ -383,22 +383,22 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
         BlockExpression shaperBlock,
         Expression instanceVariable)
     {
-        INavigation navigation = (INavigation)includeExpression.Navigation;
-        MethodInfo includeMethod = navigation.IsCollection ? IncludeCollectionMethodInfo : IncludeReferenceMethodInfo;
-        Type includingClrType = navigation.DeclaringEntityType.ClrType;
-        Type relatedEntityClrType = navigation.TargetEntityType.ClrType;
+        var navigation = (INavigation)includeExpression.Navigation;
+        var includeMethod = navigation.IsCollection ? IncludeCollectionMethodInfo : IncludeReferenceMethodInfo;
+        var includingClrType = navigation.DeclaringEntityType.ClrType;
+        var relatedEntityClrType = navigation.TargetEntityType.ClrType;
 #pragma warning disable EF1001 // Internal EF Core API usage.
         Expression entityEntryVariable = _trackQueryResults
             ? shaperBlock.Variables.Single(v => v.Type == typeof(InternalEntityEntry))
             : Expression.Constant(null, typeof(InternalEntityEntry));
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
-        ParameterExpression concreteEntityTypeVariable = shaperBlock.Variables.Single(v => v.Type == typeof(IEntityType));
-        INavigation inverseNavigation = navigation.Inverse;
-        Delegate fixup = GenerateFixup(
+        var concreteEntityTypeVariable = shaperBlock.Variables.Single(v => v.Type == typeof(IEntityType));
+        var inverseNavigation = navigation.Inverse;
+        var fixup = GenerateFixup(
             includingClrType, relatedEntityClrType, navigation, inverseNavigation);
 
-        Expression navigationExpression = Visit(includeExpression.NavigationExpression);
+        var navigationExpression = Visit(includeExpression.NavigationExpression);
 
         shaperExpressions.Add(
             Expression.IfThen(
@@ -444,7 +444,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
 
         if (entry == null)
         {
-            TIncludingEntity includingEntity = (TIncludingEntity)entity;
+            var includingEntity = (TIncludingEntity)entity;
             navigation.SetIsLoadedWhenNoTracking(includingEntity);
             if (relatedEntity != null)
             {
@@ -489,12 +489,12 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
 
         if (entry == null)
         {
-            TIncludingEntity includingEntity = (TIncludingEntity)entity;
+            var includingEntity = (TIncludingEntity)entity;
             navigation.SetIsLoadedWhenNoTracking(includingEntity);
 
             if (relatedEntities != null)
             {
-                foreach (TIncludedEntity relatedEntity in relatedEntities)
+                foreach (var relatedEntity in relatedEntities)
                 {
                     fixup(includingEntity, relatedEntity);
                     inverseNavigation?.SetIsLoadedWhenNoTracking(relatedEntity);
@@ -512,7 +512,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
 
             if (relatedEntities != null)
             {
-                using IEnumerator<TIncludedEntity> enumerator = relatedEntities.GetEnumerator();
+                using var enumerator = relatedEntities.GetEnumerator();
                 while (enumerator.MoveNext())
                 {
                 }
@@ -532,8 +532,8 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
         INavigation navigation,
         INavigation inverseNavigation)
     {
-        ParameterExpression entityParameter = Expression.Parameter(entityType);
-        ParameterExpression relatedEntityParameter = Expression.Parameter(relatedEntityType);
+        var entityParameter = Expression.Parameter(entityType);
+        var relatedEntityParameter = Expression.Parameter(relatedEntityType);
         List<Expression> expressions = new()
         {
             navigation.IsCollection
@@ -585,8 +585,8 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
         IEnumerable<TEntity> entities)
     {
         // TODO: throw a better exception for non-ICollection navigations
-        ICollection<TEntity> collection = (ICollection<TEntity>)accessor.Create();
-        foreach (TEntity entity in entities)
+        var collection = (ICollection<TEntity>)accessor.Create();
+        foreach (var entity in entities)
         {
             collection.Add(entity);
         }

--- a/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
@@ -67,7 +67,7 @@ namespace MongoDB.EntityFrameworkCore.Serializers
             {
                 var entityType = navigation.TargetEntityType;
                 var serializer = _entitySerializerCache.GetOrCreateSerializer(entityType);
-                string? elementName = entityType.GetContainingElementName();
+                var elementName = entityType.GetContainingElementName();
                 if (elementName != null)
                 {
                     serializationInfo = new BsonSerializationInfo(elementName, serializer, entityType.ClrType);

--- a/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
@@ -58,7 +58,8 @@ internal static class SerializationHelper
     internal static BsonSerializationInfo GetPropertySerializationInfo(IReadOnlyProperty property)
     {
         var serializer = CreateTypeSerializer(property.ClrType, property);
-        if (property.IsPrimaryKey() && property.DeclaringEntityType.FindPrimaryKey()?.Properties.Count > 1)
+        if (property.IsPrimaryKey() && property.DeclaringType is IEntityType entityType
+                                    && entityType.FindPrimaryKey()?.Properties.Count > 1)
         {
             return BsonSerializationInfo.CreateWithPath(new[]
             {

--- a/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
@@ -123,7 +123,7 @@ internal static class SerializationHelper
         else
         {
             rawValue = document;
-            foreach (string? node in elementSerializationInfo.ElementPath)
+            foreach (var node in elementSerializationInfo.ElementPath)
             {
                 var doc = (BsonDocument)rawValue;
                 if (!doc.TryGetValue(node, out rawValue))

--- a/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
@@ -14,13 +14,10 @@
  */
 
 using System;
-using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Update;
 using MongoDB.Bson;
-using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -65,18 +65,18 @@ internal static class BsonBinding
             return CreateGetBsonDocument(bsonDocExpression, name, required, entityType);
         }
 
-        IProperty? targetProperty = entityType.FindProperty(name);
+        var targetProperty = entityType.FindProperty(name);
         if (targetProperty != null)
         {
             mappedType = targetProperty.IsNullable ? mappedType.MakeNullable() : mappedType;
             return CreateGetPropertyValue(bsonDocExpression, Expression.Constant(targetProperty), mappedType);
         }
 
-        INavigation navigationProperty = entityType.FindNavigation(name) ??
-                                         throw new InvalidOperationException(
-                                             CoreStrings.PropertyNotFound(name, entityType.DisplayName()));
+        var navigationProperty = entityType.FindNavigation(name) ??
+                                 throw new InvalidOperationException(
+                                     CoreStrings.PropertyNotFound(name, entityType.DisplayName()));
 
-        string fieldName = navigationProperty.TargetEntityType.GetContainingElementName()!;
+        var fieldName = navigationProperty.TargetEntityType.GetContainingElementName()!;
         return CreateGetElementValue(bsonDocExpression, fieldName, mappedType);
     }
 
@@ -89,7 +89,7 @@ internal static class BsonBinding
 
     private static BsonArray? GetBsonArray(BsonDocument document, string name)
     {
-        if (!document.TryGetValue(name, out BsonValue bsonValue))
+        if (!document.TryGetValue(name, out var bsonValue))
         {
             throw new InvalidOperationException($"Document element '{name}' is mapped collection but missing.");
         }
@@ -114,7 +114,7 @@ internal static class BsonBinding
 
     private static BsonDocument? GetBsonDocument(BsonDocument parent, string name, bool required, IReadOnlyTypeBase entityType)
     {
-        BsonValue? value = parent.GetValue(name, BsonNull.Value);
+        var value = parent.GetValue(name, BsonNull.Value);
 
         if (value == BsonNull.Value && required)
         {

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -81,9 +81,9 @@ internal static class BsonBinding
     }
 
     private static Expression CreateGetBsonArray(Expression bsonDocExpression, string name)
-        => Expression.Call(null, __getBsonArray, bsonDocExpression, Expression.Constant(name));
+        => Expression.Call(null, GetBsonArrayMethodInfo, bsonDocExpression, Expression.Constant(name));
 
-    private static readonly MethodInfo __getBsonArray
+    private static readonly MethodInfo GetBsonArrayMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
             .Single(mi => mi.Name == nameof(GetBsonArray));
 
@@ -105,10 +105,11 @@ internal static class BsonBinding
 
     private static Expression CreateGetBsonDocument(
         Expression bsonDocExpression, string name, bool required, IEntityType entityType)
-        => Expression.Call(null, __getBsonDocument, bsonDocExpression, Expression.Constant(name), Expression.Constant(required),
+        => Expression.Call(null, GetBsonDocumentMethodInfo, bsonDocExpression, Expression.Constant(name),
+            Expression.Constant(required),
             Expression.Constant(entityType));
 
-    private static readonly MethodInfo __getBsonDocument
+    private static readonly MethodInfo GetBsonDocumentMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
             .Single(mi => mi.Name == nameof(GetBsonDocument));
 
@@ -127,16 +128,16 @@ internal static class BsonBinding
 
     private static Expression
         CreateGetPropertyValue(Expression bsonDocExpression, Expression propertyExpression, Type resultType) =>
-        Expression.Call(null, __getPropertyValueMethodInfo.MakeGenericMethod(resultType), bsonDocExpression, propertyExpression);
+        Expression.Call(null, GetPropertyValueMethodInfo.MakeGenericMethod(resultType), bsonDocExpression, propertyExpression);
 
     private static Expression CreateGetElementValue(Expression bsonDocExpression, string name, Type type) =>
-        Expression.Call(null, __getElementValueMethodInfo.MakeGenericMethod(type), bsonDocExpression, Expression.Constant(name));
+        Expression.Call(null, GetElementValueMethodInfo.MakeGenericMethod(type), bsonDocExpression, Expression.Constant(name));
 
-    private static readonly MethodInfo __getPropertyValueMethodInfo
+    private static readonly MethodInfo GetPropertyValueMethodInfo
         = typeof(SerializationHelper).GetMethods(BindingFlags.Static | BindingFlags.Public)
             .Single(mi => mi.Name == nameof(SerializationHelper.GetPropertyValue));
 
-    private static readonly MethodInfo __getElementValueMethodInfo
+    private static readonly MethodInfo GetElementValueMethodInfo
         = typeof(SerializationHelper).GetMethods(BindingFlags.Static | BindingFlags.Public)
             .Single(mi => mi.Name == nameof(SerializationHelper.GetElementValue));
 }

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -140,7 +140,7 @@ public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
             }
 
             writer.WriteName(navigation.TargetEntityType.GetContainingElementName());
-            object? embeddedValue = entry.GetCurrentValue(navigation);
+            var embeddedValue = entry.GetCurrentValue(navigation);
 
             if (embeddedValue == null)
             {
@@ -151,7 +151,7 @@ public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
                 if (navigation.IsCollection)
                 {
                     writer.WriteStartArray();
-                    foreach (object dependent in (IEnumerable)embeddedValue)
+                    foreach (var dependent in (IEnumerable)embeddedValue)
                     {
                         var embeddedEntry =
                             ((InternalEntityEntry)entry).StateManager.TryGetEntry(dependent,
@@ -191,7 +191,7 @@ public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
 
         if (!keyProperties.Any()) return;
 
-        bool compoundKey = keyProperties.Length > 1;
+        var compoundKey = keyProperties.Length > 1;
         if (compoundKey)
         {
             writer.WriteName("_id");
@@ -201,7 +201,7 @@ public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
         foreach (var property in keyProperties)
         {
             var serializationInfo = SerializationHelper.GetPropertySerializationInfo(property);
-            string? elementName = serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName;
+            var elementName = serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName;
             writer.WriteName(elementName);
             var root = BsonSerializationContext.CreateRoot(writer);
             serializationInfo.Serializer.Serialize(root, entry.GetCurrentValue(property));
@@ -223,7 +223,7 @@ public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
         foreach (var property in properties)
         {
             var serializationInfo = SerializationHelper.GetPropertySerializationInfo(property);
-            string? elementName = serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName;
+            var elementName = serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName;
             writer.WriteName(elementName);
             var root = BsonSerializationContext.CreateRoot(writer);
             serializationInfo.Serializer.Serialize(root, entry.GetCurrentValue(property));

--- a/src/MongoDB.EntityFrameworkCore/ValueGeneration/ObjectIdValueGenerator.cs
+++ b/src/MongoDB.EntityFrameworkCore/ValueGeneration/ObjectIdValueGenerator.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024-present MongoDB Inc.
+﻿/* Copyright 2023-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
@@ -343,7 +343,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
     {
         var collection = tempDatabase.CreateTemporaryCollection<DecimalEntity>();
 
-        decimal expected = 0m;
+        var expected = 0m;
         while (expected <= 0)
             expected = random.NextDecimal();
 
@@ -381,7 +381,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
     {
         var collection = tempDatabase.CreateTemporaryCollection<DecimalEntity>();
 
-        decimal expected = 0m;
+        var expected = 0m;
         while (expected >= 0)
             expected = random.NextDecimal();
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
@@ -69,11 +69,20 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
         {
             var context = SingleEntityDbContext.Create(collection, ConfigureContext);
             context.Entitites.AddRange(
-                new[]
+            [
+                new Entity
                 {
-                    new Entity {Key1 = "one", Key2 = 1}, new Entity {Key1 = "two", Key2 = 2},
-                    new Entity {Key1 = "two", Key2 = 3},
-                });
+                    Key1 = "one", Key2 = 1
+                },
+                new Entity
+                {
+                    Key1 = "two", Key2 = 2
+                },
+                new Entity
+                {
+                    Key1 = "two", Key2 = 3
+                }
+            ]);
 
             context.SaveChanges();
         }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -34,7 +34,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(__personWithLocation);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
-        PersonWithLocation actual = db.Entitites.Single();
+        var actual = db.Entitites.Single();
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(__location1.latitude, actual.location.latitude);
@@ -62,7 +62,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(__personWithLocation);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
-        PersonWithLocation actual = db.Entitites.First(e => e.location.latitude > 0.00m);
+        var actual = db.Entitites.First(e => e.location.latitude > 0.00m);
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(__location1.latitude, actual.location.latitude);
@@ -76,7 +76,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(__personWithCity);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
-        PersonWithCity actual = db.Entitites.First(e => e.location.city.name == "San Diego");
+        var actual = db.Entitites.First(e => e.location.city.name == "San Diego");
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(__location1.latitude, actual.location.latitude);
@@ -131,7 +131,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_nested_one_level_creates()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        PersonWithLocation expected =
+        var expected =
             new PersonWithLocation
             {
                 name = "Charlie",
@@ -149,7 +149,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
-            PersonWithLocation actual = db.Entitites.First(p => p.name == "Charlie");
+            var actual = db.Entitites.First(p => p.name == "Charlie");
 
             Assert.Equal(expected.name, actual.name);
             Assert.Equal(expected.location.latitude, actual.location.latitude);
@@ -188,7 +188,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<PersonWithMultipleLocations> db = SingleEntityDbContext.Create(collection);
-            PersonWithMultipleLocations actual = db.Entitites.First(p => p.name == "Alfred");
+            var actual = db.Entitites.First(p => p.name == "Alfred");
 
             Assert.Equal(expected.name, actual.name);
             Assert.Equal(expected.locations[0].latitude, actual.locations[0].latitude);
@@ -314,7 +314,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(__personWithCity);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
-        PersonWithCity actual = db.Entitites.Single();
+        var actual = db.Entitites.Single();
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(__location1.latitude, actual.location.latitude);
@@ -492,11 +492,11 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_with_two_owned_entities_materializes()
     {
         IMongoCollection<PersonWithTwoLocations> collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
-        PersonWithTwoLocations expected = __personWithTwoLocations[0];
+        var expected = __personWithTwoLocations[0];
         collection.WriteTestDocs(__personWithTwoLocations);
         SingleEntityDbContext<PersonWithTwoLocations> db = SingleEntityDbContext.Create(collection);
 
-        PersonWithTwoLocations? actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entitites.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected.name, actual.name);
@@ -523,7 +523,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<PersonWithTwoLocations> db = SingleEntityDbContext.Create(collection);
-            PersonWithTwoLocations? actual = db.Entitites.FirstOrDefault();
+            var actual = db.Entitites.FirstOrDefault();
 
             Assert.NotNull(actual);
             Assert.Equal(expected.name, actual.name);
@@ -538,12 +538,12 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_can_have_element_name_set()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        PersonWithLocation expected = __personWithLocation[0];
+        var expected = __personWithLocation[0];
         collection.WriteTestDocs(__personWithLocation);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().OwnsOne(p => p.location, r => r.HasElementName("location")); });
 
-        PersonWithLocation? actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entitites.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected.name, actual.name);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -171,17 +171,18 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         {
             _id = ObjectId.GenerateNewId(),
             name = "Alfred",
-            locations = new List<Location>
-            {
+            locations =
+            [
                 new()
                 {
                     latitude = 1.234m, longitude = 1.567m
                 },
+
                 new()
                 {
                     latitude = 5.1m, longitude = 3.9m
                 }
-            }
+            ]
         };
 
         {
@@ -642,12 +643,12 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
     private static readonly PersonWithCity[] PersonWithCity1 =
-    {
+    [
         new()
         {
             name = "Carmen", location = LocationWithCity1
         }
-    };
+    ];
 
     private static readonly Location Location1 = new()
     {
@@ -655,20 +656,20 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     };
 
     private static readonly PersonWithLocation[] PersonWithLocation1 =
-    {
+    [
         new()
         {
             name = "Carmen", location = Location1
         }
-    };
+    ];
 
     private static readonly PersonWithLocation[] PersonWithMissingLocation1 =
-    {
+    [
         new()
         {
             name = "Elizabeth"
         }
-    };
+    ];
 
     private static readonly Location Location2 = new()
     {
@@ -676,22 +677,18 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     };
 
     private static readonly PersonWithMultipleLocations[] PersonWithLocations1 =
-    {
+    [
         new()
         {
-            name = "Damien",
-            locations = new List<Location>
-            {
-                Location2, Location1
-            }
+            name = "Damien", locations = [Location2, Location1]
         }
-    };
+    ];
 
     private static readonly PersonWithTwoLocations[] PersonWithTwoLocations1 =
-    {
+    [
         new()
         {
             name = "Henry", first = Location1, second = Location2
         }
-    };
+    ];
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -31,20 +31,25 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_nested_one_level_materializes_single()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        collection.WriteTestDocs(__personWithLocation);
+        collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entitites.Single();
 
         Assert.Equal("Carmen", actual.name);
-        Assert.Equal(__location1.latitude, actual.location.latitude);
-        Assert.Equal(__location1.longitude, actual.location.longitude);
+        Assert.Equal(Location1.latitude, actual.location.latitude);
+        Assert.Equal(Location1.longitude, actual.location.longitude);
     }
 
     [Fact]
     public void OwnedEntity_missing_document_element_does_not_throw()
     {
-        _tempDatabase.CreateTemporaryCollection<Person>("personNoLocation").WriteTestDocs([new Person { name = "Bill" }]);
+        _tempDatabase.CreateTemporaryCollection<Person>("personNoLocation").WriteTestDocs([
+            new Person
+            {
+                name = "Bill"
+            }
+        ]);
 
         var collection = _tempDatabase.MongoDatabase.GetCollection<PersonWithOptionalLocation>("personNoLocation");
         var db = SingleEntityDbContext.Create(collection);
@@ -59,35 +64,35 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_nested_one_level_allows_nested_where()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        collection.WriteTestDocs(__personWithLocation);
+        collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entitites.First(e => e.location.latitude > 0.00m);
 
         Assert.Equal("Carmen", actual.name);
-        Assert.Equal(__location1.latitude, actual.location.latitude);
-        Assert.Equal(__location1.longitude, actual.location.longitude);
+        Assert.Equal(Location1.latitude, actual.location.latitude);
+        Assert.Equal(Location1.longitude, actual.location.longitude);
     }
 
     [Fact]
     public void OwnedEntity_nested_two_levels_allows_nested_where()
     {
         IMongoCollection<PersonWithCity> collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
-        collection.WriteTestDocs(__personWithCity);
+        collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entitites.First(e => e.location.city.name == "San Diego");
 
         Assert.Equal("Carmen", actual.name);
-        Assert.Equal(__location1.latitude, actual.location.latitude);
-        Assert.Equal(__location1.longitude, actual.location.longitude);
+        Assert.Equal(Location1.latitude, actual.location.latitude);
+        Assert.Equal(Location1.longitude, actual.location.longitude);
     }
 
     [Fact]
     public void OwnedEntity_materializes_when_missing_non_required_owned_entity()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        collection.WriteTestDocs(__personWithMissingLocation);
+        collection.WriteTestDocs(PersonWithMissingLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(false); });
 
@@ -102,7 +107,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_throws_when_missing_required_owned_entity()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        collection.WriteTestDocs(__personWithMissingLocation);
+        collection.WriteTestDocs(PersonWithMissingLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(); });
 
@@ -115,7 +120,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_nested_one_level_materializes_many()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        collection.WriteTestDocs(__personWithLocation);
+        collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
         List<PersonWithLocation> actual = db.Entitites.Where(p => p.name != "bob").ToList();
@@ -123,8 +128,8 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         Assert.NotEmpty(actual);
 
         Assert.Equal("Carmen", actual[0].name);
-        Assert.Equal(__location1.latitude, actual[0].location.latitude);
-        Assert.Equal(__location1.longitude, actual[0].location.longitude);
+        Assert.Equal(Location1.latitude, actual[0].location.latitude);
+        Assert.Equal(Location1.longitude, actual[0].location.longitude);
     }
 
     [Fact]
@@ -311,22 +316,22 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_nested_two_levels_materializes_single()
     {
         IMongoCollection<PersonWithCity> collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
-        collection.WriteTestDocs(__personWithCity);
+        collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entitites.Single();
 
         Assert.Equal("Carmen", actual.name);
-        Assert.Equal(__location1.latitude, actual.location.latitude);
-        Assert.Equal(__location1.longitude, actual.location.longitude);
-        Assert.Equal(__city.name, actual.location.city.name);
+        Assert.Equal(Location1.latitude, actual.location.latitude);
+        Assert.Equal(Location1.longitude, actual.location.longitude);
+        Assert.Equal(City1.name, actual.location.city.name);
     }
 
     [Fact]
     public void OwnedEntity_nested_two_levels_materializes_many()
     {
         IMongoCollection<PersonWithCity> collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
-        collection.WriteTestDocs(__personWithCity);
+        collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
         List<PersonWithCity> actual = db.Entitites.Where(p => p.name != "bob").ToList();
@@ -334,9 +339,9 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         Assert.NotEmpty(actual);
 
         Assert.Equal("Carmen", actual[0].name);
-        Assert.Equal(__location1.latitude, actual[0].location.latitude);
-        Assert.Equal(__location1.longitude, actual[0].location.longitude);
-        Assert.Equal(__city.name, actual[0].location.city.name);
+        Assert.Equal(Location1.latitude, actual[0].location.latitude);
+        Assert.Equal(Location1.longitude, actual[0].location.longitude);
+        Assert.Equal(City1.name, actual[0].location.city.name);
     }
 
     [Fact]
@@ -344,7 +349,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         IMongoCollection<PersonWithMultipleLocations> collection =
             _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
-        collection.WriteTestDocs(__personWithLocations);
+        collection.WriteTestDocs(PersonWithLocations1);
         SingleEntityDbContext<PersonWithMultipleLocations> db = SingleEntityDbContext.Create(collection);
 
         List<PersonWithMultipleLocations> actual = db.Entitites.Where(p => p.name != "bob").ToList();
@@ -354,25 +359,41 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         Assert.Equal("Damien", actual[0].name);
         Assert.Equal(2, actual[0].locations.Count);
 
-        Assert.Single(actual[0].locations, s => __location1.latitude == s.latitude && __location1.longitude == s.longitude);
-        Assert.Single(actual[0].locations, s => __location2.latitude == s.latitude && __location2.longitude == s.longitude);
+        Assert.Single(actual[0].locations, s => Location1.latitude == s.latitude && Location1.longitude == s.longitude);
+        Assert.Single(actual[0].locations, s => Location2.latitude == s.latitude && Location2.longitude == s.longitude);
     }
 
     [Fact]
     public void OwnedEntity_with_ienumerable_collection_materializes_many()
     {
-        var expectedLocation = new Location { latitude = 1.01m, longitude = 1.02m };
+        var expectedLocation = new Location
+        {
+            latitude = 1.01m, longitude = 1.02m
+        };
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithIEnumerableLocations>();
         collection.WriteTestDocs(new PersonWithIEnumerableLocations[]
         {
-            new() { _id = ObjectId.GenerateNewId(), name = "IEnumerableRound1", locations = new List<Location>
+            new()
             {
-                expectedLocation
-            }},
-            new() { _id = ObjectId.GenerateNewId(), name = "IEnumerableRound2", locations = new List<Location>
+                _id = ObjectId.GenerateNewId(),
+                name = "IEnumerableRound1",
+                locations = new List<Location>
+                {
+                    expectedLocation
+                }
+            },
+            new()
             {
-                new() { latitude = 1.03m, longitude = 1.04m }
-            }}
+                _id = ObjectId.GenerateNewId(),
+                name = "IEnumerableRound2",
+                locations = new List<Location>
+                {
+                    new()
+                    {
+                        latitude = 1.03m, longitude = 1.04m
+                    }
+                }
+            }
         });
 
         var actual = SingleEntityDbContext.Create(collection).Entitites.ToList();
@@ -392,7 +413,10 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         {
             _id = ObjectId.GenerateNewId(),
             name = "IEnumerableSerialize",
-            locations = new List<Location> { __location1, __location2 }
+            locations = new List<Location>
+            {
+                Location1, Location2
+            }
         };
 
         {
@@ -408,8 +432,8 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
             Assert.NotNull(actual);
             Assert.Equal("IEnumerableSerialize", actual.name);
             Assert.Equal(2, actual.locations.Count());
-            Assert.Equal(__location1, actual.locations.First());
-            Assert.Equal(__location2, actual.locations.Last());
+            Assert.Equal(Location1, actual.locations.First());
+            Assert.Equal(Location2, actual.locations.Last());
         }
     }
 
@@ -423,7 +447,10 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         {
             _id = ObjectId.GenerateNewId(),
             name = "IEnumerableSerialize",
-            locations = EnumerableOnlyWrapper.Wrap(new List<Location> { __location1, __location2 })
+            locations = EnumerableOnlyWrapper.Wrap(new List<Location>
+            {
+                Location1, Location2
+            })
         };
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.Add(entity));
@@ -492,8 +519,8 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_with_two_owned_entities_materializes()
     {
         IMongoCollection<PersonWithTwoLocations> collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
-        var expected = __personWithTwoLocations[0];
-        collection.WriteTestDocs(__personWithTwoLocations);
+        var expected = PersonWithTwoLocations1[0];
+        collection.WriteTestDocs(PersonWithTwoLocations1);
         SingleEntityDbContext<PersonWithTwoLocations> db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entitites.FirstOrDefault();
@@ -512,7 +539,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         IMongoCollection<PersonWithTwoLocations> collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
         PersonWithTwoLocations expected = new()
         {
-            name = "Elizabeth", first = __location2, second = __location1
+            name = "Elizabeth", first = Location2, second = Location1
         };
 
         {
@@ -538,8 +565,8 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_can_have_element_name_set()
     {
         IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
-        var expected = __personWithLocation[0];
-        collection.WriteTestDocs(__personWithLocation);
+        var expected = PersonWithLocation1[0];
+        collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().OwnsOne(p => p.location, r => r.HasElementName("location")); });
 
@@ -604,39 +631,39 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         public Location second { get; set; }
     }
 
-    private static readonly City __city = new()
+    private static readonly City City1 = new()
     {
         name = "San Diego"
     };
 
-    private static readonly LocationWithCity __locationWithCity =
+    private static readonly LocationWithCity LocationWithCity1 =
         new()
         {
-            latitude = 32.715736m, longitude = -117.161087m, city = __city
+            latitude = 32.715736m, longitude = -117.161087m, city = City1
         };
 
-    private static readonly PersonWithCity[] __personWithCity =
+    private static readonly PersonWithCity[] PersonWithCity1 =
     {
         new()
         {
-            name = "Carmen", location = __locationWithCity
+            name = "Carmen", location = LocationWithCity1
         }
     };
 
-    private static readonly Location __location1 = new()
+    private static readonly Location Location1 = new()
     {
         latitude = 32.715736m, longitude = -117.161087m
     };
 
-    private static readonly PersonWithLocation[] __personWithLocation =
+    private static readonly PersonWithLocation[] PersonWithLocation1 =
     {
         new()
         {
-            name = "Carmen", location = __location1
+            name = "Carmen", location = Location1
         }
     };
 
-    private static readonly PersonWithLocation[] __personWithMissingLocation =
+    private static readonly PersonWithLocation[] PersonWithMissingLocation1 =
     {
         new()
         {
@@ -644,28 +671,28 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         }
     };
 
-    private static readonly Location __location2 = new()
+    private static readonly Location Location2 = new()
     {
         latitude = 49.45981m, longitude = -2.53527m
     };
 
-    private static readonly PersonWithMultipleLocations[] __personWithLocations =
+    private static readonly PersonWithMultipleLocations[] PersonWithLocations1 =
     {
         new()
         {
             name = "Damien",
             locations = new List<Location>
             {
-                __location2, __location1
+                Location2, Location1
             }
         }
     };
 
-    private static readonly PersonWithTwoLocations[] __personWithTwoLocations =
+    private static readonly PersonWithTwoLocations[] PersonWithTwoLocations1 =
     {
         new()
         {
-            name = "Henry", first = __location1, second = __location2
+            name = "Henry", first = Location1, second = Location2
         }
     };
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using MongoDB.Bson;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
@@ -30,7 +29,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_nested_one_level_materializes_single()
     {
-        IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
@@ -63,7 +62,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_nested_one_level_allows_nested_where()
     {
-        IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
@@ -77,7 +76,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_nested_two_levels_allows_nested_where()
     {
-        IMongoCollection<PersonWithCity> collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
         collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
@@ -91,7 +90,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_materializes_when_missing_non_required_owned_entity()
     {
-        IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithMissingLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(false); });
@@ -106,7 +105,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_throws_when_missing_required_owned_entity()
     {
-        IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithMissingLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(); });
@@ -119,7 +118,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_nested_one_level_materializes_many()
     {
-        IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
@@ -135,7 +134,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_nested_one_level_creates()
     {
-        IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         var expected =
             new PersonWithLocation
             {
@@ -165,7 +164,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_collection_creates()
     {
-        IMongoCollection<PersonWithMultipleLocations> collection =
+        var collection =
             _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
 
         PersonWithMultipleLocations expected = new()
@@ -315,7 +314,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_nested_two_levels_materializes_single()
     {
-        IMongoCollection<PersonWithCity> collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
         collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
@@ -330,7 +329,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_nested_two_levels_materializes_many()
     {
-        IMongoCollection<PersonWithCity> collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
         collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
@@ -347,7 +346,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_with_collection_materializes_many()
     {
-        IMongoCollection<PersonWithMultipleLocations> collection =
+        var collection =
             _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
         collection.WriteTestDocs(PersonWithLocations1);
         SingleEntityDbContext<PersonWithMultipleLocations> db = SingleEntityDbContext.Create(collection);
@@ -518,7 +517,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_with_two_owned_entities_materializes()
     {
-        IMongoCollection<PersonWithTwoLocations> collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
         var expected = PersonWithTwoLocations1[0];
         collection.WriteTestDocs(PersonWithTwoLocations1);
         SingleEntityDbContext<PersonWithTwoLocations> db = SingleEntityDbContext.Create(collection);
@@ -536,7 +535,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_with_two_owned_entities_creates()
     {
-        IMongoCollection<PersonWithTwoLocations> collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
         PersonWithTwoLocations expected = new()
         {
             name = "Elizabeth", first = Location2, second = Location1
@@ -564,7 +563,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void OwnedEntity_can_have_element_name_set()
     {
-        IMongoCollection<PersonWithLocation> collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         var expected = PersonWithLocation1[0];
         collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SkipTakeOrderingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SkipTakeOrderingTests.cs
@@ -83,7 +83,7 @@ public class SkipTakeOrderingTests
     {
         var results = _db.Planets.OrderBy(o => o.name).ToArray();
 
-        string previousName = "";
+        var previousName = "";
 
         Assert.Equal(8, results.Length);
         Assert.All(results, r =>
@@ -98,7 +98,7 @@ public class SkipTakeOrderingTests
     {
         var results = _db.Planets.OrderByDescending(o => o.name).ToArray();
 
-        string previousName = "zzz";
+        var previousName = "zzz";
 
         Assert.Equal(8, results.Length);
         Assert.All(results, r =>
@@ -113,7 +113,7 @@ public class SkipTakeOrderingTests
     {
         var results = _db.Planets.OrderBy(o => o.orderFromSun).ToArray();
 
-        int previousOrderFromSun = 0;
+        var previousOrderFromSun = 0;
 
         Assert.Equal(8, results.Length);
         Assert.All(results, r =>
@@ -128,7 +128,7 @@ public class SkipTakeOrderingTests
     {
         var results = _db.Planets.OrderByDescending(o => o.orderFromSun).ToArray();
 
-        int previousOrderFromSun = 9999;
+        var previousOrderFromSun = 9999;
 
         Assert.Equal(8, results.Length);
         Assert.All(results, r =>
@@ -146,8 +146,8 @@ public class SkipTakeOrderingTests
         Assert.Equal(8, results.Length);
         Assert.False(results.First().hasRings);
         Assert.True(results.Last().hasRings);
-        bool changed = false;
-        bool previousHasRings = false;
+        var changed = false;
+        var previousHasRings = false;
         Assert.All(results, r =>
         {
             if (r.hasRings != previousHasRings)
@@ -167,8 +167,8 @@ public class SkipTakeOrderingTests
         Assert.Equal(8, results.Length);
         Assert.True(results.First().hasRings);
         Assert.False(results.Last().hasRings);
-        bool changed = false;
-        bool previousHasRings = true;
+        var changed = false;
+        var previousHasRings = true;
         Assert.All(results, r =>
         {
             if (r.hasRings != previousHasRings)
@@ -188,9 +188,9 @@ public class SkipTakeOrderingTests
         Assert.Equal(8, results.Length);
         Assert.False(results.First().hasRings);
         Assert.True(results.Last().hasRings);
-        bool ringsChanged = false;
-        bool previousHasRings = false;
-        string previousName = "";
+        var ringsChanged = false;
+        var previousHasRings = false;
+        var previousName = "";
 
         Assert.All(results, r =>
         {
@@ -215,9 +215,9 @@ public class SkipTakeOrderingTests
         Assert.Equal(8, results.Length);
         Assert.False(results.First().hasRings);
         Assert.True(results.Last().hasRings);
-        bool ringsChanged = false;
-        bool previousHasRings = false;
-        string previousName = "zzzz";
+        var ringsChanged = false;
+        var previousHasRings = false;
+        var previousName = "zzzz";
         Assert.All(results, r =>
         {
             if (r.hasRings != previousHasRings)
@@ -241,9 +241,9 @@ public class SkipTakeOrderingTests
         Assert.Equal(8, results.Length);
         Assert.True(results.First().hasRings);
         Assert.False(results.Last().hasRings);
-        bool ringsChanged = false;
-        bool previousHasRings = true;
-        string previousName = "";
+        var ringsChanged = false;
+        var previousHasRings = true;
+        var previousName = "";
         Assert.All(results, r =>
         {
             if (r.hasRings != previousHasRings)
@@ -267,9 +267,9 @@ public class SkipTakeOrderingTests
         Assert.Equal(8, results.Length);
         Assert.True(results.First().hasRings);
         Assert.False(results.Last().hasRings);
-        bool ringsChanged = false;
-        bool previousHasRings = true;
-        string previousName = "zzzz";
+        var ringsChanged = false;
+        var previousHasRings = true;
+        var previousName = "zzzz";
         Assert.All(results, r =>
         {
             if (r.hasRings != previousHasRings)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
@@ -31,35 +31,35 @@ public class TopScalarTests
     [Fact]
     public void Count_with_no_predicate()
     {
-        int result = _db.Planets.Count();
+        var result = _db.Planets.Count();
         Assert.Equal(8, result);
     }
 
     [Fact]
     public void Count_with_no_predicate_after_where()
     {
-        int result = _db.Planets.Where(p => p.hasRings).Count();
+        var result = _db.Planets.Where(p => p.hasRings).Count();
         Assert.Equal(4, result);
     }
 
     [Fact]
     public void Count_with_predicate()
     {
-        int result = _db.Planets.Count(p => p.hasRings);
+        var result = _db.Planets.Count(p => p.hasRings);
         Assert.Equal(4, result);
     }
 
     [Fact]
     public void Count_with_predicate_after_where()
     {
-        int result = _db.Planets.Where(p => p.orderFromSun > 5).Count(p => p.hasRings);
+        var result = _db.Planets.Where(p => p.orderFromSun > 5).Count(p => p.hasRings);
         Assert.Equal(3, result);
     }
 
     [Fact]
     public async Task CountAsync_with_no_predicate()
     {
-        int result = await _db.Planets.CountAsync();
+        var result = await _db.Planets.CountAsync();
         Assert.Equal(8, result);
     }
 
@@ -67,133 +67,133 @@ public class TopScalarTests
     [Fact]
     public async Task CountAsync_with_no_predicate_after_where()
     {
-        int result = await _db.Planets.Where(p => p.hasRings).CountAsync();
+        var result = await _db.Planets.Where(p => p.hasRings).CountAsync();
         Assert.Equal(4, result);
     }
 
     [Fact]
     public async Task CountAsync_with_predicate()
     {
-        int result = await _db.Planets.CountAsync(p => p.hasRings);
+        var result = await _db.Planets.CountAsync(p => p.hasRings);
         Assert.Equal(4, result);
     }
 
     [Fact]
     public async Task CountAsync_with_predicate_after_where()
     {
-        int result = await _db.Planets.Where(p => p.orderFromSun > 5).CountAsync(p => p.hasRings);
+        var result = await _db.Planets.Where(p => p.orderFromSun > 5).CountAsync(p => p.hasRings);
         Assert.Equal(3, result);
     }
 
     [Fact]
     public void LongCount_with_no_predicate()
     {
-        long result = _db.Planets.LongCount();
+        var result = _db.Planets.LongCount();
         Assert.Equal(8, result);
     }
 
     [Fact]
     public void LongCount_with_no_predicate_after_where()
     {
-        long result = _db.Planets.Where(p => p.hasRings).LongCount();
+        var result = _db.Planets.Where(p => p.hasRings).LongCount();
         Assert.Equal(4, result);
     }
 
     [Fact]
     public void LongCount_with_predicate()
     {
-        long result = _db.Planets.LongCount(p => p.hasRings);
+        var result = _db.Planets.LongCount(p => p.hasRings);
         Assert.Equal(4, result);
     }
 
     [Fact]
     public void LongCount_with_predicate_after_where()
     {
-        long result = _db.Planets.Where(p => p.orderFromSun > 5).LongCount(p => p.hasRings);
+        var result = _db.Planets.Where(p => p.orderFromSun > 5).LongCount(p => p.hasRings);
         Assert.Equal(3, result);
     }
 
     [Fact]
     public async Task LongCountAsync_with_no_predicate()
     {
-        long result = await _db.Planets.LongCountAsync();
+        var result = await _db.Planets.LongCountAsync();
         Assert.Equal(8, result);
     }
 
     [Fact]
     public async Task LongCountAsync_with_no_predicate_after_where()
     {
-        long result = await _db.Planets.Where(p => p.hasRings).LongCountAsync();
+        var result = await _db.Planets.Where(p => p.hasRings).LongCountAsync();
         Assert.Equal(4, result);
     }
 
     [Fact]
     public async Task LongCountAsync_with_predicate()
     {
-        long result = await _db.Planets.LongCountAsync(p => p.hasRings);
+        var result = await _db.Planets.LongCountAsync(p => p.hasRings);
         Assert.Equal(4, result);
     }
 
     [Fact]
     public async Task LongCountAsync_with_predicate_after_where()
     {
-        long result = await _db.Planets.Where(p => p.orderFromSun > 6).LongCountAsync(p => p.hasRings);
+        var result = await _db.Planets.Where(p => p.orderFromSun > 6).LongCountAsync(p => p.hasRings);
         Assert.Equal(2, result);
     }
 
     [Fact]
     public void Any_with_no_predicate()
     {
-        bool result = _db.Planets.Any();
+        var result = _db.Planets.Any();
         Assert.True(result);
     }
 
     [Fact]
     public void Any_with_no_predicate_after_where()
     {
-        bool result = _db.Planets.Where(p => p.orderFromSun < 1).Any();
+        var result = _db.Planets.Where(p => p.orderFromSun < 1).Any();
         Assert.False(result);
     }
 
     [Fact]
     public void Any_with_predicate()
     {
-        bool result = _db.Planets.Any(p => p.hasRings);
+        var result = _db.Planets.Any(p => p.hasRings);
         Assert.True(result);
     }
 
     [Fact]
     public void Any_with_predicate_after_where()
     {
-        bool result = _db.Planets.Where(p => p.orderFromSun < 5).Any(p => p.hasRings);
+        var result = _db.Planets.Where(p => p.orderFromSun < 5).Any(p => p.hasRings);
         Assert.False(result);
     }
 
     [Fact]
     public async Task AnyAsync_with_no_predicate()
     {
-        bool result = await _db.Planets.AnyAsync();
+        var result = await _db.Planets.AnyAsync();
         Assert.True(result);
     }
 
     [Fact]
     public async Task AnyAsync_with_no_predicate_after_where()
     {
-        bool result = await _db.Planets.Where(p => p.orderFromSun < 1).AnyAsync();
+        var result = await _db.Planets.Where(p => p.orderFromSun < 1).AnyAsync();
         Assert.False(result);
     }
 
     [Fact]
     public async Task AnyAsync_with_predicate()
     {
-        bool result = await _db.Planets.AnyAsync(p => p.hasRings);
+        var result = await _db.Planets.AnyAsync(p => p.hasRings);
         Assert.True(result);
     }
 
     [Fact]
     public async Task AnyAsync_with_predicate_after_where()
     {
-        bool result = await _db.Planets.Where(p => p.orderFromSun < 5).AnyAsync(p => p.hasRings);
+        var result = await _db.Planets.Where(p => p.orderFromSun < 5).AnyAsync(p => p.hasRings);
         Assert.False(result);
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
@@ -144,7 +144,7 @@ public class WhereTests
     [Fact]
     public void Where_string_eq_with_param()
     {
-        string prm = "Earth";
+        var prm = "Earth";
         var results = _db.Planets.Where(p => p.name == prm).ToArray();
         Assert.Single(results);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System.Collections;
-
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
 
 public class CollectionSerializationTests : BaseSerializationTests
@@ -274,7 +272,8 @@ public class CollectionSerializationTests : BaseSerializationTests
     public void IEnumerable_exposed_list_round_trips(params int[] expected)
     {
         var collection =
-            TempDatabase.CreateTemporaryCollection<IEnumerableEntity>(nameof(IEnumerable_exposed_list_round_trips) + expected.Length);
+            TempDatabase.CreateTemporaryCollection<IEnumerableEntity>(
+                nameof(IEnumerable_exposed_list_round_trips) + expected.Length);
 
         {
             using var db = SingleEntityDbContext.Create(collection);
@@ -304,7 +303,8 @@ public class CollectionSerializationTests : BaseSerializationTests
     public void Nullable_ienumerable_exposed_list_round_trips(params int[] expected)
     {
         var collection =
-            TempDatabase.CreateTemporaryCollection<NullableIEnumerableEntity>(nameof(Nullable_ienumerable_exposed_list_round_trips) + expected.Length);
+            TempDatabase.CreateTemporaryCollection<NullableIEnumerableEntity>(nameof(Nullable_ienumerable_exposed_list_round_trips)
+                                                                              + expected.Length);
 
         {
             using var db = SingleEntityDbContext.Create(collection);
@@ -336,7 +336,10 @@ public class CollectionSerializationTests : BaseSerializationTests
         using var db = SingleEntityDbContext.Create(collection);
         db.Entitites.Add(new IEnumerableEntity
         {
-            anEnumerable = EnumerableOnlyWrapper.Wrap(new [] { 1, 2, 3 })
+            anEnumerable = EnumerableOnlyWrapper.Wrap(new[]
+            {
+                1, 2, 3
+            })
         });
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.SaveChanges());

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
@@ -198,7 +198,7 @@ public class CollectionSerializationTests : BaseSerializationTests
             using var db = SingleEntityDbContext.Create(collection);
             db.Entitites.Add(new ListEntity
             {
-                aList = new List<int>(expected)
+                aList = [..expected]
             });
             db.SaveChanges();
         }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
@@ -27,7 +27,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
     [Fact]
     public void DateTime_round_trips_as_utc_with_expected_precision()
     {
-        DateTime expected = DateTime.UtcNow;
+        var expected = DateTime.UtcNow;
         var collection = TempDatabase.CreateTemporaryCollection<DateTimeEntity>();
 
         {
@@ -50,7 +50,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
     [Fact]
     public void DateTime_round_trips_as_local()
     {
-        DateTime expected = DateTime.Now;
+        var expected = DateTime.Now;
         var collection = TempDatabase.CreateTemporaryCollection<DateTimeEntity>();
 
         {
@@ -151,7 +151,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
     [Fact]
     public void DateTimeOffset_round_trips()
     {
-        DateTimeOffset expected = DateTimeOffset.Now;
+        var expected = DateTimeOffset.Now;
         var collection = TempDatabase.CreateTemporaryCollection<DateTimeOffsetEntity>();
 
         {
@@ -251,7 +251,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
     [Fact]
     public void TimeSpan_round_trips()
     {
-        TimeSpan expected = TimeSpan.FromTicks(Random.Shared.NextInt64());
+        var expected = TimeSpan.FromTicks(Random.Shared.NextInt64());
         var collection = TempDatabase.CreateTemporaryCollection<TimeSpanEntity>();
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
@@ -28,7 +28,7 @@ public class DecimalSerializationTests : BaseSerializationTests
     [InlineData("0")]
     public void Decimal_round_trips(string expectedString)
     {
-        Decimal expected = Decimal.Parse(expectedString);
+        var expected = Decimal.Parse(expectedString);
         var collection = TempDatabase.CreateTemporaryCollection<DecimalEntity>(nameof(Decimal_round_trips) + expected);
 
         {
@@ -69,7 +69,7 @@ public class DecimalSerializationTests : BaseSerializationTests
     [InlineData(null)]
     public void Nullable_Decimal_round_trips(string expectedString)
     {
-        Decimal? expected = Decimal.TryParse(expectedString, out Decimal parsedDecimal) ? parsedDecimal : null;
+        Decimal? expected = Decimal.TryParse(expectedString, out var parsedDecimal) ? parsedDecimal : null;
 
         var collection =
             TempDatabase.CreateTemporaryCollection<NullableDecimalEntity>(nameof(Nullable_Decimal_round_trips) + expected);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
@@ -30,7 +30,7 @@ public class GuidSerializationTests : BaseSerializationTests
     [InlineData("00000000-0000-0000-0000-000000000000")]
     public void Guid_round_trips(string expectedString)
     {
-        Guid expected = Guid.Parse(expectedString);
+        var expected = Guid.Parse(expectedString);
         var collection = TempDatabase.CreateTemporaryCollection<GuidEntity>(nameof(Guid_round_trips) + expected);
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
@@ -29,7 +29,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
     [InlineData("64a8583aa1ee84d292c009dd")]
     public void ObjectId_round_trips(string expectedString)
     {
-        ObjectId expected = ObjectId.Parse(expectedString);
+        var expected = ObjectId.Parse(expectedString);
         var collection = TempDatabase.CreateTemporaryCollection<ObjectIdEntity>(nameof(ObjectId_round_trips) + expectedString);
 
         {
@@ -112,7 +112,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
     [InlineData("-987654321.01234")]
     public void Decimal128_round_trips(string expectedString)
     {
-        Decimal128 expected = Decimal128.Parse(expectedString);
+        var expected = Decimal128.Parse(expectedString);
         var collection = TempDatabase.CreateTemporaryCollection<Decimal128Entity>(nameof(Decimal128_round_trips) + expectedString);
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
@@ -19,7 +19,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
 
 public class StringSerializationTests : BaseSerializationTests
 {
-    private static long __collectionCounter;
+    private static long CollectionCounter;
 
     public StringSerializationTests(TemporaryDatabaseFixture tempDatabase)
         : base(tempDatabase)
@@ -34,7 +34,7 @@ public class StringSerializationTests : BaseSerializationTests
     [InlineData(null)]
     public void String_round_trips(string? expected)
     {
-        var counter = Interlocked.Increment(ref __collectionCounter);
+        var counter = Interlocked.Increment(ref CollectionCounter);
         IMongoCollection<StringEntity> collection =
             TempDatabase.CreateTemporaryCollection<StringEntity>(nameof(String_round_trips) + counter);
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using MongoDB.Driver;
-
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
 
 public class StringSerializationTests : BaseSerializationTests
@@ -35,7 +33,7 @@ public class StringSerializationTests : BaseSerializationTests
     public void String_round_trips(string? expected)
     {
         var counter = Interlocked.Increment(ref CollectionCounter);
-        IMongoCollection<StringEntity> collection =
+        var collection =
             TempDatabase.CreateTemporaryCollection<StringEntity>(nameof(String_round_trips) + counter);
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
@@ -34,7 +34,7 @@ public class StringSerializationTests : BaseSerializationTests
     [InlineData(null)]
     public void String_round_trips(string? expected)
     {
-        long counter = Interlocked.Increment(ref __collectionCounter);
+        var counter = Interlocked.Increment(ref __collectionCounter);
         IMongoCollection<StringEntity> collection =
             TempDatabase.CreateTemporaryCollection<StringEntity>(nameof(String_round_trips) + counter);
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
@@ -73,14 +73,17 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         IMongoCollection<SimpleEntity> collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
         SingleEntityDbContext<SimpleEntity> dbContext = SingleEntityDbContext.Create(collection);
 
-        SimpleEntity expected = new() {_id = ObjectId.GenerateNewId(), name = "Generated"};
+        SimpleEntity expected = new()
+        {
+            _id = ObjectId.GenerateNewId(), name = "Generated"
+        };
         dbContext.Entitites.Add(expected);
         dbContext.SaveChanges();
 
         Assert.Same(expected, dbContext.Entitites.First());
 
         // Check with C# Driver for second opinion
-        SimpleEntity? directFound = collection.Find(f => f._id == expected._id).Single();
+        var directFound = collection.Find(f => f._id == expected._id).Single();
         Assert.Equal(expected._id, directFound._id);
         Assert.Equal(expected.name, directFound.name);
     }
@@ -91,14 +94,17 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         IMongoCollection<SimpleEntity> collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
         SingleEntityDbContext<SimpleEntity> dbContext = SingleEntityDbContext.Create(collection);
 
-        SimpleEntity expected = new() {name = "Not Set"};
+        SimpleEntity expected = new()
+        {
+            name = "Not Set"
+        };
         dbContext.Entitites.Add(expected);
         dbContext.SaveChanges();
 
         Assert.Same(expected, dbContext.Entitites.First());
 
         // Check with C# Driver for second opinion
-        SimpleEntity? directFound = collection.Find(f => f._id == expected._id).Single();
+        var directFound = collection.Find(f => f._id == expected._id).Single();
         Assert.NotEqual(ObjectId.Empty, directFound._id);
         Assert.NotEqual(default, directFound._id);
         Assert.Equal(expected._id, directFound._id);
@@ -111,14 +117,17 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         IMongoCollection<SimpleEntity> collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
         SingleEntityDbContext<SimpleEntity> dbContext = SingleEntityDbContext.Create(collection);
 
-        SimpleEntity expected = new() {_id = ObjectId.Empty, name = "Empty"};
+        SimpleEntity expected = new()
+        {
+            _id = ObjectId.Empty, name = "Empty"
+        };
         dbContext.Entitites.Add(expected);
         dbContext.SaveChanges();
 
         Assert.Same(expected, dbContext.Entitites.First());
 
         // Check with C# Driver for second opinion
-        SimpleEntity? directFound = collection.Find(f => f._id == expected._id).Single();
+        var directFound = collection.Find(f => f._id == expected._id).Single();
         Assert.NotEqual(ObjectId.Empty, directFound._id);
         Assert.NotEqual(default, directFound._id);
         Assert.Equal(expected._id, directFound._id);
@@ -150,7 +159,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<NumericTypesEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            NumericTypesEntity foundEntity = newDbContext.Entitites.Single();
+            var foundEntity = newDbContext.Entitites.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aDecimal, foundEntity.aDecimal);
             Assert.Equal(expected.aSingle, foundEntity.aSingle);
@@ -184,7 +193,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<OtherClrTypeEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            OtherClrTypeEntity foundEntity = newDbContext.Entitites.Single();
+            var foundEntity = newDbContext.Entitites.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aString, foundEntity.aString);
             Assert.Equal(expected.aChar, foundEntity.aChar);
@@ -211,7 +220,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<MongoSpecificTypeEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            MongoSpecificTypeEntity foundEntity = newDbContext.Entitites.Single();
+            var foundEntity = newDbContext.Entitites.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aDecimal128, foundEntity.aDecimal128);
         }
@@ -224,15 +233,33 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue0)]
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue1)]
     [InlineData(typeof(int[]), null)]
-    [InlineData(typeof(int[]), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(int[]), new[]
+    {
+        -5, 0, 128, 10
+    })]
     [InlineData(typeof(IList<int>), null)]
-    [InlineData(typeof(IList<int>), new[] {-5, 0, 128, 10})]
-    [InlineData(typeof(IReadOnlyList<int>), new[] {-5, 0, 128, 10})]
-    [InlineData(typeof(List<int>), new[] {-5, 0, 128, 10})]
+    [InlineData(typeof(IList<int>), new[]
+    {
+        -5, 0, 128, 10
+    })]
+    [InlineData(typeof(IReadOnlyList<int>), new[]
+    {
+        -5, 0, 128, 10
+    })]
+    [InlineData(typeof(List<int>), new[]
+    {
+        -5, 0, 128, 10
+    })]
     [InlineData(typeof(string[]), null)]
-    [InlineData(typeof(string[]), new[] {"one", "two"})]
+    [InlineData(typeof(string[]), new[]
+    {
+        "one", "two"
+    })]
     [InlineData(typeof(IList<string>), null)]
-    [InlineData(typeof(List<string>), new[] {"one", "two"})]
+    [InlineData(typeof(List<string>), new[]
+    {
+        "one", "two"
+    })]
     [InlineData(typeof(Collection<int>), null)]
     [InlineData(typeof(ObservableCollection<int>), null)]
     public void Entity_add_tests(Type valueType, object? value)
@@ -260,7 +287,10 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new Entity<TValue> {_id = ObjectId.GenerateNewId(), Value = value});
+            dbContext.Entitites.Add(new Entity<TValue>
+            {
+                _id = ObjectId.GenerateNewId(), Value = value
+            });
             dbContext.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
@@ -23,7 +23,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 [XUnitCollection("UpdateTests")]
 public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 {
-    private static readonly Random __random = new();
+    private static readonly Random Random = new();
     private readonly TemporaryDatabaseFixture _tempDatabase;
 
     public AddEntityTests(TemporaryDatabaseFixture tempDatabase) => _tempDatabase = tempDatabase;
@@ -141,14 +141,14 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         NumericTypesEntity expected = new()
         {
-            _id = __random.Next(),
-            aDecimal = __random.NextDecimal(),
-            aSingle = __random.NextSingle(),
-            aDouble = __random.NextDouble() * double.MaxValue,
-            aByte = __random.NextByte(),
-            anInt16 = __random.NextInt16(),
-            anInt32 = __random.Next(),
-            anInt64 = __random.NextInt64()
+            _id = Random.Next(),
+            aDecimal = Random.NextDecimal(),
+            aSingle = Random.NextSingle(),
+            aDouble = Random.NextDouble() * double.MaxValue,
+            aByte = Random.NextByte(),
+            anInt16 = Random.NextInt16(),
+            anInt32 = Random.Next(),
+            anInt64 = Random.NextInt64()
         };
 
         {
@@ -209,7 +209,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         MongoSpecificTypeEntity expected = new()
         {
-            _id = ObjectId.GenerateNewId(), aDecimal128 = new Decimal128(__random.NextDecimal())
+            _id = ObjectId.GenerateNewId(), aDecimal128 = new Decimal128(Random.NextDecimal())
         };
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/ContextTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/ContextTests.cs
@@ -62,7 +62,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
         db.Entitites.AddRange(items);
         db.SaveChanges();
 
-        for (int i = 0; i < updateCount; i++)
+        for (var i = 0; i < updateCount; i++)
             items[i].name = "Updated " + i;
 
         Assert.Equal(updateCount, db.SaveChanges());
@@ -82,7 +82,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
         db.Entitites.AddRange(items);
         await db.SaveChangesAsync();
 
-        for (int i = 0; i < updateCount; i++)
+        for (var i = 0; i < updateCount; i++)
             items[i].name = "Updated " + i;
 
         Assert.Equal(updateCount, await db.SaveChangesAsync());

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
@@ -35,7 +35,10 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {Id = 1, Name = "John"};
+            var person = new PersonWithCity
+            {
+                Id = 1, Name = "John"
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -59,7 +62,15 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
+            var person = new PersonWithCity
+            {
+                Id = 1,
+                Name = "John",
+                City = new City
+                {
+                    Id = 1, Name = "New York"
+                }
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -83,7 +94,15 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
+            var person = new PersonWithCity
+            {
+                Id = 1,
+                Name = "John",
+                City = new City
+                {
+                    Id = 1, Name = "New York"
+                }
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -110,12 +129,23 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
+            var person = new PersonWithCity
+            {
+                Id = 1,
+                Name = "John",
+                City = new City
+                {
+                    Id = 1, Name = "New York"
+                }
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
 
-            person.City = new City {Id = 2, Name = "Washington"};
+            person.City = new City
+            {
+                Id = 2, Name = "Washington"
+            };
             db.SaveChanges();
         }
 
@@ -137,7 +167,15 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCity {Id = 1, Name = "John", City = new City {Id = 1, Name = "New York"}};
+            var person = new PersonWithCity
+            {
+                Id = 1,
+                Name = "John",
+                City = new City
+                {
+                    Id = 1, Name = "New York"
+                }
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -164,7 +202,10 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var person = new PersonWithCities {Id = 1, Name = "John"};
+            var person = new PersonWithCities
+            {
+                Id = 1, Name = "John"
+            };
 
             db.Entitites.Add(person);
             db.SaveChanges();
@@ -192,7 +233,17 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
             {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+                Cities =
+                [
+                    new City
+                    {
+                        Id = 1, Name = "New York"
+                    },
+                    new City
+                    {
+                        Id = 2, Name = "Washington"
+                    }
+                ]
             };
 
             db.Entitites.Add(person);
@@ -223,7 +274,17 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
             {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+                Cities =
+                [
+                    new City
+                    {
+                        Id = 1, Name = "New York"
+                    },
+                    new City
+                    {
+                        Id = 2, Name = "Washington"
+                    }
+                ]
             };
 
 
@@ -256,13 +317,29 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
             {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+                Cities =
+                [
+                    new City
+                    {
+                        Id = 1, Name = "New York"
+                    },
+                    new City
+                    {
+                        Id = 2, Name = "Washington"
+                    }
+                ]
             };
 
             db.Entitites.Add(person);
             db.SaveChanges();
 
-            person.Cities = person.Cities.Concat(new List<City> {new City {Id = 3, Name = "Denver"}}).ToList();
+            person.Cities = person.Cities.Concat(new List<City>
+            {
+                new City
+                {
+                    Id = 3, Name = "Denver"
+                }
+            }).ToList();
             db.SaveChanges();
         }
 
@@ -290,7 +367,17 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
             {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+                Cities =
+                [
+                    new City
+                    {
+                        Id = 1, Name = "New York"
+                    },
+                    new City
+                    {
+                        Id = 2, Name = "Washington"
+                    }
+                ]
             };
 
             db.Entitites.Add(person);
@@ -322,7 +409,17 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
             {
                 Id = 1,
                 Name = "John",
-                Cities = new List<City> {new City {Id = 1, Name = "New York"}, new City {Id = 2, Name = "Washington"}}
+                Cities =
+                [
+                    new City
+                    {
+                        Id = 1, Name = "New York"
+                    },
+                    new City
+                    {
+                        Id = 2, Name = "Washington"
+                    }
+                ]
             };
 
             db.Entitites.Add(person);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
@@ -52,7 +52,10 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void Update_simple_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
-        var entity = new SimpleEntity {_id = ObjectId.GenerateNewId(), name = "Before"};
+        var entity = new SimpleEntity
+        {
+            _id = ObjectId.GenerateNewId(), name = "Before"
+        };
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
@@ -108,7 +111,7 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void Entity_update_tests(Type valueType, object initialValue, object updatedValue)
     {
         var methodInfo = this.GetType().GetMethod(nameof(EntityAddTestImpl), BindingFlags.Instance | BindingFlags.NonPublic);
-        methodInfo.MakeGenericMethod(valueType).Invoke(this, new[] {initialValue, updatedValue});
+        methodInfo.MakeGenericMethod(valueType).Invoke(this, [initialValue, updatedValue]);
     }
 
     private enum TestEnum
@@ -124,7 +127,10 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            var entity = new Entity<TValue> {_id = ObjectId.GenerateNewId(), Value = initialValue};
+            var entity = new Entity<TValue>
+            {
+                _id = ObjectId.GenerateNewId(), Value = initialValue
+            };
             dbContext.Entitites.Add(entity);
             dbContext.SaveChanges();
             entity.Value = updatedValue;

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SampleGuidesFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SampleGuidesFixture.cs
@@ -38,7 +38,7 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
     }
 
     private static readonly Planet[] PlanetData =
-    {
+    [
         new()
         {
             _id = ObjectId.Parse("621ff30d2a3e781873fcb65c"),
@@ -53,10 +53,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Venus",
             orderFromSun = 2,
             hasRings = false,
-            mainAtmosphere = new[]
-            {
+            mainAtmosphere =
+            [
                 "CO2", "N"
-            }
+            ]
         },
         new()
         {
@@ -64,10 +64,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Earth",
             orderFromSun = 3,
             hasRings = false,
-            mainAtmosphere = new[]
-            {
+            mainAtmosphere =
+            [
                 "N", "O2", "Ar"
-            }
+            ]
         },
         new()
         {
@@ -75,10 +75,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Mars",
             orderFromSun = 4,
             hasRings = false,
-            mainAtmosphere = new[]
-            {
+            mainAtmosphere =
+            [
                 "CO2", "Ar", "N"
-            }
+            ]
         },
         new()
         {
@@ -86,10 +86,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Jupiter",
             orderFromSun = 5,
             hasRings = true,
-            mainAtmosphere = new[]
-            {
+            mainAtmosphere =
+            [
                 "H2", "He", "CH4"
-            }
+            ]
         },
         new()
         {
@@ -97,10 +97,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Saturn",
             orderFromSun = 6,
             hasRings = true,
-            mainAtmosphere = new[]
-            {
+            mainAtmosphere =
+            [
                 "H2", "He", "CH4"
-            }
+            ]
         },
         new()
         {
@@ -108,10 +108,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Uranus",
             orderFromSun = 7,
             hasRings = true,
-            mainAtmosphere = new[]
-            {
+            mainAtmosphere =
+            [
                 "H2", "He", "CH4"
-            }
+            ]
         },
         new()
         {
@@ -119,12 +119,12 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Neptune",
             orderFromSun = 8,
             hasRings = true,
-            mainAtmosphere = new[]
-            {
+            mainAtmosphere =
+            [
                 "H2", "He", "CH4"
-            }
+            ]
         }
-    };
+    ];
 
     class InternalMoon
     {
@@ -146,7 +146,7 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
     }
 
     private static readonly InternalMoon[] MoonData =
-    {
+    [
         new()
         {
             _id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb65f"), "I"), name = "Triton", yearOfDiscovery = 1846
@@ -167,5 +167,5 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
         {
             _id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb663"), "VI"), name = "Titan", yearOfDiscovery = 1655
         }
-    };
+    ];
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SampleGuidesFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SampleGuidesFixture.cs
@@ -32,12 +32,12 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
     public SampleGuidesFixture()
     {
         MongoDatabase.GetCollection<Planet>("planets")
-            .BulkWrite(__planetData.Select(p => new InsertOneModel<Planet>(p)));
+            .BulkWrite(PlanetData.Select(p => new InsertOneModel<Planet>(p)));
         MongoDatabase.GetCollection<InternalMoon>("moons")
-            .BulkWrite(__moonData.Select(m => new InsertOneModel<InternalMoon>(m)));
+            .BulkWrite(MoonData.Select(m => new InsertOneModel<InternalMoon>(m)));
     }
 
-    private static readonly Planet[] __planetData =
+    private static readonly Planet[] PlanetData =
     {
         new()
         {
@@ -53,7 +53,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Venus",
             orderFromSun = 2,
             hasRings = false,
-            mainAtmosphere = new[] {"CO2", "N"}
+            mainAtmosphere = new[]
+            {
+                "CO2", "N"
+            }
         },
         new()
         {
@@ -61,7 +64,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Earth",
             orderFromSun = 3,
             hasRings = false,
-            mainAtmosphere = new[] {"N", "O2", "Ar"}
+            mainAtmosphere = new[]
+            {
+                "N", "O2", "Ar"
+            }
         },
         new()
         {
@@ -69,7 +75,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Mars",
             orderFromSun = 4,
             hasRings = false,
-            mainAtmosphere = new[] {"CO2", "Ar", "N"}
+            mainAtmosphere = new[]
+            {
+                "CO2", "Ar", "N"
+            }
         },
         new()
         {
@@ -77,7 +86,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Jupiter",
             orderFromSun = 5,
             hasRings = true,
-            mainAtmosphere = new[] {"H2", "He", "CH4"}
+            mainAtmosphere = new[]
+            {
+                "H2", "He", "CH4"
+            }
         },
         new()
         {
@@ -85,7 +97,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Saturn",
             orderFromSun = 6,
             hasRings = true,
-            mainAtmosphere = new[] {"H2", "He", "CH4"}
+            mainAtmosphere = new[]
+            {
+                "H2", "He", "CH4"
+            }
         },
         new()
         {
@@ -93,7 +108,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Uranus",
             orderFromSun = 7,
             hasRings = true,
-            mainAtmosphere = new[] {"H2", "He", "CH4"}
+            mainAtmosphere = new[]
+            {
+                "H2", "He", "CH4"
+            }
         },
         new()
         {
@@ -101,7 +119,10 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
             name = "Neptune",
             orderFromSun = 8,
             hasRings = true,
-            mainAtmosphere = new[] {"H2", "He", "CH4"}
+            mainAtmosphere = new[]
+            {
+                "H2", "He", "CH4"
+            }
         }
     };
 
@@ -124,12 +145,27 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
         }
     }
 
-    private static readonly InternalMoon[] __moonData =
+    private static readonly InternalMoon[] MoonData =
     {
-        new() {_id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb65f"), "I"), name = "Triton", yearOfDiscovery = 1846},
-        new() {_id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb65f"), "II"), name = "Nereid", yearOfDiscovery = 1949},
-        new() {_id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb661"), "I"), name = "The Moon", yearOfDiscovery = null},
-        new() {_id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb663"), "I"), name = "Mimas", yearOfDiscovery = 1789},
-        new() {_id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb663"), "VI"), name = "Titan", yearOfDiscovery = 1655 }
+        new()
+        {
+            _id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb65f"), "I"), name = "Triton", yearOfDiscovery = 1846
+        },
+        new()
+        {
+            _id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb65f"), "II"), name = "Nereid", yearOfDiscovery = 1949
+        },
+        new()
+        {
+            _id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb661"), "I"), name = "The Moon", yearOfDiscovery = null
+        },
+        new()
+        {
+            _id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb663"), "I"), name = "Mimas", yearOfDiscovery = 1789
+        },
+        new()
+        {
+            _id = new InternalMoonKey(ObjectId.Parse("621ff30d2a3e781873fcb663"), "VI"), name = "Titan", yearOfDiscovery = 1655
+        }
     };
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SingleEntityDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SingleEntityDbContext.cs
@@ -1,17 +1,17 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
@@ -24,12 +24,13 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
 
 internal static class SingleEntityDbContext
 {
-    private static readonly ConcurrentDictionary<object, DbContextOptions> __collectionOptionsCache = new();
+    private static readonly ConcurrentDictionary<object, DbContextOptions> CollectionOptionsCache = new();
 
-    private static DbContextOptions<SingleEntityDbContext<T2>> GetOrCreateOptionsBuilder<T1, T2>(IMongoCollection<T1> collection) where T1:class where T2:class
+    private static DbContextOptions<SingleEntityDbContext<T2>> GetOrCreateOptionsBuilder<T1, T2>(IMongoCollection<T1> collection)
+        where T1 : class where T2 : class
     {
-        if (__collectionOptionsCache.TryGetValue(collection, out var existingOptions))
-            return (DbContextOptions<SingleEntityDbContext<T2>>) existingOptions;
+        if (CollectionOptionsCache.TryGetValue(collection, out var existingOptions))
+            return (DbContextOptions<SingleEntityDbContext<T2>>)existingOptions;
 
         var newOptions = new DbContextOptionsBuilder<SingleEntityDbContext<T2>>()
             .UseMongoDB(collection.Database.Client, collection.Database.DatabaseNamespace.DatabaseName)
@@ -37,27 +38,29 @@ internal static class SingleEntityDbContext
             .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
             .Options;
 
-        __collectionOptionsCache.TryAdd(collection, newOptions);
+        CollectionOptionsCache.TryAdd(collection, newOptions);
 
         return newOptions;
     }
 
-    public static SingleEntityDbContext<T> Create<T>(IMongoCollection<T> collection, Action<ModelBuilder>? modelBuilderAction = null) where T:class =>
-        new (GetOrCreateOptionsBuilder<T, T>(collection), collection.CollectionNamespace.CollectionName, modelBuilderAction);
+    public static SingleEntityDbContext<T> Create<T>(IMongoCollection<T> collection,
+        Action<ModelBuilder>? modelBuilderAction = null) where T : class =>
+        new(GetOrCreateOptionsBuilder<T, T>(collection), collection.CollectionNamespace.CollectionName, modelBuilderAction);
 
-    public static SingleEntityDbContext<T2> Create<T1, T2>(IMongoCollection<T1> collection, Action<ModelBuilder>? modelBuilderAction = null) where T1:class where T2:class
-        => new (GetOrCreateOptionsBuilder<T1, T2>(collection), collection.CollectionNamespace.CollectionName, modelBuilderAction);
+    public static SingleEntityDbContext<T2> Create<T1, T2>(IMongoCollection<T1> collection,
+        Action<ModelBuilder>? modelBuilderAction = null) where T1 : class where T2 : class
+        => new(GetOrCreateOptionsBuilder<T1, T2>(collection), collection.CollectionNamespace.CollectionName, modelBuilderAction);
 
     private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
     {
-        private static int __count;
+        private static int Count;
 
         public object Create(DbContext context, bool designTime)
-            => Interlocked.Increment(ref __count);
+            => Interlocked.Increment(ref Count);
     }
 }
 
-internal class SingleEntityDbContext<T> : DbContext where T:class
+internal class SingleEntityDbContext<T> : DbContext where T : class
 {
     private readonly string _collectionName;
     private readonly Action<ModelBuilder>? _modelBuilderAction;

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
@@ -23,15 +23,15 @@ public class TemporaryDatabaseFixture : IDisposable
 {
     public const string TestDatabasePrefix = "EFCoreTest-";
 
-    private static readonly string __timeStamp = DateTime.Now.ToString("s").Replace(':', '-');
-    private static int __count;
+    private static readonly string TimeStamp = DateTime.Now.ToString("s").Replace(':', '-');
+    private static int Count;
 
     private readonly IMongoClient _mongoClient;
 
     public TemporaryDatabaseFixture()
     {
         _mongoClient = TestServer.GetClient();
-        MongoDatabase = _mongoClient.GetDatabase($"{TestDatabasePrefix}{__timeStamp}-{Interlocked.Increment(ref __count)}");
+        MongoDatabase = _mongoClient.GetDatabase($"{TestDatabasePrefix}{TimeStamp}-{Interlocked.Increment(ref Count)}");
     }
 
     public IMongoDatabase MongoDatabase { get; }
@@ -68,7 +68,8 @@ public class TemporaryDatabaseFixture : IDisposable
     {
         if (name == ".ctor")
             name = GetLastConstructorTypeNameFromStack()
-                   ?? throw new InvalidOperationException("Test was unable to determine a suitable collection name, please pass one to CreateTemporaryCollection");
+                   ?? throw new InvalidOperationException(
+                       "Test was unable to determine a suitable collection name, please pass one to CreateTemporaryCollection");
 
         MongoDatabase.CreateCollection(name);
         return MongoDatabase.GetCollection<T>(name);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestServer.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestServer.cs
@@ -1,17 +1,17 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using MongoDB.Driver;
 
@@ -21,9 +21,13 @@ internal static class TestServer
 {
     private const string MongoServer = "localhost";
 
-    private static readonly MongoClientSettings __mongoClientSettings = new() {Server = MongoServerAddress.Parse(MongoServer)};
-    private static readonly MongoClient __mongoClient = new(__mongoClientSettings);
+    private static readonly MongoClientSettings MongoClientSettings = new()
+    {
+        Server = MongoServerAddress.Parse(MongoServer)
+    };
+
+    private static readonly MongoClient MongoClient = new(MongoClientSettings);
 
     public static IMongoClient GetClient()
-        => __mongoClient;
+        => MongoClient;
 }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
@@ -90,7 +90,7 @@ public static class MongoDbContextOptionsExtensionsTest
                 "db");
 
         var extension = optionsBuilder.Options.FindExtension<MongoOptionsExtension>();
-        string? logFragment = extension?.Info.LogFragment;
+        var logFragment = extension?.Info.LogFragment;
 
         Assert.DoesNotContain("NotActuallyA", logFragment);
         Assert.Contains("myDbUsr:redacted@", logFragment);

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/NamingHelperMethodTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/NamingHelperMethodTests.cs
@@ -30,7 +30,7 @@ public static class NamingHelperMethodTests
     [InlineData("test-THIS-Out", "testThisOut")]
     public static void ToCamelCase_finds_word_boundaries_and_camel_cases_words(string toConvert, string expected)
     {
-        string actual = toConvert.ToCamelCase(CultureInfo.InvariantCulture);
+        var actual = toConvert.ToCamelCase(CultureInfo.InvariantCulture);
         Assert.Equal(expected, actual);
     }
 
@@ -45,7 +45,7 @@ public static class NamingHelperMethodTests
     [InlineData("test-THIS-Out", "TestThisOut")]
     public static void ToTitleCase_finds_word_boundaries_and_title_cases_words(string toConvert, string expected)
     {
-        string actual = toConvert.ToTitleCase(CultureInfo.InvariantCulture);
+        var actual = toConvert.ToTitleCase(CultureInfo.InvariantCulture);
         Assert.Equal(expected, actual);
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/TestUtilities/SingleEntityDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/TestUtilities/SingleEntityDbContext.cs
@@ -33,10 +33,10 @@ internal static class SingleEntityDbContext
 
     private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
     {
-        private static int __count;
+        private static int Count;
 
         public object Create(DbContext context, bool designTime)
-            => Interlocked.Increment(ref __count);
+            => Interlocked.Increment(ref Count);
     }
 }
 

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/MongoValueGeneratorSelectorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/MongoValueGeneratorSelectorTests.cs
@@ -32,7 +32,7 @@ public class MongoValueGeneratorSelectorTests
         builder.Entity<RootEntity>();
 
         builder.FinalizeModel();
-        IModel model = (IModel)builder.Model;
+        var model = (IModel)builder.Model;
         var serviceProvider = instance.CreateServiceProvider();
         _valueGeneratorSelector = (IValueGeneratorSelector)serviceProvider.GetService(typeof(IValueGeneratorSelector))!;
         _entityType = model.FindEntityType(typeof(EntityWithDifferentTypes))!;

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/ObjectIdValueGeneratorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/ObjectIdValueGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2024-present MongoDB Inc.
+﻿/* Copyright 2023-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/ObjectIdValueGeneratorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/ObjectIdValueGeneratorTests.cs
@@ -34,7 +34,7 @@ public class ObjectIdValueGeneratorTests
         var generator = new ObjectIdValueGenerator();
         var values = new HashSet<ObjectId>(loops);
 
-        for (int i = 0; i < loops; i++)
+        for (var i = 0; i < loops; i++)
             values.Add(generator.Next(null!));
 
         Assert.Equal(loops, values.Count);

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/OwnedEntityIndexValueGeneratorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/ValueGeneration/OwnedEntityIndexValueGeneratorTests.cs
@@ -26,7 +26,7 @@ public class OwnedEntityIndexValueGeneratorTests
         var generator = new OwnedEntityIndexValueGenerator();
         var values = new HashSet<int>(loops);
 
-        for (int i = 0; i < loops; i++)
+        for (var i = 0; i < loops; i++)
             values.Add(generator.Next(null!));
 
         Assert.Equal(loops, values.Count);


### PR DESCRIPTION
The smallest code/style format I could manage and be happy with broken out one type per commit for easy review. Almost all of these were automatic except the first (comments only) and fourth.

1. Corrects 3 files copyright notices from 2024 to 2023 for project-wide standard header (manual)
2. Uses "var" instead of declared type and updates .editorconfig to enforce  (auto)
3. Removed some unused usings (auto)
4. Switch from using deprecated DeclaredEntityType (manual)
5. Standardize on the EF style static naming (auto)
6. A few more vars (auto)
7. Use the collection initializer syntax (auto)
8. Switch back to using compiled regex we dropped previously to support EF6 (auto)
9. Null check pattern (auto)
10. Correct a variable name (auto)