### PR TITLE
Add default ValueConverter test coverage

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
@@ -29,6 +30,7 @@ using MongoDB.EntityFrameworkCore.Query.Factories;
 using MongoDB.EntityFrameworkCore.Query.Visitors.Dependencies;
 using MongoDB.EntityFrameworkCore.Serializers;
 using MongoDB.EntityFrameworkCore.Storage;
+using MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 using MongoDB.EntityFrameworkCore.ValueGeneration;
 
 // ReSharper disable once CheckNamespace (extensions should be in the EF namespace for discovery)
@@ -110,6 +112,7 @@ public static class MongoServiceCollectionExtensions
             .TryAdd<IDatabaseCreator, MongoDatabaseCreator>()
             .TryAdd<IQueryContextFactory, MongoQueryContextFactory>()
             .TryAdd<ITypeMappingSource, MongoTypeMappingSource>()
+            .TryAdd<IValueConverterSelector, MongoValueConverterSelector>()
             .TryAdd<IQueryTranslationPreprocessorFactory, MongoQueryTranslationPreprocessorFactory>()
             .TryAdd<IQueryCompilationContextFactory, MongoQueryCompilationContextFactory>()
             .TryAdd<IQueryTranslationPostprocessorFactory, MongoQueryTranslationPostprocessorFactory>()

--- a/src/MongoDB.EntityFrameworkCore/Serializers/ValueConverterSerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/ValueConverterSerializer.cs
@@ -19,12 +19,7 @@ using MongoDB.Bson.Serialization;
 
 namespace MongoDB.EntityFrameworkCore.Serializers;
 
