### PR TITLE
Fix Entities typo on SingleEntityDbContext used in tests

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
@@ -119,7 +119,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aGuid);
@@ -137,7 +137,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aString);
@@ -155,7 +155,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.anInt16);
@@ -172,7 +172,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(0, actual.anInt16);
@@ -190,7 +190,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.anInt16);
@@ -208,7 +208,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.anInt32);
@@ -225,7 +225,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(0, actual.anInt32);
@@ -243,7 +243,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.anInt32);
@@ -261,7 +261,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.anInt64);
@@ -278,7 +278,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(0, actual.anInt64);
@@ -296,7 +296,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.anInt64);
@@ -314,7 +314,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aByte);
@@ -332,7 +332,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aChar);
@@ -353,7 +353,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aDecimal);
@@ -370,7 +370,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(0, actual.aDecimal);
@@ -391,7 +391,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aDecimal);
@@ -409,7 +409,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aSingle);
@@ -426,7 +426,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(0, actual.aSingle);
@@ -444,7 +444,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aSingle);
@@ -462,7 +462,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aDouble);
@@ -479,7 +479,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(0, actual.aDouble);
@@ -497,7 +497,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aDouble);
@@ -513,7 +513,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Empty(actual.aList);
@@ -533,10 +533,10 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         };
 
         var db = SingleEntityDbContext.Create(collection);
-        db.Entitites.Add(item);
+        db.Entities.Add(item);
         db.SaveChanges();
 
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aList);
     }
@@ -551,7 +551,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Empty(actual.aList);
@@ -571,10 +571,10 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         };
 
         var db = SingleEntityDbContext.Create(collection);
-        db.Entitites.Add(item);
+        db.Entities.Add(item);
         db.SaveChanges();
 
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
         Assert.NotNull(actual);
         Assert.Equal(expected, actual.aList);
     }
@@ -678,7 +678,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var db = SingleEntityDbContext.Create(collection);
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(value, actual.Value);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
@@ -55,7 +55,7 @@ public class DiscriminatorTests(TemporaryDatabaseFixture tempDatabase)
             mb.Entity<Vehicle>().HasDiscriminator(v => v.VehicleType);
         });
 
-        var ex = Assert.Throws<NotSupportedException>(() => db.Entitites.FirstOrDefault());
+        var ex = Assert.Throws<NotSupportedException>(() => db.Entities.FirstOrDefault());
         Assert.Contains(nameof(Vehicle), ex.Message);
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ElementNameTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ElementNameTests.cs
@@ -73,7 +73,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
-            dbContext.Entitites.Add(new RenamedKeyElement {PrimaryKey = id, Name = expectedName});
+            dbContext.Entities.Add(new RenamedKeyElement {PrimaryKey = id, Name = expectedName});
             dbContext.SaveChanges();
         }
 
@@ -87,7 +87,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
         {
             // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
-            var found = dbContext.Entitites.Single(f => f.PrimaryKey == id);
+            var found = dbContext.Entities.Single(f => f.PrimaryKey == id);
             Assert.Equal(expectedName, found.Name);
         }
     }
@@ -109,7 +109,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
-            dbContext.Entitites.Add(
+            dbContext.Entities.Add(
                 new RenamedNonKeyElements {_id = id, FirstName = expectedFirstName, LastName = expectedLastName});
             dbContext.SaveChanges();
         }
@@ -125,7 +125,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
         {
             // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
-            var found = dbContext.Entitites.Single(f => f._id == id);
+            var found = dbContext.Entities.Single(f => f._id == id);
             Assert.Equal(expectedFirstName, found.FirstName);
             Assert.Equal(expectedLastName, found.LastName);
         }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -50,7 +50,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<IdIsObjectId>();
         var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expectedId, found._id);
     }
 
@@ -64,7 +64,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<IdIsObjectId>();
         var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
 
-        var found = db.Entitites.First(e => e._id == expectedId);
+        var found = db.Entities.First(e => e._id == expectedId);
         Assert.Equal(expectedId, found._id);
     }
 
@@ -75,7 +75,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
 
         var original = new IdIsObjectId();
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<IdIsString>().AsQueryable().First();
@@ -97,7 +97,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<IdIsString>();
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expected._id.ToString(), found._id);
     }
 
@@ -110,7 +110,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<IdIsString>();
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
 
-        var found = db.Entitites.First(e => e._id == expected._id.ToString());
+        var found = db.Entities.First(e => e._id == expected._id.ToString());
         Assert.Equal(expected._id.ToString(), found._id);
     }
 
@@ -121,7 +121,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
 
         var original = new IdIsString { _id = ObjectId.GenerateNewId().ToString() };
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<IdIsObjectId>().AsQueryable().First();
@@ -156,7 +156,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<ActiveIsBool>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
         Assert.Equal(active, found.active);
     }
@@ -173,7 +173,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<ActiveIsBool>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
 
-        var found = db.Entitites.First(e => e.active == active);
+        var found = db.Entities.First(e => e.active == active);
         Assert.Equal(expected._id, found._id);
         Assert.Equal(active, found.active);
     }
@@ -187,7 +187,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
 
         var original = new ActiveIsBool { active = active };
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<ActiveIsString>(collection.CollectionNamespace.CollectionName).AsQueryable().First();
@@ -224,7 +224,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
         Assert.Equal(days, found.days);
     }
@@ -242,7 +242,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
 
-        var found = db.Entitites.First(e => e.days == days);
+        var found = db.Entities.First(e => e.days == days);
         Assert.Equal(expected._id, found._id);
         Assert.Equal(days, found.days);
     }
@@ -257,7 +257,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
 
         var original = new DaysIsInt { days = days };
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<DaysIsString>(collection.CollectionNamespace.CollectionName).AsQueryable().First();
@@ -289,7 +289,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<DaysIsTimeSpan>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
         Assert.Equal(days, found.days.TotalDays);
     }
@@ -307,7 +307,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
 
-        var found = db.Entitites.First(e => e.days == days);
+        var found = db.Entities.First(e => e.days == days);
         Assert.Equal(expected._id, found._id);
         Assert.Equal(days, found.days);
     }
@@ -322,7 +322,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
 
         var original = new DaysIsTimeSpan { days = TimeSpan.FromDays(days) };
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<DaysIsInt>(collection.CollectionNamespace.CollectionName).AsQueryable().First();
@@ -349,7 +349,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
         Assert.Equal(days, found.days);
     }
@@ -367,7 +367,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
-        var found = db.Entitites.First(e => e.days == days);
+        var found = db.Entities.First(e => e.days == days);
         Assert.Equal(expected._id, found._id);
         Assert.Equal(days, found.days);
     }
@@ -382,7 +382,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
         var original = new DaysIsString { days = days.ToString() };
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<DaysIsInt>(collection.CollectionNamespace.CollectionName).AsQueryable().First();
@@ -420,7 +420,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
         Assert.Equal(amount, found.amount);
     }
@@ -439,7 +439,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
 
-        var found = db.Entitites.First(e => e.amount == amount);
+        var found = db.Entities.First(e => e.amount == amount);
         Assert.Equal(expected._id, found._id);
         Assert.Equal(amount, found.amount);
     }
