### PR TITLE
Prevent EF multiple service warnings in more tests

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestModels.ConferencePlanner;
 using Microsoft.Extensions.DependencyInjection;
@@ -72,6 +73,7 @@ public static class MongoDbContextOptionsExtensionsTest
         var options = new DbContextOptionsBuilder()
             .UseMongoDB(connectionString, databaseName)
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
             .Options;
 
         var context = new DbContext(options);
@@ -87,7 +89,8 @@ public static class MongoDbContextOptionsExtensionsTest
         var optionsBuilder = new DbContextOptionsBuilder()
             .UseMongoDB(
                 "mongodb://myDbUsr:NotActuallyAP%40ssw0rd@m0.example.com:27017,m2.example.com:27017,m2.example.com:27017/?authSource=admin",
-                "db");
+                "db")
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 
         var extension = optionsBuilder.Options.FindExtension<MongoOptionsExtension>();
         var logFragment = extension?.Info.LogFragment;

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConventionTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions.BsonAttributes;
@@ -67,7 +68,9 @@ public static class BsonDateTimeOptionsAttributeConventionTests
         public DbSet<DatesEntity> Dates { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseMongoDB("mongodb://localhost:27017", "UnitTests");
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class ModelBuilderSpecifiedDbContext : BaseDbContext

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions.BsonAttributes;
@@ -47,7 +48,9 @@ public static class BsonElementAttributeConventionTests
         public DbSet<Customer> Customers { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseMongoDB("mongodb://localhost:27017", "UnitTests");
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class ModelBuilderSpecifiedDbContext : BaseDbContext

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions.BsonAttributes;
@@ -53,7 +54,9 @@ public static class BsonIgnoreAttributeConventionTests
         public DbSet<Customer> Customers { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseMongoDB("mongodb://localhost:27017", "UnitTests");
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class ModelBuilderSpecifiedDbContext : BaseDbContext

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonRequiredAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonRequiredAttributeConventionTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions.BsonAttributes;
@@ -53,7 +54,9 @@ public static class BsonRequiredAttributeConventionTests
         public DbSet<Customer> Customers { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            => optionsBuilder.UseMongoDB("mongodb://localhost:27017", "UnitTests");
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class ModelBuilderSpecifiedDbContext : BaseDbContext

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionAttributeConventionTests.cs
@@ -1,19 +1,20 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions;
@@ -47,7 +48,8 @@ public static class CollectionAttributeConventionTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class ModelBuilderSpecifiedDbContext : BaseDbContext

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionNameFromDbSetConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionNameFromDbSetConventionTests.cs
@@ -1,19 +1,20 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions;
@@ -49,7 +50,8 @@ public static class CollectionNameFromDbSetConventionTests
     {
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class NamedCollectionsDbContext : BaseDbContext
@@ -62,6 +64,7 @@ public static class CollectionNameFromDbSetConventionTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
@@ -16,6 +16,7 @@
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions;
@@ -57,7 +58,8 @@ public static class ColumnAttributeConventionTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class ModelBuilderSpecifiedDbContext : BaseDbContext

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
@@ -1,19 +1,20 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions;
@@ -68,6 +69,7 @@ public static class PrimaryKeyDiscoveryConventionTests
     {
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/TableAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/TableAttributeConventionTests.cs
@@ -1,20 +1,21 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Metadata.Conventions;
@@ -51,7 +52,8 @@ public static class TableAttributeConventionTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     class ModelBuilderSpecifiedDbContext : BaseDbContext

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoCollectionExpressionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoCollectionExpressionTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
@@ -44,7 +45,8 @@ public static class MongoCollectionExpressionTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoQueryExpressionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoQueryExpressionTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 
@@ -34,7 +35,8 @@ public static class MongoQueryExpressionTests
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
-                .UseMongoDB("mongodb://localhost:27017", "UnitTests");
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
     }
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/TestUtilities/MongoTestHelpers.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/TestUtilities/MongoTestHelpers.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -31,5 +32,7 @@ public sealed class MongoTestHelpers : TestHelpers
         => services.AddEntityFrameworkMongoDB();
 
     public override DbContextOptionsBuilder UseProviderOptions(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseMongoDB("mongodb://localhost:27017", "UnitTests");
+        => optionsBuilder
+            .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
 }


### PR DESCRIPTION
Started getting some of the EF multiple service warnings as more tests were not using the SingleEntityContext helper.