-internal interface IDifferentStorageType
-{
-    public Type StorageType { get; }
-}
-
-internal class ValueConverterSerializer<TActual, TStorage> : IBsonSerializer<TActual>, IDifferentStorageType
+internal class ValueConverterSerializer<TActual, TStorage> : IBsonSerializer<TActual>
 {
     private readonly ValueConverter<TActual, TStorage> _valueConverter;
     private readonly IBsonSerializer<TStorage> _storageSerializer;

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/MongoValueConverterSelector.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/MongoValueConverterSelector.cs
@@ -1,0 +1,70 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
+
+/// <summary>
+/// A <see cref="ValueConverterSelector"/> that adds support for MongoDB-specific value converters.
+/// </summary>
+public class MongoValueConverterSelector : ValueConverterSelector
+{
+    private readonly ConcurrentDictionary<(Type ModelClrType, Type ProviderClrType), ValueConverterInfo> _mongoConverters = new();
+
+    /// <summary>
+    /// Creates a new instance of <see cref="MongoValueConverterSelector"/>.
+    /// </summary>
+    /// <param name="dependencies">Parameter object containing dependencies for this service.</param>
+    public MongoValueConverterSelector(ValueConverterSelectorDependencies dependencies)
+        : base(dependencies)
+    {
+    }
+
+    /// <inheritdoc />
+    public override IEnumerable<ValueConverterInfo> Select(
+        Type modelClrType,
+        Type? providerClrType = null)
+    {
+        if (modelClrType == typeof(ObjectId))
+        {
+            if (providerClrType == null
+                || providerClrType == typeof(string))
+            {
+                yield return _mongoConverters.GetOrAdd(
+                    (modelClrType, typeof(string)),
+                    _ => ObjectIdToStringConverter.DefaultInfo);
+            }
+        }
+        else if (modelClrType == typeof(string))
+        {
+            if (providerClrType == typeof(ObjectId))
+            {
+                yield return _mongoConverters.GetOrAdd(
+                    (modelClrType, typeof(ObjectId)),
+                    _ => StringToObjectIdConverter.DefaultInfo);
+            }
+        }
+
+        foreach (var converter in base.Select(modelClrType, providerClrType))
+        {
+            yield return converter;
+        }
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/ObjectIdToStringConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/ObjectIdToStringConverter.cs
@@ -1,0 +1,58 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
+
+/// <summary>
+/// Converts a <see cref="ObjectId" /> to and from <see cref="string"/> values.
+/// </summary>
+/// <remarks>
+/// See <see href="https://aka.ms/efcore-docs-value-converters">EF Core value converters</see> for more information and examples.
+/// </remarks>
+public class ObjectIdToStringConverter : StringObjectIdConverter<ObjectId, string>
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="ObjectIdToStringConverter"/> class.
+    /// </summary>
+    public ObjectIdToStringConverter()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="ObjectIdToStringConverter"/> class.
+    /// </summary>
+    /// <param name="mappingHints">
+    /// Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
+    /// facets for the converted data.
+    /// </param>
+    public ObjectIdToStringConverter(ConverterMappingHints? mappingHints = null)
+        : base(
+            ToString(),
+            ToObjectId(),
+            mappingHints)
+    {
+    }
+
+    /// <summary>
+    /// A <see cref="ValueConverterInfo" /> for the default use of this converter.
+    /// </summary>
+    public static ValueConverterInfo DefaultInfo { get; }
+        = new(typeof(ObjectId), typeof(string), i => new ObjectIdToStringConverter(i.MappingHints));
+}

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringObjectIdConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringObjectIdConverter.cs
@@ -1,0 +1,61 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
+
+/// <summary>
+/// A base <see cref="ValueConverter{TModel,TProvider}"/> for converting between
+/// <see cref="ObjectId"/> and <see cref="string"/>.
+/// </summary>
+/// <typeparam name="TModel">The type in the entity model.</typeparam>
+/// <typeparam name="TProvider">The type to use in the provider.</typeparam>
+public class StringObjectIdConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="StringObjectIdConverter{TModel, TProvider}"/> class.
+    /// </summary>
+    /// <param name="convertToProviderExpression">The expression to convert from the model to the provider.</param>
+    /// <param name="convertFromProviderExpression">The expression to convert from the provider to the model.</param>
+    /// <param name="mappingHints">Optional <see cref="ConverterMappingHints"/> that may be considered.</param>
+    public StringObjectIdConverter(
+        Expression<Func<TModel, TProvider>> convertToProviderExpression,
+        Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+        ConverterMappingHints? mappingHints = null)
+        : base(
+            convertToProviderExpression,
+            convertFromProviderExpression,
+            mappingHints)
+    {
+    }
+
+    /// <summary>
+    /// An expression to convert from a <see cref="string"/> to an <see cref="ObjectId"/>.
+    /// </summary>
+    /// <returns>The expression that performs the conversion.</returns>
+    protected static new Expression<Func<ObjectId, string>> ToString()
+        => v => v.ToString();
+
+    /// <summary>
+    /// An expression to convert from an <see cref="ObjectId"/> to a <see cref="string"/>.
+    /// </summary>
+    /// <returns>The expression that performs the conversion.</returns>
+    protected static Expression<Func<string, ObjectId>> ToObjectId()
+        => v => ObjectId.Parse(v);
+}

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringToObjectIdConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringToObjectIdConverter.cs
@@ -1,0 +1,57 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
+
+/// <summary>
+/// Converts a <see cref="string"/> to and from <see cref="ObjectId" /> values.
+/// </summary>
+/// <remarks>
+/// See <see href="https://aka.ms/efcore-docs-value-converters">EF Core value converters</see> for more information and examples.
+/// </remarks>
+public class StringToObjectIdConverter : StringObjectIdConverter<string, ObjectId>
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="StringToObjectIdConverter"/> class.
+    /// </summary>
+    public StringToObjectIdConverter()
+        : this(null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="StringToObjectIdConverter"/> class.
+    /// </summary>
+    /// <param name="mappingHints">
+    /// Hints that can be used by the <see cref="ITypeMappingSource" /> to create data types with appropriate
+    /// facets for the converted data.
+    /// </param>
+    public StringToObjectIdConverter(ConverterMappingHints? mappingHints = null)
+        : base(
+            ToObjectId(),
+            ToString(),
+            mappingHints)
+    {
+    }
+
+    /// <summary>
+    /// A <see cref="ValueConverterInfo" /> for the default use of this converter.
+    /// </summary>
+    public static ValueConverterInfo DefaultInfo { get; }
+        = new(typeof(string), typeof(ObjectId), i => new StringToObjectIdConverter(i.MappingHints));
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -795,4 +795,92 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         Assert.Equal(original._id, found._id);
         Assert.Equal(amount.ToString(), found.amount);
     }
+
+    [Theory]
+    [InlineData(["507f1f77bcf86cd799439011"])]
+    [InlineData(["507f191e810c19729de860ea"])]
+    public void String_can_deserialize_from_ObjectId_with_default_converter(string id)
+    {
+        var docs = tempDatabase.CreateTemporaryCollection<IdIsObjectId>(
+            nameof(String_can_deserialize_from_ObjectId_with_default_converter) + "_" + id);
+        docs.InsertOne(new IdIsObjectId
+        {
+            _id = ObjectId.Parse(id)
+        });
+
+        var collection = GetCollection<IdIsString>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<IdIsString>().Property(e => e._id).HasConversion<ObjectId>();
+        });
+
+        var found = db.Entities.First();
+        Assert.Equal(id, found._id);
+    }
+
+    [Theory]
+    [InlineData(["507f1f77bcf86cd799439011"])]
+    [InlineData(["507f191e810c19729de860ea"])]
+    public void String_can_query_against_ObjectId_with_default_converter(string id)
+    {
+        var docs = tempDatabase.CreateTemporaryCollection<IdIsObjectId>(
+            nameof(String_can_query_against_ObjectId_with_default_converter) + "_" + id);
+        docs.InsertOne(new IdIsObjectId
+        {
+            _id = ObjectId.Parse(id)
+        });
+
+        var collection = GetCollection<IdIsString>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<IdIsString>().Property(e => e._id).HasConversion<ObjectId>();
+        });
+
+        var found = db.Entities.First(e => e._id == id);
+        Assert.Equal(id, found._id);
+    }
+
+    [Theory]
+    [InlineData(["507f1f77bcf86cd799439011"])]
+    [InlineData(["507f191e810c19729de860ea"])]
+    public void String_can_serialize_to_ObjectId_with_default_converter(string id)
+    {
+        var docs = tempDatabase.CreateTemporaryCollection<IdIsString>(
+            nameof(String_can_serialize_to_ObjectId_with_default_converter) + "_" + id);
+        var db = SingleEntityDbContext.Create(docs, mb =>
+        {
+            mb.Entity<IdIsString>().Property(e => e._id).HasConversion<ObjectId>();
+        });
+        var original = new IdIsString
+        {
+            _id = id
+        };
+        db.Entities.Add(original);
+        db.SaveChanges();
+
+        var found = GetCollection<IdIsObjectId>(docs.CollectionNamespace.CollectionName).AsQueryable().First();
+        Assert.Equal(original._id, found._id.ToString());
+    }
+
+    [Theory]
+    [InlineData(["507f1f77bcf86cd799439011"])]
+    [InlineData(["507f191e810c19729de860ea"])]
+    public void ObjectId_can_deserialize_from_string_with_default_converter(string id)
+    {
+        var docs = tempDatabase.CreateTemporaryCollection<IdIsString>(
+            nameof(ObjectId_can_deserialize_from_string_with_default_converter) + "_" + id);
+        docs.InsertOne(new IdIsString
+        {
+            _id = id
+        });
+
+        var collection = GetCollection<IdIsObjectId>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<IdIsObjectId>().Property(e => e._id).HasConversion<string>();
+        });
+
+        var found = db.Entities.First();
+        Assert.Equal(id, found._id.ToString());
+    }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -44,7 +44,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void ObjectId_can_deserialize_from_string()
     {
         var expectedId = ObjectId.GenerateNewId();
-        var expected = new IdIsString { _id = expectedId.ToString() };
+        var expected = new IdIsString
+        {
+            _id = expectedId.ToString()
+        };
         tempDatabase.CreateTemporaryCollection<IdIsString>().InsertOne(expected);
 
         var collection = GetCollection<IdIsObjectId>();
@@ -58,7 +61,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void ObjectId_can_query_against_string()
     {
         var expectedId = ObjectId.GenerateNewId();
-        var expected = new IdIsString { _id = expectedId.ToString() };
+        var expected = new IdIsString
+        {
+            _id = expectedId.ToString()
+        };
         tempDatabase.CreateTemporaryCollection<IdIsString>().InsertOne(expected);
 
         var collection = GetCollection<IdIsObjectId>();
@@ -91,7 +97,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [Fact]
     public void String_can_deserialize_from_ObjectId()
     {
-        var expected = new IdIsObjectId { _id = ObjectId.GenerateNewId() };
+        var expected = new IdIsObjectId
+        {
+            _id = ObjectId.GenerateNewId()
+        };
         tempDatabase.CreateTemporaryCollection<IdIsObjectId>().InsertOne(expected);
 
         var collection = GetCollection<IdIsString>();
@@ -104,7 +113,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [Fact]
     public void String_can_query_against_ObjectId()
     {
-        var expected = new IdIsObjectId { _id = ObjectId.GenerateNewId() };
+        var expected = new IdIsObjectId
+        {
+            _id = ObjectId.GenerateNewId()
+        };
         tempDatabase.CreateTemporaryCollection<IdIsObjectId>().InsertOne(expected);
 
         var collection = GetCollection<IdIsString>();
@@ -120,7 +132,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = tempDatabase.CreateTemporaryCollection<IdIsString>();
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
 
-        var original = new IdIsString { _id = ObjectId.GenerateNewId().ToString() };
+        var original = new IdIsString
+        {
+            _id = ObjectId.GenerateNewId().ToString()
+        };
         db.Entities.Add(original);
         db.SaveChanges();
 
@@ -149,7 +164,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([false])]
     public void Bool_can_deserialize_from_string(bool active)
     {
-        var expected = new ActiveIsString { active = active.ToString(), _id = ObjectId.GenerateNewId() };
+        var expected = new ActiveIsString
+        {
+            active = active.ToString(), _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<ActiveIsString>(nameof(Bool_can_deserialize_from_string) + "_" + active);
         docs.InsertOne(expected);
 
@@ -166,7 +184,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([false])]
     public void Bool_can_query_against_string(bool active)
     {
-        var expected = new ActiveIsString { active = active.ToString(), _id = ObjectId.GenerateNewId() };
+        var expected = new ActiveIsString
+        {
+            active = active.ToString(), _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<ActiveIsString>(nameof(Bool_can_query_against_string) + "_" + active);
         docs.InsertOne(expected);
 
@@ -186,7 +207,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = tempDatabase.CreateTemporaryCollection<ActiveIsBool>(nameof(Bool_can_serialize_to_string) + "_" + active);
         var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
 
-        var original = new ActiveIsBool { active = active };
+        var original = new ActiveIsBool
+        {
+            active = active
+        };
         db.Entities.Add(original);
         db.SaveChanges();
 
@@ -217,7 +241,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([0])]
     public void Int_can_deserialize_from_string(int days)
     {
-        var expected = new DaysIsString { days = days.ToString(), _id = ObjectId.GenerateNewId() };
+        var expected = new DaysIsString
+        {
+            days = days.ToString(), _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<DaysIsString>(nameof(Int_can_deserialize_from_string) + "_" + days);
         docs.InsertOne(expected);
 
@@ -235,7 +262,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([0])]
     public void Int_can_query_against_string(int days)
     {
-        var expected = new DaysIsString { days = days.ToString(), _id = ObjectId.GenerateNewId() };
+        var expected = new DaysIsString
+        {
+            days = days.ToString(), _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<DaysIsString>(nameof(Int_can_query_against_string) + "_" + days);
         docs.InsertOne(expected);
 
@@ -256,7 +286,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = tempDatabase.CreateTemporaryCollection<DaysIsInt>(nameof(Int_can_serialize_to_string) + "_" + days);
         var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
 
-        var original = new DaysIsInt { days = days };
+        var original = new DaysIsInt
+        {
+            days = days
+        };
         db.Entities.Add(original);
         db.SaveChanges();
 
@@ -282,7 +315,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([0])]
     public void TimeSpan_can_deserialize_from_int(int days)
     {
-        var expected = new DaysIsInt { days = days, _id = ObjectId.GenerateNewId() };
+        var expected = new DaysIsInt
+        {
+            days = days, _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<DaysIsInt>(nameof(TimeSpan_can_deserialize_from_int) + "_" + days);
         docs.InsertOne(expected);
 
@@ -300,7 +336,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([0])]
     public void TimeSpan_can_query_against_int(int days)
     {
-        var expected = new DaysIsInt { days = days, _id = ObjectId.GenerateNewId() };
+        var expected = new DaysIsInt
+        {
+            days = days, _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<DaysIsInt>(nameof(TimeSpan_can_query_against_int) + "_" + days);
         docs.InsertOne(expected);
 
@@ -321,7 +360,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = tempDatabase.CreateTemporaryCollection<DaysIsTimeSpan>(nameof(TimeSpan_can_serialize_to_int) + "_" + days);
         var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
 
-        var original = new DaysIsTimeSpan { days = TimeSpan.FromDays(days) };
+        var original = new DaysIsTimeSpan
+        {
+            days = TimeSpan.FromDays(days)
+        };
         db.Entities.Add(original);
         db.SaveChanges();
 
@@ -342,16 +384,44 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([0])]
     public void String_can_deserialize_from_int(int days)
     {
-        var expected = new DaysIsInt { days = days, _id = ObjectId.GenerateNewId() };
+        var expected = new DaysIsInt
+        {
+            days = days, _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<DaysIsInt>(nameof(String_can_deserialize_from_int) + "_" + days);
         docs.InsertOne(expected);
 
-        var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
+        var collection = GetCollection<DaysIsString>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
-        Assert.Equal(days, found.days);
+        Assert.Equal(days.ToString(), found.days);
+    }
+
+    [Theory]
+    [InlineData([1])]
+    [InlineData([-123])]
+    [InlineData([0])]
+    public void String_can_deserialize_from_int_with_default_converter(int days)
+    {
+        var expected = new DaysIsInt
+        {
+            days = days, _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<DaysIsInt>(nameof(String_can_deserialize_from_int_with_default_converter)
+                                                                     + "_" + days);
+        docs.InsertOne(expected);
+
+        var collection = GetCollection<DaysIsString>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<DaysIsString>().Property(d => d.days).HasConversion<int>();
+        });
+
+        var found = db.Entities.First();
+        Assert.Equal(expected._id, found._id);
+        Assert.Equal(days.ToString(), found.days);
     }
 
     [Theory]
@@ -360,16 +430,19 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData([0])]
     public void String_can_query_against_int(int days)
     {
-        var expected = new DaysIsInt { days = days, _id = ObjectId.GenerateNewId() };
+        var expected = new DaysIsInt
+        {
+            days = days, _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<DaysIsInt>(nameof(String_can_query_against_int) + "_" + days);
         docs.InsertOne(expected);
 
-        var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
+        var collection = GetCollection<DaysIsString>(docs.CollectionNamespace.CollectionName);
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
-        var found = db.Entities.First(e => e.days == days);
+        var found = db.Entities.First(e => e.days == days.ToString());
         Assert.Equal(expected._id, found._id);
-        Assert.Equal(days, found.days);
+        Assert.Equal(days.ToString(), found.days);
     }
 
     [Theory]
@@ -381,7 +454,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection = tempDatabase.CreateTemporaryCollection<DaysIsString>(nameof(String_can_serialize_to_int) + "_" + days);
         var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
-        var original = new DaysIsString { days = days.ToString() };
+        var original = new DaysIsString
+        {
+            days = days.ToString()
+        };
         db.Entities.Add(original);
         db.SaveChanges();
 
@@ -413,8 +489,12 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void Decimal_can_deserialize_from_Decimal128(string amountString)
     {
         var amount = decimal.Parse(amountString);
-        var expected = new AmountIsDecimal128 { amount = new Decimal128(amount), _id = ObjectId.GenerateNewId() };
-        var docs = tempDatabase.CreateTemporaryCollection<AmountIsDecimal128>(nameof(Decimal_can_deserialize_from_Decimal128) + "_" + amount);
+        var expected = new AmountIsDecimal128
+        {
+            amount = new Decimal128(amount), _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<AmountIsDecimal128>(nameof(Decimal_can_deserialize_from_Decimal128) + "_"
+            + amount);
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
@@ -432,8 +512,12 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void Decimal_can_query_against_Decimal128(string amountString)
     {
         var amount = decimal.Parse(amountString);
-        var expected = new AmountIsDecimal128 { amount = new Decimal128(amount), _id = ObjectId.GenerateNewId() };
-        var docs = tempDatabase.CreateTemporaryCollection<AmountIsDecimal128>(nameof(Decimal_can_query_against_Decimal128) + "_" + amount);
+        var expected = new AmountIsDecimal128
+        {
+            amount = new Decimal128(amount), _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<AmountIsDecimal128>(nameof(Decimal_can_query_against_Decimal128) + "_"
+            + amount);
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
@@ -451,10 +535,14 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void Decimal_can_serialize_to_Decimal128(string amountString)
     {
         var amount = decimal.Parse(amountString);
-        var collection = tempDatabase.CreateTemporaryCollection<AmountIsDecimal>(nameof(Decimal_can_serialize_to_Decimal128) + "_" + amount);
+        var collection =
+            tempDatabase.CreateTemporaryCollection<AmountIsDecimal>(nameof(Decimal_can_serialize_to_Decimal128) + "_" + amount);
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
 
-        var original = new AmountIsDecimal { amount = amount };
+        var original = new AmountIsDecimal
+        {
+            amount = amount
+        };
         db.Entities.Add(original);
         db.SaveChanges();
 
@@ -480,8 +568,12 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData(["0"])]
     public void Decimal_can_deserialize_from_string(string amount)
     {
-        var expected = new AmountIsString { amount = amount, _id = ObjectId.GenerateNewId() };
-        var docs = tempDatabase.CreateTemporaryCollection<AmountIsString>(nameof(Decimal_can_deserialize_from_string) + "_" + amount);
+        var expected = new AmountIsString
+        {
+            amount = amount, _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<AmountIsString>(
+            nameof(Decimal_can_deserialize_from_string) + "_" + amount);
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
@@ -498,7 +590,10 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData(["0"])]
     public void Decimal_can_query_against_string(string amount)
     {
-        var expected = new AmountIsString { amount = amount, _id = ObjectId.GenerateNewId() };
+        var expected = new AmountIsString
+        {
+            amount = amount, _id = ObjectId.GenerateNewId()
+        };
         var docs = tempDatabase.CreateTemporaryCollection<AmountIsString>(nameof(Decimal_can_query_against_string) + "_" + amount);
         docs.InsertOne(expected);
 
@@ -516,10 +611,14 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData(["0"])]
     public void Decimal_can_serialize_to_string(string amount)
     {
-        var collection = tempDatabase.CreateTemporaryCollection<AmountIsDecimal>(nameof(Decimal_can_serialize_to_string) + "_" + amount);
+        var collection =
+            tempDatabase.CreateTemporaryCollection<AmountIsDecimal>(nameof(Decimal_can_serialize_to_string) + "_" + amount);
         var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
 
-        var original = new AmountIsDecimal { amount = decimal.Parse(amount) };
+        var original = new AmountIsDecimal
+        {
+            amount = decimal.Parse(amount)
+        };
         db.Entities.Add(original);
         db.SaveChanges();
 
@@ -528,6 +627,70 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         Assert.Equal(amount, found.amount);
     }
 
-    IMongoCollection<T> GetCollection<T>([CallerMemberName]string? name = null)
+    IMongoCollection<T> GetCollection<T>([CallerMemberName] string? name = null)
         => tempDatabase.MongoDatabase.GetCollection<T>(name);
+
+    class AmountIsDouble : IdIsObjectId
+    {
+        public double amount { get; set; }
+    }
+
+    [Theory]
+    [InlineData([1.1234f])]
+    [InlineData([-123.213f])]
+    [InlineData([0f])]
+    public void Double_can_serialize_to_string_with_default_converter(double amount)
+    {
+        var collection =
+            tempDatabase.CreateTemporaryCollection<AmountIsDouble>(nameof(Double_can_serialize_to_string_with_default_converter)
+                                                                   + "_" + amount);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<AmountIsDouble>().Property(e => e.amount).HasConversion<string>();
+        });
+
+        var original = new AmountIsDouble
+        {
+            amount = amount
+        };
+        db.Entities.Add(original);
+        db.SaveChanges();
+
+        var found = GetCollection<AmountIsString>(collection.CollectionNamespace.CollectionName).AsQueryable().First();
+        Assert.Equal(original._id, found._id);
+        Assert.Equal(amount.ToString(), found.amount);
+    }
+
+    class AmountIsGuid : IdIsObjectId
+    {
+        public Guid amount { get; set; }
+    }
+
+    [Theory]
+    [InlineData(["6ec635e0-06e0-11ef-93e0-325096b39f47"])]
+    [InlineData(["380bb5de-fb71-4f6d-a349-2b83908ab43b"])]
+    [InlineData(["018f2ea7-a7a7-7c33-bd63-c6b1b1d5ecff"])]
+    [InlineData(["00000000-0000-0000-0000-000000000000"])]
+    public void Guid_can_serialize_to_string_with_default_converter(string amountString)
+    {
+        var amount = Guid.Parse(amountString);
+        var collection =
+            tempDatabase.CreateTemporaryCollection<AmountIsGuid>(nameof(Guid_can_serialize_to_string_with_default_converter) + "_"
+                + amountString);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<AmountIsGuid>().Property(e => e.amount).HasConversion<string>();
+        });
+
+        var original = new AmountIsGuid
+        {
+            amount = amount
+        };
+        db.Entities.Add(original);
+        db.SaveChanges();
+
+        var found = GetCollection<AmountIsString>(collection.CollectionNamespace.CollectionName).AsQueryable().First();
+        Assert.Equal(original._id, found._id);
+        Assert.Equal(amount.ToString(), found.amount);
+    }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -636,6 +636,56 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     }
 
     [Theory]
+    [InlineData(["1.1234"])]
+    [InlineData(["-123.213"])]
+    [InlineData(["0"])]
+    public void Double_can_deserialize_from_string_with_default_converter(string amount)
+    {
+        var expected = new AmountIsString
+        {
+            amount = amount, _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<AmountIsString>(
+            nameof(Double_can_deserialize_from_string_with_default_converter) + "_" + amount);
+        docs.InsertOne(expected);
+
+        var collection = GetCollection<AmountIsDouble>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<AmountIsDouble>().Property(e => e.amount).HasConversion<string>();
+        });
+
+        var found = db.Entities.First();
+        Assert.Equal(expected._id, found._id);
+        Assert.Equal(amount, found.amount.ToString());
+    }
+
+    [Theory]
+    [InlineData(["1.1234"])]
+    [InlineData(["-123.213"])]
+    [InlineData(["0"])]
+    public void Double_can_query_against_string_with_default_converter(string amount)
+    {
+        var expected = new AmountIsString
+        {
+            amount = amount, _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<AmountIsString>(
+            nameof(Double_can_query_against_string_with_default_converter) + "_" + amount);
+        docs.InsertOne(expected);
+
+        var collection = GetCollection<AmountIsDouble>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<AmountIsDouble>().Property(e => e.amount).HasConversion<string>();
+        });
+
+        var found = db.Entities.First(e => e.amount.ToString() == amount);
+        Assert.Equal(expected._id, found._id);
+        Assert.Equal(amount, found.amount.ToString());
+    }
+
+    [Theory]
     [InlineData([1.1234f])]
     [InlineData([-123.213f])]
     [InlineData([0f])]
@@ -664,6 +714,58 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     class AmountIsGuid : IdIsObjectId
     {
         public Guid amount { get; set; }
+    }
+
+    [Theory]
+    [InlineData(["6ec635e0-06e0-11ef-93e0-325096b39f47"])]
+    [InlineData(["380bb5de-fb71-4f6d-a349-2b83908ab43b"])]
+    [InlineData(["018f2ea7-a7a7-7c33-bd63-c6b1b1d5ecff"])]
+    [InlineData(["00000000-0000-0000-0000-000000000000"])]
+    public void Guid_can_deserialize_from_string_with_default_converter(string amount)
+    {
+        var expected = new AmountIsString
+        {
+            amount = amount, _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<AmountIsString>(
+            nameof(Guid_can_deserialize_from_string_with_default_converter) + "_" + amount);
+        docs.InsertOne(expected);
+
+        var collection = GetCollection<AmountIsGuid>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<AmountIsGuid>().Property(e => e.amount).HasConversion<string>();
+        });
+
+        var found = db.Entities.First();
+        Assert.Equal(expected._id, found._id);
+        Assert.Equal(amount, found.amount.ToString());
+    }
+
+    [Theory]
+    [InlineData(["6ec635e0-06e0-11ef-93e0-325096b39f47"])]
+    [InlineData(["380bb5de-fb71-4f6d-a349-2b83908ab43b"])]
+    [InlineData(["018f2ea7-a7a7-7c33-bd63-c6b1b1d5ecff"])]
+    [InlineData(["00000000-0000-0000-0000-000000000000"])]
+    public void Guid_can_query_against_string_with_default_converter(string amount)
+    {
+        var expected = new AmountIsString
+        {
+            amount = amount, _id = ObjectId.GenerateNewId()
+        };
+        var docs = tempDatabase.CreateTemporaryCollection<AmountIsString>(
+            nameof(Guid_can_query_against_string_with_default_converter) + "_" + amount);
+        docs.InsertOne(expected);
+
+        var collection = GetCollection<AmountIsGuid>(docs.CollectionNamespace.CollectionName);
+        var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<AmountIsGuid>().Property(e => e.amount).HasConversion<string>();
+        });
+
+        var found = db.Entities.First(e => e.amount.ToString() == amount);
+        Assert.Equal(expected._id, found._id);
+        Assert.Equal(amount, found.amount.ToString());
     }
 
     [Theory]


### PR DESCRIPTION
Just a few tests to make sure the default ones are detected.

Not all default converters might work - it will depend on what they do and whether the Mongo C# LINQ driver supports those expressions.