@@ -455,7 +455,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
 
         var original = new AmountIsDecimal { amount = amount };
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<AmountIsDecimal128>(collection.CollectionNamespace.CollectionName).AsQueryable().First();
@@ -487,7 +487,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
 
-        var found = db.Entitites.First();
+        var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
         Assert.Equal(amount, found.amount.ToString());
     }
@@ -505,7 +505,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
 
-        var found = db.Entitites.First(e => e.amount == decimal.Parse(amount));
+        var found = db.Entities.First(e => e.amount == decimal.Parse(amount));
         Assert.Equal(expected._id, found._id);
         Assert.Equal(amount, found.amount.ToString());
     }
@@ -520,7 +520,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
 
         var original = new AmountIsDecimal { amount = decimal.Parse(amount) };
-        db.Entitites.Add(original);
+        db.Entities.Add(original);
         db.SaveChanges();
 
         var found = GetCollection<AmountIsString>(collection.CollectionNamespace.CollectionName).AsQueryable().First();

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
@@ -72,7 +72,7 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new OwnedEntityRemappingEntity
+            dbContext.Entities.Add(new OwnedEntityRemappingEntity
             {
                 _id = id,
                 Location = location
@@ -97,7 +97,7 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new NonKeyRemappingEntity
+            dbContext.Entities.Add(new NonKeyRemappingEntity
             {
                 _id = id, RemapThisToName = name
             });
@@ -121,7 +121,7 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new KeyRemappingEntity
+            dbContext.Entities.Add(new KeyRemappingEntity
             {
                 _id = id, name = name
             });
@@ -149,10 +149,10 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
             {
                 _id = id, name = name
             };
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
 
-            dbContext.Entitites.Remove(entity);
+            dbContext.Entities.Remove(entity);
             dbContext.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
@@ -57,7 +57,7 @@ public class BsonIgnoreAttributeConventionTests(TemporaryDatabaseFixture tempDat
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new IgnoredPropertiesEntity
+            dbContext.Entities.Add(new IgnoredPropertiesEntity
             {
                 _id = id, KeepMe = name, IgnoreMe = "a", AndMe = true
             });

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
@@ -76,7 +76,7 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new OwnedEntityRemappingEntity
+            dbContext.Entities.Add(new OwnedEntityRemappingEntity
             {
                 _id = id,
                 Location = location
@@ -101,7 +101,7 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new NonKeyRemappingEntity {_id = id, RemapThisToName = name});
+            dbContext.Entities.Add(new NonKeyRemappingEntity {_id = id, RemapThisToName = name});
             dbContext.SaveChanges();
         }
 
@@ -122,7 +122,7 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new KeyRemappingEntity {_id = id, name = name});
+            dbContext.Entities.Add(new KeyRemappingEntity {_id = id, name = name});
             dbContext.SaveChanges();
         }
 
@@ -144,10 +144,10 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
         {
             var dbContext = SingleEntityDbContext.Create(collection);
             var entity = new KeyRemappingEntity {_id = id, name = name};
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
 
-            dbContext.Entitites.Remove(entity);
+            dbContext.Entities.Remove(entity);
             dbContext.SaveChanges();
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
@@ -72,7 +72,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new UnderscoreIdNamedProperty {_id = id, name = name});
+            dbContext.Entities.Add(new UnderscoreIdNamedProperty {_id = id, name = name});
             dbContext.SaveChanges();
         }
 
@@ -87,7 +87,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         {
             // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entitites.Single(f => f._id == id);
+            var found = dbContext.Entities.Single(f => f._id == id);
             Assert.Equal(name, found.name);
         }
     }
@@ -102,7 +102,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new IdNamedProperty {Id = id, name = name});
+            dbContext.Entities.Add(new IdNamedProperty {Id = id, name = name});
             dbContext.SaveChanges();
         }
 
@@ -116,7 +116,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         {
             // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entitites.Single(f => f.Id == id);
+            var found = dbContext.Entities.Single(f => f.Id == id);
             Assert.Equal(name, found.name);
         }
     }
@@ -132,7 +132,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         {
             var dbContext = SingleEntityDbContext.Create(collection);
             var entity = new ColumnAttributedIdProperty {MyPrimaryKey = id, name = name};
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
         }
 
@@ -147,7 +147,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         {
             // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entitites.Single(f => f.MyPrimaryKey == id);
+            var found = dbContext.Entities.Single(f => f.MyPrimaryKey == id);
             Assert.Equal(name, found.name);
         }
     }
@@ -163,7 +163,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         {
             var dbContext = SingleEntityDbContext.Create(collection);
             var entity = new Product {ProductId = id, name = name};
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
         }
 
@@ -177,7 +177,7 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         {
             // Find with EF
             var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entitites.Single(f => f.ProductId == id);
+            var found = dbContext.Entities.Single(f => f.ProductId == id);
             Assert.Equal(name, found.name);
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
@@ -33,7 +33,7 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var dbContext = CreateContext();
 
-        var result = dbContext.Entitites.Where(e => e.Key1 == "two").ToList();
+        var result = dbContext.Entities.Where(e => e.Key1 == "two").ToList();
 
         Assert.Equal(2, result.Count);
         Assert.All(result, e => Assert.Equal("two", e.Key1));
@@ -44,7 +44,7 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var dbContext = CreateContext();
 
-        var result = dbContext.Entitites.Where(e => e.Key1 == "two" && e.Key2 == 3).ToList();
+        var result = dbContext.Entities.Where(e => e.Key1 == "two" && e.Key2 == 3).ToList();
 
         Assert.Single(result);
         Assert.All(result, e => Assert.Equal("two", e.Key1));
@@ -56,7 +56,7 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var dbContext = CreateContext();
 
-        var result = dbContext.Entitites.Where(e => e.Key2 > 2).ToList();
+        var result = dbContext.Entities.Where(e => e.Key2 > 2).ToList();
 
         Assert.Single(result);
         Assert.All(result, e => Assert.True(e.Key2 > 2));
@@ -68,7 +68,7 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var context = SingleEntityDbContext.Create(collection, ConfigureContext);
-            context.Entitites.AddRange(
+            context.Entities.AddRange(
             [
                 new Entity
                 {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -33,7 +33,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.Single();
+        var actual = db.Entities.Single();
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(Location1.latitude, actual.location.latitude);
@@ -53,7 +53,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.MongoDatabase.GetCollection<PersonWithOptionalLocation>("personNoLocation");
         var db = SingleEntityDbContext.Create(collection);
 
-        var person = db.Entitites.First();
+        var person = db.Entities.First();
         Assert.NotNull(person);
         Assert.Equal("Bill", person.name);
         Assert.Null(person.location);
@@ -66,7 +66,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First(e => e.location.latitude > 0.00m);
+        var actual = db.Entities.First(e => e.location.latitude > 0.00m);
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(Location1.latitude, actual.location.latitude);
@@ -80,7 +80,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First(e => e.location.city.name == "San Diego");
+        var actual = db.Entities.First(e => e.location.city.name == "San Diego");
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(Location1.latitude, actual.location.latitude);
@@ -95,7 +95,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(false); });
 
-        List<PersonWithLocation> actual = db.Entitites.Where(p => p.name == "Elizabeth").ToList();
+        List<PersonWithLocation> actual = db.Entities.Where(p => p.name == "Elizabeth").ToList();
 
         Assert.NotEmpty(actual);
         Assert.Equal("Elizabeth", actual[0].name);
@@ -110,7 +110,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(); });
 
-        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.Where(p => p.name != "bob").ToList());
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.Where(p => p.name != "bob").ToList());
         Assert.Contains(nameof(PersonWithLocation), ex.Message);
         Assert.Contains(nameof(PersonWithLocation.location), ex.Message);
     }
