### PR TITLE
Detect unsupported attribute properties

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
@@ -1,18 +1,19 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
@@ -60,6 +61,15 @@ public class ColumnAttributeConvention :
         {
             propertyBuilder.HasElementName(attribute.Name, fromDataAnnotation: true);
         }
+
+        if (!string.IsNullOrWhiteSpace(attribute.TypeName))
+        {
+            var meta = propertyBuilder.Metadata;
+            throw new NotSupportedException($"Property '{meta.DeclaringType.ShortName()}.{meta.PropertyInfo?.Name}' specifies a "
+                                            + $"{nameof(ColumnAttribute)}.{nameof(ColumnAttribute.TypeName)
+                                            } which is not supported by "
+                                            + $"MongoDB. Consider using EF ValueConverters to handle the conversion instead.");
+        }
     }
 
     /// <summary>
@@ -77,7 +87,7 @@ public class ColumnAttributeConvention :
 
         if (!string.IsNullOrWhiteSpace(attribute?.Name) && meta.TargetEntityType.IsOwned())
         {
-           meta.TargetEntityType.SetContainingElementName(attribute.Name, fromDataAnnotation: true);
+            meta.TargetEntityType.SetContainingElementName(attribute.Name, fromDataAnnotation: true);
         }
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
@@ -93,7 +93,7 @@ public class PrimaryKeyDiscoveryConvention : KeyDiscoveryConvention
         switch (keys.Length)
         {
             case > 1:
-                throw new NotSupportedException("Alternate keys not supported at this time.");
+                throw new NotSupportedException("Alternate keys are not supported by the MongoDB EF Core Provider.");
             case 1:
                 keys[0].Properties[0].SetElementName("_id");
                 break;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/TableAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/TableAttributeConvention.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -51,6 +52,14 @@ public class TableAttributeConvention : TypeAttributeConventionBase<TableAttribu
         if (!string.IsNullOrWhiteSpace(attribute.Name))
         {
             entityTypeBuilder.ToCollection(attribute.Name, fromDataAnnotation: true);
+        }
+
+        if (!string.IsNullOrWhiteSpace(attribute.Schema))
+        {
+            var meta = entityTypeBuilder.Metadata;
+            throw new NotSupportedException($"Entity '{meta.ShortName()}' specifies a "
+                                            + $"{nameof(TableAttribute)}.{nameof(TableAttribute.Schema)} which is not supported by "
+                                            + $"MongoDB.");
         }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/TableAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/TableAttributeConventionTests.cs
@@ -1,17 +1,17 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
@@ -24,15 +24,26 @@ public static class TableAttributeConventionTests
     [Fact]
     public static void TableAttribute_specified_names_are_used_as_Table_names()
     {
-        using var context = new BaseDbContext();
-        Assert.Equal("attributeSpecifiedName", GetCollectionName<Customer>(context));
+        using var db = new BaseDbContext();
+        Assert.Equal("attributeSpecifiedName", GetCollectionName<Customer>(db));
     }
 
     [Fact]
     public static void ModelBuilder_specified_collection_names_override_TableAttribute_names()
     {
-        using var context = new ModelBuilderSpecifiedDbContext();
-        Assert.Equal("fluentSpecifiedName", GetCollectionName<Customer>(context));
+        using var db = new ModelBuilderSpecifiedDbContext();
+        Assert.Equal("fluentSpecifiedName", GetCollectionName<Customer>(db));
+    }
+
+    [Fact]
+    public static void TableAttribute_causes_not_supported_exception_when_schema_specified()
+    {
+        using var db = SingleEntityDbContext.Create<SchemaSpecifiedEntity>();
+
+        var ex = Assert.Throws<NotSupportedException>(() => db.Entities.First());
+        Assert.Contains(nameof(SchemaSpecifiedEntity), ex.Message);
+        Assert.Contains(nameof(TableAttribute), ex.Message);
+        Assert.Contains(nameof(TableAttribute.Schema), ex.Message);
     }
 
     static string GetCollectionName<TEntity>(DbContext context) =>
@@ -40,6 +51,13 @@ public static class TableAttributeConventionTests
 
     [Table("attributeSpecifiedName")]
     class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Table("attributeSpecifiedName", Schema = "not-allowed")]
+    class SchemaSpecifiedEntity
     {
         public int Id { get; set; }
         public string Name { get; set; }


### PR DESCRIPTION
Although we support the Table and Column attribute we don't support Table.Schema or Column.TypeName parts of them.

This PR throws if we encounter those.

We are intentionally allowing the unsupported Column.Order through as it has no data loss implications.