@@ -122,7 +122,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithLocation1);
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
 
-        List<PersonWithLocation> actual = db.Entitites.Where(p => p.name != "bob").ToList();
+        List<PersonWithLocation> actual = db.Entities.Where(p => p.name != "bob").ToList();
 
         Assert.NotEmpty(actual);
 
@@ -147,13 +147,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(expected);
+            db.Entities.Add(expected);
             db.SaveChanges();
         }
 
         {
             SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection);
-            var actual = db.Entitites.First(p => p.name == "Charlie");
+            var actual = db.Entities.First(p => p.name == "Charlie");
 
             Assert.Equal(expected.name, actual.name);
             Assert.Equal(expected.location.latitude, actual.location.latitude);
@@ -187,13 +187,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<PersonWithMultipleLocations> db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(expected);
+            db.Entities.Add(expected);
             db.SaveChanges();
         }
 
         {
             SingleEntityDbContext<PersonWithMultipleLocations> db = SingleEntityDbContext.Create(collection);
-            var actual = db.Entitites.First(p => p.name == "Alfred");
+            var actual = db.Entities.First(p => p.name == "Alfred");
 
             Assert.Equal(expected.name, actual.name);
             Assert.Equal(expected.locations[0].latitude, actual.locations[0].latitude);
@@ -237,7 +237,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.Empty(actual.children);
     }
 
@@ -253,7 +253,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.NotNull(actual.children);
         Assert.Empty(actual.children);
     }
@@ -270,7 +270,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.Null(actual.children);
     }
 
@@ -286,7 +286,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.Null(actual.children);
     }
 
@@ -297,7 +297,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs([new MissingNullableCollection()]);
         var db = SingleEntityDbContext.Create<MissingNullableCollection, SimpleNullableCollection>(collection);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.First());
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.First());
         Assert.Contains(nameof(SimpleNullableCollection.children), ex.Message);
     }
 
@@ -308,7 +308,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs([new MissingNullableCollection()]);
         var db = SingleEntityDbContext.Create<MissingNullableCollection, SimpleNullableCollection>(collection);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.First());
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.First());
         Assert.Contains(nameof(SimpleNullableCollection.children), ex.Message);
     }
 
@@ -319,7 +319,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.Single();
+        var actual = db.Entities.Single();
 
         Assert.Equal("Carmen", actual.name);
         Assert.Equal(Location1.latitude, actual.location.latitude);
@@ -334,7 +334,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithCity1);
         SingleEntityDbContext<PersonWithCity> db = SingleEntityDbContext.Create(collection);
 
-        List<PersonWithCity> actual = db.Entitites.Where(p => p.name != "bob").ToList();
+        List<PersonWithCity> actual = db.Entities.Where(p => p.name != "bob").ToList();
 
         Assert.NotEmpty(actual);
 
@@ -352,7 +352,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithLocations1);
         SingleEntityDbContext<PersonWithMultipleLocations> db = SingleEntityDbContext.Create(collection);
 
-        List<PersonWithMultipleLocations> actual = db.Entitites.Where(p => p.name != "bob").ToList();
+        List<PersonWithMultipleLocations> actual = db.Entities.Where(p => p.name != "bob").ToList();
 
         Assert.NotEmpty(actual);
 
@@ -396,7 +396,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
             }
         });
 
-        var actual = SingleEntityDbContext.Create(collection).Entitites.ToList();
+        var actual = SingleEntityDbContext.Create(collection).Entities.ToList();
 
         Assert.NotEmpty(actual);
         Assert.Equal("IEnumerableRound1", actual[0].name);
@@ -421,13 +421,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(entity);
+            db.Entities.Add(entity);
             db.SaveChanges();
         }
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var actual = db.Entitites.FirstOrDefault();
+            var actual = db.Entities.FirstOrDefault();
 
             Assert.NotNull(actual);
             Assert.Equal("IEnumerableSerialize", actual.name);
@@ -453,7 +453,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
             })
         };
 
-        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.Add(entity));
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.Add(entity));
         Assert.Contains(nameof(PersonWithIEnumerableLocations.locations), ex.Message);
         Assert.Contains(entity.locations.GetType().ShortDisplayName(), ex.Message);
     }
@@ -495,7 +495,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         {
             var db = SingleEntityDbContext.Create(collection);
 
-            var found = db.Entitites.Single();
+            var found = db.Entities.Single();
             Assert.Equal(2, found.locations.Count);
 
             found.locations.RemoveAt(0);
@@ -509,7 +509,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var db = SingleEntityDbContext.Create(collection);
-            var found = db.Entitites.Single();
+            var found = db.Entities.Single();
 
             Assert.Empty(found.locations);
         }
@@ -523,7 +523,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.WriteTestDocs(PersonWithTwoLocations1);
         SingleEntityDbContext<PersonWithTwoLocations> db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected.name, actual.name);
@@ -544,13 +544,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<PersonWithTwoLocations> db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(expected);
+            db.Entities.Add(expected);
             db.SaveChanges();
         }
 
         {
             SingleEntityDbContext<PersonWithTwoLocations> db = SingleEntityDbContext.Create(collection);
-            var actual = db.Entitites.FirstOrDefault();
+            var actual = db.Entities.FirstOrDefault();
 
             Assert.NotNull(actual);
             Assert.Equal(expected.name, actual.name);
@@ -570,7 +570,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         SingleEntityDbContext<PersonWithLocation> db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().OwnsOne(p => p.location, r => r.HasElementName("location")); });
 
-        var actual = db.Entitites.FirstOrDefault();
+        var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
         Assert.Equal(expected.name, actual.name);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/PrimitiveCollectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/PrimitiveCollectionTests.cs
@@ -46,7 +46,7 @@ public class PrimitiveCollectionTests(TemporaryDatabaseFixture tempDatabase) : I
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.Empty(actual.items);
     }
 
@@ -57,7 +57,7 @@ public class PrimitiveCollectionTests(TemporaryDatabaseFixture tempDatabase) : I
         collection.WriteTestDocs([new MissingPrimitiveList()]);
         var db = SingleEntityDbContext.Create<MissingPrimitiveList, NonNullablePrimitiveArray>(collection);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.First());
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.First());
         Assert.Contains("null", ex.Message);
         Assert.Contains("non-nullable", ex.Message);
         Assert.Contains(nameof(NonNullablePrimitiveList.items), ex.Message);
@@ -75,7 +75,7 @@ public class PrimitiveCollectionTests(TemporaryDatabaseFixture tempDatabase) : I
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => db.Entitites.First());
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.First());
         Assert.Contains("null", ex.Message);
         Assert.Contains("non-nullable", ex.Message);
         Assert.Contains(nameof(NonNullablePrimitiveList.items), ex.Message);
@@ -88,7 +88,7 @@ public class PrimitiveCollectionTests(TemporaryDatabaseFixture tempDatabase) : I
         collection.WriteTestDocs([new MissingPrimitiveList()]);
         var db = SingleEntityDbContext.Create<MissingPrimitiveList, NullablePrimitiveArray>(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.Null(actual.items);
     }
 
@@ -104,7 +104,7 @@ public class PrimitiveCollectionTests(TemporaryDatabaseFixture tempDatabase) : I
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.NotNull(actual.items);
         Assert.Empty(actual.items);
     }
@@ -121,7 +121,7 @@ public class PrimitiveCollectionTests(TemporaryDatabaseFixture tempDatabase) : I
         ]);
         var db = SingleEntityDbContext.Create(collection);
 
-        var actual = db.Entitites.First();
+        var actual = db.Entities.First();
         Assert.Null(actual.items);
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
@@ -219,7 +219,7 @@ public class WhereTests
     public void Where_string_list_contains()
     {
         var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
-        var results = db.Entitites.Where(p => p.mainAtmosphere.Contains("H2")).ToArray();
+        var results = db.Entities.Where(p => p.mainAtmosphere.Contains("H2")).ToArray();
         Assert.Equal(4, results.Length);
         Assert.All(results, p => Assert.Contains("H2", p.mainAtmosphere));
     }
@@ -228,7 +228,7 @@ public class WhereTests
     public void Where_string_list_not_contains()
     {
         var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
-        var results = db.Entitites.Where(p => !p.mainAtmosphere.Contains("H2")).ToArray();
+        var results = db.Entities.Where(p => !p.mainAtmosphere.Contains("H2")).ToArray();
         Assert.Equal(4, results.Length);
         Assert.All(results, p => Assert.DoesNotContain("H2", p.mainAtmosphere));
     }
@@ -237,7 +237,7 @@ public class WhereTests
     public void Where_string_list_count()
     {
         var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
-        var results = db.Entitites.Where(p => p.mainAtmosphere.Count == 2).ToArray();
+        var results = db.Entities.Where(p => p.mainAtmosphere.Count == 2).ToArray();
         Assert.Single(results);
         Assert.Equal(2, results[0].mainAtmosphere.Count);
     }
@@ -246,7 +246,7 @@ public class WhereTests
     public void Where_string_list_any()
     {
         var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
-        var results = db.Entitites.Where(p => p.mainAtmosphere.Any()).ToArray();
+        var results = db.Entities.Where(p => p.mainAtmosphere.Any()).ToArray();
         Assert.Equal(7, results.Length);
         Assert.All(results, p => Assert.NotEmpty(p.mainAtmosphere));
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BooleanSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/BooleanSerializationTests.cs
@@ -31,7 +31,7 @@ public class BooleanSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new BooleanEntity
+            db.Entities.Add(new BooleanEntity
             {
                 aBoolean = expected
             });
@@ -40,7 +40,7 @@ public class BooleanSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aBoolean);
         }
@@ -52,7 +52,7 @@ public class BooleanSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<BooleanEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class BooleanEntity : BaseIdEntity
@@ -71,7 +71,7 @@ public class BooleanSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableBooleanEntity
+            db.Entities.Add(new NullableBooleanEntity
             {
                 aNullableBoolean = expected
             });
@@ -80,7 +80,7 @@ public class BooleanSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableBoolean);
         }
@@ -92,7 +92,7 @@ public class BooleanSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableBooleanEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableBoolean);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
@@ -31,7 +31,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new IntArrayEntity
+            db.Entities.Add(new IntArrayEntity
             {
                 anIntArray = expected
             });
@@ -40,7 +40,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.anIntArray);
         }
@@ -52,7 +52,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<IntArrayEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class IntArrayEntity : BaseIdEntity
@@ -72,7 +72,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableIntArrayEntity
+            db.Entities.Add(new NullableIntArrayEntity
             {
                 anIntArray = expected
             });
@@ -81,7 +81,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.anIntArray);
         }
@@ -93,7 +93,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableIntArrayEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.anIntArray);
     }
@@ -114,7 +114,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new StringArrayEntity
+            db.Entities.Add(new StringArrayEntity
             {
                 aStringArray = expected
             });
@@ -123,7 +123,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aStringArray);
         }
@@ -135,7 +135,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<StringArrayEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class StringArrayEntity : BaseIdEntity
@@ -155,7 +155,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableStringArrayEntity
+            db.Entities.Add(new NullableStringArrayEntity
             {
                 aStringArray = expected
             });
@@ -164,7 +164,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aStringArray);
         }
@@ -176,7 +176,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableStringArrayEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aStringArray);
     }
@@ -196,7 +196,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new ListEntity
+            db.Entities.Add(new ListEntity
             {
                 aList = [..expected]
             });
@@ -205,7 +205,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equivalent(expected, result.aList);
         }
@@ -217,7 +217,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ListEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class ListEntity : BaseIdEntity
@@ -235,7 +235,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableListEntity
+            db.Entities.Add(new NullableListEntity
             {
                 aList = new List<int>(expected)
             });
@@ -244,7 +244,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equivalent(expected, result.aList);
         }
@@ -256,7 +256,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableListEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aList);
     }
@@ -277,7 +277,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new IEnumerableEntity
+            db.Entities.Add(new IEnumerableEntity
             {
                 anEnumerable = new List<int>(expected)
             });
@@ -286,7 +286,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equivalent(expected, result.anEnumerable);
         }
@@ -308,7 +308,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableIEnumerableEntity
+            db.Entities.Add(new NullableIEnumerableEntity
             {
                 anEnumerable = new List<int>(expected)
             });
@@ -317,7 +317,7 @@ public class CollectionSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equivalent(expected, result.anEnumerable);
         }
@@ -334,7 +334,7 @@ public class CollectionSerializationTests : BaseSerializationTests
         var collection = TempDatabase.CreateTemporaryCollection<IEnumerableEntity>();
 
         using var db = SingleEntityDbContext.Create(collection);
-        db.Entitites.Add(new IEnumerableEntity
+        db.Entities.Add(new IEnumerableEntity
         {
             anEnumerable = EnumerableOnlyWrapper.Wrap(new[]
             {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
@@ -32,7 +32,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DateTimeEntity
+            db.Entities.Add(new DateTimeEntity
             {
                 aDateTime = expected
             });
@@ -41,7 +41,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected.ToExpectedPrecision(), result.aDateTime.ToExpectedPrecision());
         }
@@ -56,7 +56,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         {
             using var db = SingleEntityDbContext.Create(collection,
                 model => model.Entity<DateTimeEntity>().Property(e => e.aDateTime).HasDateTimeKind(DateTimeKind.Local));
-            db.Entitites.Add(new DateTimeEntity
+            db.Entities.Add(new DateTimeEntity
             {
                 aDateTime = expected
             });
@@ -66,7 +66,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         {
             using var db = SingleEntityDbContext.Create(collection,
                 model => model.Entity<DateTimeEntity>().Property(e => e.aDateTime).HasDateTimeKind(DateTimeKind.Local));
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected.ToExpectedPrecision(), result.aDateTime.ToExpectedPrecision());
         }
@@ -78,7 +78,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DateTimeEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class DateTimeEntity : BaseIdEntity
@@ -94,7 +94,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeEntity
+            db.Entities.Add(new NullableDateTimeEntity
             {
                 aNullableDateTime = expected
             });
@@ -103,7 +103,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected.Value.ToExpectedPrecision(), result.aNullableDateTime.Value.ToExpectedPrecision());
         }
@@ -117,7 +117,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeEntity
+            db.Entities.Add(new NullableDateTimeEntity
             {
                 aNullableDateTime = expected
             });
@@ -126,7 +126,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Null(result.aNullableDateTime);
         }
@@ -138,7 +138,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableDateTimeEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableDateTime);
     }
@@ -156,7 +156,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DateTimeOffsetEntity
+            db.Entities.Add(new DateTimeOffsetEntity
             {
                 aDateTimeOffset = expected
             });
@@ -165,7 +165,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aDateTimeOffset);
         }
@@ -177,7 +177,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DateTimeOffsetEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class DateTimeOffsetEntity : BaseIdEntity
@@ -193,7 +193,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeOffsetEntity
+            db.Entities.Add(new NullableDateTimeOffsetEntity
             {
                 aNullableDateTimeOffset = expected
             });
@@ -202,7 +202,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected.Value, result.aNullableDateTimeOffset.Value);
         }
@@ -216,7 +216,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDateTimeOffsetEntity
+            db.Entities.Add(new NullableDateTimeOffsetEntity
             {
                 aNullableDateTimeOffset = expected
             });
@@ -225,7 +225,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Null(result.aNullableDateTimeOffset);
         }
@@ -237,7 +237,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableDateTimeOffsetEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableDateTimeOffset);
     }
@@ -256,7 +256,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new TimeSpanEntity
+            db.Entities.Add(new TimeSpanEntity
             {
                 aTimeSpan = expected
             });
@@ -265,7 +265,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aTimeSpan);
         }
@@ -277,7 +277,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<TimeSpanEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class TimeSpanEntity : BaseIdEntity
@@ -298,7 +298,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableTimeSpanEntity
+            db.Entities.Add(new NullableTimeSpanEntity
             {
                 aNullableTimeSpan = expected
             });
@@ -307,7 +307,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableTimeSpan);
         }
@@ -319,7 +319,7 @@ public class DateAndTimeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableTimeSpanEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableTimeSpan);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DecimalSerializationTests.cs
@@ -33,7 +33,7 @@ public class DecimalSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DecimalEntity
+            db.Entities.Add(new DecimalEntity
             {
                 aDecimal = expected
             });
@@ -42,7 +42,7 @@ public class DecimalSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aDecimal);
         }
@@ -54,7 +54,7 @@ public class DecimalSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DecimalEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class DecimalEntity : BaseIdEntity
@@ -76,7 +76,7 @@ public class DecimalSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDecimalEntity
+            db.Entities.Add(new NullableDecimalEntity
             {
                 aNullableDecimal = expected
             });
@@ -85,7 +85,7 @@ public class DecimalSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableDecimal);
         }
@@ -97,7 +97,7 @@ public class DecimalSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableDecimalEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableDecimal);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/FloatingSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/FloatingSerializationTests.cs
@@ -32,7 +32,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new FloatEntity
+            db.Entities.Add(new FloatEntity
             {
                 aFloat = expected
             });
@@ -41,7 +41,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aFloat);
         }
@@ -53,7 +53,7 @@ public class FloatingSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<FloatEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class FloatEntity : BaseIdEntity
@@ -72,7 +72,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableFloatEntity
+            db.Entities.Add(new NullableFloatEntity
             {
                 aNullableFloat = expected
             });
@@ -81,7 +81,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableFloat);
         }
@@ -93,7 +93,7 @@ public class FloatingSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableFloatEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableFloat);
     }
@@ -113,7 +113,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new DoubleEntity
+            db.Entities.Add(new DoubleEntity
             {
                 aDouble = expected
             });
@@ -122,7 +122,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aDouble);
         }
@@ -134,7 +134,7 @@ public class FloatingSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<DoubleEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class DoubleEntity : BaseIdEntity
@@ -154,7 +154,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDoubleEntity
+            db.Entities.Add(new NullableDoubleEntity
             {
                 aNullableDouble = expected
             });
@@ -163,7 +163,7 @@ public class FloatingSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableDouble);
         }
@@ -175,7 +175,7 @@ public class FloatingSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableDoubleEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableDouble);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/GuidSerializationTests.cs
@@ -35,7 +35,7 @@ public class GuidSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new GuidEntity
+            db.Entities.Add(new GuidEntity
             {
                 aGuid = expected
             });
@@ -44,7 +44,7 @@ public class GuidSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aGuid);
         }
@@ -56,7 +56,7 @@ public class GuidSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<GuidEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class GuidEntity : BaseIdEntity
@@ -78,7 +78,7 @@ public class GuidSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableGuidEntity
+            db.Entities.Add(new NullableGuidEntity
             {
                 aNullableGuid = expected
             });
@@ -87,7 +87,7 @@ public class GuidSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableGuid);
         }
@@ -99,7 +99,7 @@ public class GuidSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableGuidEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableGuid);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/IntegerSerializationTests.cs
@@ -32,7 +32,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new IntEntity
+            db.Entities.Add(new IntEntity
             {
                 anInt = expected
             });
@@ -41,7 +41,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.anInt);
         }
@@ -53,7 +53,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<IntEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class IntEntity : BaseIdEntity
@@ -72,7 +72,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableIntEntity
+            db.Entities.Add(new NullableIntEntity
             {
                 aNullableInt = expected
             });
@@ -81,7 +81,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableInt);
         }
@@ -93,7 +93,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableIntEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableInt);
     }
@@ -113,7 +113,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new LongEntity
+            db.Entities.Add(new LongEntity
             {
                 aLong = expected
             });
@@ -122,7 +122,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aLong);
         }
@@ -134,7 +134,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<LongEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class LongEntity : BaseIdEntity
@@ -153,7 +153,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableLongEntity
+            db.Entities.Add(new NullableLongEntity
             {
                 aNullableLong = expected
             });
@@ -162,7 +162,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableLong);
         }
@@ -174,7 +174,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableLongEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableLong);
     }
@@ -194,7 +194,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new ShortEntity
+            db.Entities.Add(new ShortEntity
             {
                 aShort = expected
             });
@@ -203,7 +203,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aShort);
         }
@@ -215,7 +215,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ShortEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class ShortEntity : BaseIdEntity
@@ -234,7 +234,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableShortEntity
+            db.Entities.Add(new NullableShortEntity
             {
                 aNullableShort = expected
             });
@@ -243,7 +243,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableShort);
         }
@@ -255,7 +255,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableShortEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableShort);
     }
@@ -276,7 +276,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new SByteEntity
+            db.Entities.Add(new SByteEntity
             {
                 aByte = expected
             });
@@ -285,7 +285,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aByte);
         }
@@ -297,7 +297,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<SByteEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class SByteEntity : BaseIdEntity
@@ -318,7 +318,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableSByteEntity
+            db.Entities.Add(new NullableSByteEntity
             {
                 aNullableSByte = expected
             });
@@ -327,7 +327,7 @@ public class IntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableSByte);
         }
@@ -339,7 +339,7 @@ public class IntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableSByteEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableSByte);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/MongoTypeSerializationTests.cs
@@ -34,7 +34,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new ObjectIdEntity
+            db.Entities.Add(new ObjectIdEntity
             {
                 anObjectId = expected
             });
@@ -43,7 +43,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.anObjectId);
         }
@@ -55,7 +55,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ObjectIdEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class ObjectIdEntity : BaseIdEntity
@@ -75,7 +75,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableObjectIdEntity
+            db.Entities.Add(new NullableObjectIdEntity
             {
                 aNullableObjectId = expected
             });
@@ -84,7 +84,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableObjectId);
         }
@@ -96,7 +96,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableObjectIdEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableObjectId);
     }
@@ -117,7 +117,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new Decimal128Entity
+            db.Entities.Add(new Decimal128Entity
             {
                 anDecimal128 = expected
             });
@@ -126,7 +126,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.anDecimal128);
         }
@@ -138,7 +138,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<Decimal128Entity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class Decimal128Entity : BaseIdEntity
@@ -160,7 +160,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableDecimal128Entity
+            db.Entities.Add(new NullableDecimal128Entity
             {
                 aNullableDecimal128 = expected
             });
@@ -169,7 +169,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableDecimal128);
         }
@@ -181,7 +181,7 @@ public class MongoTypeSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableDecimal128Entity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableDecimal128);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/StringSerializationTests.cs
@@ -38,7 +38,7 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new StringEntity
+            db.Entities.Add(new StringEntity
             {
                 aString = expected
             });
@@ -47,7 +47,7 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aString);
         }
@@ -59,7 +59,7 @@ public class StringSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<StringEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aString);
     }
@@ -82,7 +82,7 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new CharEntity
+            db.Entities.Add(new CharEntity
             {
                 aChar = expected
             });
@@ -91,7 +91,7 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aChar);
         }
@@ -103,7 +103,7 @@ public class StringSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<CharEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class CharEntity : BaseIdEntity
@@ -127,7 +127,7 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableCharEntity
+            db.Entities.Add(new NullableCharEntity
             {
                 aNullableChar = expected
             });
@@ -136,7 +136,7 @@ public class StringSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableChar);
         }
@@ -148,7 +148,7 @@ public class StringSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableCharEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableChar);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/UnsignedIntegerSerializationTests.cs
@@ -31,13 +31,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new UIntEntity {aUint = expected});
+            db.Entities.Add(new UIntEntity {aUint = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aUint);
         }
@@ -49,7 +49,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<UIntEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class UIntEntity : BaseIdEntity
@@ -67,13 +67,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableUIntEntity {aNullableUint = expected});
+            db.Entities.Add(new NullableUIntEntity {aNullableUint = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableUint);
         }
@@ -85,7 +85,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableUIntEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableUint);
     }
@@ -104,13 +104,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new UlongEntity {aUlong = expected});
+            db.Entities.Add(new UlongEntity {aUlong = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aUlong);
         }
@@ -122,7 +122,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<UlongEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class UlongEntity : BaseIdEntity
@@ -140,13 +140,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableUlongEntity {aNullableUlong = expected});
+            db.Entities.Add(new NullableUlongEntity {aNullableUlong = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableUlong);
         }
@@ -158,7 +158,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableUlongEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableUlong);
     }
@@ -177,13 +177,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new UshortEntity {aUshort = expected});
+            db.Entities.Add(new UshortEntity {aUshort = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aUshort);
         }
@@ -195,7 +195,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<UshortEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class UshortEntity : BaseIdEntity
@@ -214,13 +214,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableShortEntity {aNullableUshort = expected});
+            db.Entities.Add(new NullableShortEntity {aNullableUshort = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableUshort);
         }
@@ -232,7 +232,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableShortEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableUshort);
     }
@@ -252,13 +252,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new ByteEntity {aByte = expected});
+            db.Entities.Add(new ByteEntity {aByte = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aByte);
         }
@@ -270,7 +270,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<ByteEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        Assert.Throws<InvalidOperationException>(() => db.Entitites.FirstOrDefault());
+        Assert.Throws<InvalidOperationException>(() => db.Entities.FirstOrDefault());
     }
 
     class ByteEntity : BaseIdEntity
@@ -290,13 +290,13 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entitites.Add(new NullableByteEntity {aNullableByte = expected});
+            db.Entities.Add(new NullableByteEntity {aNullableByte = expected});
             db.SaveChanges();
         }
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var result = db.Entitites.FirstOrDefault();
+            var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
             Assert.Equal(expected, result.aNullableByte);
         }
@@ -308,7 +308,7 @@ public class UnsignedIntegerSerializationTests : BaseSerializationTests
         var collection = SetupIdOnlyCollection<NullableByteEntity>();
         using var db = SingleEntityDbContext.Create(collection);
 
-        var result = db.Entitites.FirstOrDefault();
+        var result = db.Entities.FirstOrDefault();
         Assert.NotNull(result);
         Assert.Null(result.aNullableByte);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
@@ -77,10 +77,10 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         {
             _id = ObjectId.GenerateNewId(), name = "Generated"
         };
-        dbContext.Entitites.Add(expected);
+        dbContext.Entities.Add(expected);
         dbContext.SaveChanges();
 
-        Assert.Same(expected, dbContext.Entitites.First());
+        Assert.Same(expected, dbContext.Entities.First());
 
         // Check with C# Driver for second opinion
         var directFound = collection.Find(f => f._id == expected._id).Single();
@@ -98,10 +98,10 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         {
             name = "Not Set"
         };
-        dbContext.Entitites.Add(expected);
+        dbContext.Entities.Add(expected);
         dbContext.SaveChanges();
 
-        Assert.Same(expected, dbContext.Entitites.First());
+        Assert.Same(expected, dbContext.Entities.First());
 
         // Check with C# Driver for second opinion
         var directFound = collection.Find(f => f._id == expected._id).Single();
@@ -121,10 +121,10 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         {
             _id = ObjectId.Empty, name = "Empty"
         };
-        dbContext.Entitites.Add(expected);
+        dbContext.Entities.Add(expected);
         dbContext.SaveChanges();
 
-        Assert.Same(expected, dbContext.Entitites.First());
+        Assert.Same(expected, dbContext.Entities.First());
 
         // Check with C# Driver for second opinion
         var directFound = collection.Find(f => f._id == expected._id).Single();
@@ -153,13 +153,13 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<NumericTypesEntity> dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(expected);
+            dbContext.Entities.Add(expected);
             dbContext.SaveChanges();
         }
 
         {
             SingleEntityDbContext<NumericTypesEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            var foundEntity = newDbContext.Entitites.Single();
+            var foundEntity = newDbContext.Entities.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aDecimal, foundEntity.aDecimal);
             Assert.Equal(expected.aSingle, foundEntity.aSingle);
@@ -187,13 +187,13 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<OtherClrTypeEntity> dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(expected);
+            dbContext.Entities.Add(expected);
             dbContext.SaveChanges();
         }
 
         {
             SingleEntityDbContext<OtherClrTypeEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            var foundEntity = newDbContext.Entitites.Single();
+            var foundEntity = newDbContext.Entities.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aString, foundEntity.aString);
             Assert.Equal(expected.aChar, foundEntity.aChar);
@@ -214,13 +214,13 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             SingleEntityDbContext<MongoSpecificTypeEntity> dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(expected);
+            dbContext.Entities.Add(expected);
             dbContext.SaveChanges();
         }
 
         {
             SingleEntityDbContext<MongoSpecificTypeEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            var foundEntity = newDbContext.Entitites.Single();
+            var foundEntity = newDbContext.Entities.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aDecimal128, foundEntity.aDecimal128);
         }
@@ -286,7 +286,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(new Entity<TValue>
+            dbContext.Entities.Add(new Entity<TValue>
             {
                 _id = ObjectId.GenerateNewId(), Value = value
             });
@@ -295,7 +295,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var newDbContext = SingleEntityDbContext.Create(collection);
-            Entity<TValue> foundEntity = newDbContext.Entitites.Single();
+            Entity<TValue> foundEntity = newDbContext.Entities.Single();
             Assert.Equal(value, foundEntity.Value);
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/CompositeKeyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/CompositeKeyCrudTests.cs
@@ -40,7 +40,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
         }
 
@@ -67,7 +67,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
         }
 
@@ -78,7 +78,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
 
-            var actual = dbContext.Entitites.Single();
+            var actual = dbContext.Entities.Single();
 
             Assert.Equal(entity.Id1, actual.Id1);
             Assert.Equal(entity.Id2, actual.Id2);
@@ -98,7 +98,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
 
             entity.Data = "updated text";
@@ -127,7 +127,7 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
             var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
 
             dbContext.Remove(entity);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/ContextTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/ContextTests.cs
@@ -28,11 +28,11 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
 
         const int insertCount = 10;
 
-        db.Entitites.AddRange(
+        db.Entities.AddRange(
             Enumerable.Range(0, insertCount).Select(i => new Customer("Generated " + i)));
 
         Assert.Equal(insertCount, db.SaveChanges());
-        Assert.Equal(insertCount, db.Entitites.Count());
+        Assert.Equal(insertCount, db.Entities.Count());
     }
 
     [Fact]
@@ -42,11 +42,11 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
 
         const int insertCount = 9;
 
-        db.Entitites.AddRange(
+        db.Entities.AddRange(
             Enumerable.Range(0, insertCount).Select(i => new Customer("Generated " + i)));
 
         Assert.Equal(insertCount, await db.SaveChangesAsync());
-        Assert.Equal(insertCount, await db.Entitites.CountAsync());
+        Assert.Equal(insertCount, await db.Entities.CountAsync());
     }
 
     [Fact]
@@ -59,14 +59,14 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
             .Select(i => new Customer("Generated " + i))
             .ToArray();
 
-        db.Entitites.AddRange(items);
+        db.Entities.AddRange(items);
         db.SaveChanges();
 
         for (var i = 0; i < updateCount; i++)
             items[i].name = "Updated " + i;
 
         Assert.Equal(updateCount, db.SaveChanges());
-        Assert.Equal(updateCount, db.Entitites.Count(c => c.name.StartsWith("Updated ")));
+        Assert.Equal(updateCount, db.Entities.Count(c => c.name.StartsWith("Updated ")));
     }
 
     [Fact]
@@ -79,14 +79,14 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
             .Select(i => new Customer("Generated " + i))
             .ToArray();
 
-        db.Entitites.AddRange(items);
+        db.Entities.AddRange(items);
         await db.SaveChangesAsync();
 
         for (var i = 0; i < updateCount; i++)
             items[i].name = "Updated " + i;
 
         Assert.Equal(updateCount, await db.SaveChangesAsync());
-        Assert.Equal(updateCount, await db.Entitites.CountAsync(c => c.name.StartsWith("Updated ")));
+        Assert.Equal(updateCount, await db.Entities.CountAsync(c => c.name.StartsWith("Updated ")));
     }
 
     [Fact]
@@ -99,13 +99,13 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
             .Select(i => new Customer("Generated " + i))
             .ToArray();
 
-        db.Entitites.AddRange(items);
+        db.Entities.AddRange(items);
         db.SaveChanges();
 
-        db.Entitites.RemoveRange(items.Take(deleteCount));
+        db.Entities.RemoveRange(items.Take(deleteCount));
 
         Assert.Equal(deleteCount, db.SaveChanges());
-        Assert.Equal(items.Length - deleteCount, db.Entitites.Count());
+        Assert.Equal(items.Length - deleteCount, db.Entities.Count());
     }
 
     [Fact]
@@ -118,13 +118,13 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
             .Select(i => new Customer("Generated " + i))
             .ToArray();
 
-        await db.Entitites.AddRangeAsync(items);
+        await db.Entities.AddRangeAsync(items);
         await db.SaveChangesAsync();
 
-        db.Entitites.RemoveRange(items.Take(deleteCount));
+        db.Entities.RemoveRange(items.Take(deleteCount));
 
         Assert.Equal(deleteCount, await db.SaveChangesAsync());
-        Assert.Equal(deleteCount, await db.Entitites.CountAsync());
+        Assert.Equal(deleteCount, await db.Entities.CountAsync());
     }
 
     [Fact]
@@ -136,16 +136,16 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
             .Select(i => new Customer("Generated " + i))
             .ToArray();
 
-        db.Entitites.AddRange(items);
+        db.Entities.AddRange(items);
         db.SaveChanges();
 
-        db.Entitites.Remove(items[0]);
+        db.Entities.Remove(items[0]);
         items[2].name = "Updated 2";
         items[3].name = "Updated 3";
-        db.Entitites.Add(new Customer("Generated x"));
+        db.Entities.Add(new Customer("Generated x"));
 
         Assert.Equal(4, db.SaveChanges());
-        Assert.Equal(4, db.Entitites.Count());
+        Assert.Equal(4, db.Entities.Count());
     }
 
     [Fact]
@@ -157,16 +157,16 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
             .Select(i => new Customer("Generated " + i))
             .ToArray();
 
-        await db.Entitites.AddRangeAsync(items);
+        await db.Entities.AddRangeAsync(items);
         await db.SaveChangesAsync();
 
-        db.Entitites.Remove(items[0]);
+        db.Entities.Remove(items[0]);
         items[2].name = "Updated 2";
         items[3].name = "Updated 3";
-        await db.Entitites.AddAsync(new Customer("Generated x"));
+        await db.Entities.AddAsync(new Customer("Generated x"));
 
         Assert.Equal(4, await db.SaveChangesAsync());
-        Assert.Equal(4, await db.Entitites.CountAsync());
+        Assert.Equal(4, await db.Entities.CountAsync());
     }
 
     [Fact]
@@ -175,14 +175,14 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
         var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<PeopleOnMoons>());
 
         var item = new PeopleOnMoons("Space Adventurer");
-        db.Entitites.Add(item);
+        db.Entities.Add(item);
         db.SaveChanges();
 
         item.Moons.Add(new Moon("Titan"));
         item.Moons.Add(new Moon("Mimas"));
 
         Assert.Equal(1, db.SaveChanges());
-        Assert.Equal(1, db.Entitites.Count());
+        Assert.Equal(1, db.Entities.Count());
     }
 
     [Fact]
@@ -192,8 +192,8 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
 
         var item1 = new PeopleOnMoons("Captain A");
         var item2 = new PeopleOnMoons("Captain B");
-        db.Entitites.Add(item1);
-        db.Entitites.Add(item2);
+        db.Entities.Add(item1);
+        db.Entities.Add(item2);
         await db.SaveChangesAsync();
 
         item1.Moons.Add(new Moon("Io"));
@@ -202,7 +202,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
         item1.name = "Captain J";
 
         Assert.Equal(2, await db.SaveChangesAsync());
-        Assert.Equal(2, await db.Entitites.CountAsync());
+        Assert.Equal(2, await db.Entities.CountAsync());
     }
 
     class Customer(string name)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
@@ -58,12 +58,12 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.InsertOne(new SimpleEntityWithStringId {_id = ObjectId.GenerateNewId().ToString(), name = "DeleteMe"});
 
         var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entitites.Single();
+        var entity = dbContext.Entities.Single();
 
         dbContext.Remove(entity);
         dbContext.SaveChanges();
 
-        Assert.Empty(dbContext.Entitites);
+        Assert.Empty(dbContext.Entities);
     }
 
     [Fact]
@@ -73,12 +73,12 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.InsertOne(new SimpleEntityWithObjectIdId {_id = ObjectId.GenerateNewId(), name = "DeleteMe"});
 
         var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entitites.Single();
+        var entity = dbContext.Entities.Single();
 
         dbContext.Remove(entity);
         dbContext.SaveChanges();
 
-        Assert.Empty(dbContext.Entitites);
+        Assert.Empty(dbContext.Entities);
     }
 
     [Fact]
@@ -88,12 +88,12 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.InsertOne(new SimpleEntityWithGuidId {_id = Guid.NewGuid(), name = "DeleteMe"});
 
         var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entitites.Single();
+        var entity = dbContext.Entities.Single();
 
         dbContext.Remove(entity);
         dbContext.SaveChanges();
 
-        Assert.Empty(dbContext.Entitites);
+        Assert.Empty(dbContext.Entities);
     }
 
     [Fact]
@@ -103,11 +103,11 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         collection.InsertOne(new SimpleEntityWithIntId {_id = new Random().Next(), name = "DeleteMe"});
 
         var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entitites.Single();
+        var entity = dbContext.Entities.Single();
 
         dbContext.Remove(entity);
         dbContext.SaveChanges();
 
-        Assert.Empty(dbContext.Entitites);
+        Assert.Empty(dbContext.Entities);
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
@@ -40,7 +40,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 Id = 1, Name = "John"
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
         }
 
@@ -72,7 +72,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 }
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
         }
 
@@ -104,7 +104,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 }
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
 
             person.City = null;
@@ -139,7 +139,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 }
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
 
             person.City = new City
@@ -177,7 +177,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 }
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
 
             person.City.Name = "Washington";
@@ -207,7 +207,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 Id = 1, Name = "John"
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
         }
 
@@ -246,7 +246,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 ]
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
         }
 
@@ -288,7 +288,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
             };
 
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
 
             person.Cities = null;
@@ -330,7 +330,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 ]
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
 
             person.Cities = person.Cities.Concat(new List<City>
@@ -380,7 +380,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 ]
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
 
             person.Cities = person.Cities.Where(c => c.Name != "Washington").ToList();
@@ -422,7 +422,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
                 ]
             };
 
-            db.Entitites.Add(person);
+            db.Entities.Add(person);
             db.SaveChanges();
 
             person.Cities[0].Name = "Denver";

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SimpleKeyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SimpleKeyCrudTests.cs
@@ -40,7 +40,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
         }
 
@@ -67,7 +67,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
         }
 
@@ -78,7 +78,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                     .HasKey(nameof(Entity.Id));
             });
 
-            var actual = dbContext.Entitites.Single();
+            var actual = dbContext.Entities.Single();
 
             Assert.Equal(entity.Id, actual.Id);
             Assert.Equal(entity.Data, actual.Data);
@@ -97,7 +97,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
 
             entity.Data = "updated text";
@@ -126,7 +126,7 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
                     .HasKey(nameof(Entity.Id));
             });
             var entity = new Entity {Id = "key", Data = "some text"};
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
 
             dbContext.Remove(entity);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
@@ -59,14 +59,14 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
             entity.name = "After";
             dbContext.SaveChanges();
         }
 
         var newDbContext = SingleEntityDbContext.Create(collection);
-        var foundEntity = newDbContext.Entitites.Single();
+        var foundEntity = newDbContext.Entities.Single();
         Assert.Equal(entity._id, foundEntity._id);
         Assert.Equal("After", foundEntity.name);
     }
@@ -86,7 +86,7 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
             entity.session = Guid.NewGuid();
             entity.lastCount++;
@@ -95,7 +95,7 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
         }
 
         var newDbContext = SingleEntityDbContext.Create(collection);
-        var foundEntity = newDbContext.Entitites.Single();
+        var foundEntity = newDbContext.Entities.Single();
         Assert.Equal(entity._id, foundEntity._id);
         Assert.Equal(entity.session, foundEntity.session);
         Assert.Equal(entity.lastCount, foundEntity.lastCount);
@@ -129,7 +129,7 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
             {
                 _id = ObjectId.GenerateNewId(), Value = initialValue
             };
-            dbContext.Entitites.Add(entity);
+            dbContext.Entities.Add(entity);
             dbContext.SaveChanges();
             entity.Value = updatedValue;
             dbContext.SaveChanges();
@@ -137,7 +137,7 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             var newDbContext = SingleEntityDbContext.Create(collection);
-            var foundEntity = newDbContext.Entitites.Single();
+            var foundEntity = newDbContext.Entities.Single();
             Assert.Equal(updatedValue, foundEntity.Value);
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SingleEntityDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SingleEntityDbContext.cs
@@ -65,7 +65,7 @@ internal class SingleEntityDbContext<T> : DbContext where T : class
     private readonly string _collectionName;
     private readonly Action<ModelBuilder>? _modelBuilderAction;
 
-    public DbSet<T> Entitites { get; init; }
+    public DbSet<T> Entities { get; init; }
 
     public SingleEntityDbContext(DbContextOptions options, string collectionName, Action<ModelBuilder>? modelBuilderAction = null)
         : base(options)

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/TestUtilities/SingleEntityDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/TestUtilities/SingleEntityDbContext.cs
@@ -44,7 +44,7 @@ internal class SingleEntityDbContext<T> : DbContext where T : class
 {
     private readonly Action<ModelBuilder>? _modelBuilderAction;
 
-    public DbSet<T> Entitites { get; init; }
+    public DbSet<T> Entities { get; init; }
 
     public SingleEntityDbContext(
         DbContextOptions options,


### PR DESCRIPTION
The test helper class `SingleEntityDbContext` had a typo of `Entitites` instead of `Entities`.

This affects a whole bunch of tests so is an isolated PR.