### PR TITLE
Test clean-up

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Entities/Guides/GuidesDbContext.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Entities/Guides/GuidesDbContext.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
@@ -32,6 +33,7 @@ internal class GuidesDbContext(DbContextOptions options) : DbContext(options)
         bool sensitiveDataLogging = true) =>
         new(new DbContextOptionsBuilder<GuidesDbContext>()
             .UseMongoDB(database.Client, database.DatabaseNamespace.DatabaseName)
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
             .LogTo(l => logAction?.Invoke(l))
             .UseLoggerFactory(loggerFactory)
             .EnableSensitiveDataLogging(sensitiveDataLogging)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
@@ -23,13 +23,13 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests;
 [XUnitCollection(nameof(SampleGuidesFixture))]
 public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOutputHelper)
 {
-    private readonly string DbName = fixture.MongoDatabase.DatabaseNamespace.DatabaseName;
+    private readonly string _dbName = fixture.MongoDatabase.DatabaseNamespace.DatabaseName;
 
     [Fact]
     public void Query_writes_log_via_LogTo_with_mql_when_sensitive_logging()
     {
         List<string> logs = [];
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -40,14 +40,14 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         Assert.NotEmpty(items);
         Assert.Contains(logs, l => l.Contains("Executed MQL query"));
         Assert.Contains(logs,
-            l => l.Contains(DbName + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : { \"$gt\" : 1900 } } }])"));
+            l => l.Contains(_dbName + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : { \"$gt\" : 1900 } } }])"));
     }
 
     [Fact]
     public void First_writes_log_via_LogTo_with_mql_when_sensitive_logging()
     {
         List<string> logs = [];
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -58,7 +58,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         Assert.NotNull(item);
         Assert.Contains(logs, l => l.Contains("Executed MQL query"));
         Assert.Contains(logs,
-            l => l.Contains(DbName
+            l => l.Contains(_dbName
                             + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : { \"$gt\" : 1900 } } }, { \"$limit\" : NumberLong(1) }])"));
     }
 
@@ -66,7 +66,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void Single_writes_log_via_LogTo_with_mql_when_sensitive_logging()
     {
         List<string> logs = [];
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -77,7 +77,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         Assert.NotNull(item);
         Assert.Contains(logs, l => l.Contains("Executed MQL query"));
         Assert.Contains(logs,
-            l => l.Contains(DbName
+            l => l.Contains(_dbName
                             + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : 1949 } }, { \"$limit\" : NumberLong(2) }])"));
     }
 
@@ -85,7 +85,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void Query_writes_log_via_LogTo_without_mql_when_no_sensitive_logging()
     {
         List<string> logs = [];
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -95,7 +95,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.NotEmpty(items);
         Assert.Contains(logs, l => l.Contains("Executed MQL query"));
-        Assert.Contains(logs, l => l.Contains($"{DbName}.moons.aggregate([?])"));
+        Assert.Contains(logs, l => l.Contains($"{_dbName}.moons.aggregate([?])"));
         Assert.DoesNotContain(logs, l => l.Contains("yearOfDiscovery"));
     }
 
@@ -103,7 +103,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void First_writes_log_via_LogTo_without_mql_when_no_sensitive_logging()
     {
         List<string> logs = [];
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -113,7 +113,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.NotNull(item);
         Assert.Contains(logs, l => l.Contains("Executed MQL query"));
-        Assert.Contains(logs, l => l.Contains($"{DbName}.moons.aggregate([?])"));
+        Assert.Contains(logs, l => l.Contains($"{_dbName}.moons.aggregate([?])"));
         Assert.DoesNotContain(logs, l => l.Contains("yearOfDiscovery"));
     }
 
@@ -121,7 +121,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void Single_writes_log_via_LogTo_without_mql_when_no_sensitive_logging()
     {
         List<string> logs = [];
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -131,7 +131,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.NotNull(item);
         Assert.Contains(logs, l => l.Contains("Executed MQL query"));
-        Assert.Contains(logs, l => l.Contains($"{DbName}.moons.aggregate([?])"));
+        Assert.Contains(logs, l => l.Contains($"{_dbName}.moons.aggregate([?])"));
         Assert.DoesNotContain(logs, l => l.Contains("yearOfDiscovery"));
     }
 
@@ -139,7 +139,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void Query_writes_event_via_LoggerFactory_with_mql_when_sensitive_logging()
     {
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
 
         var items = db.Moons.Where(m => m.yearOfDiscovery > 1900).ToArray();
 
@@ -153,7 +153,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         ).message;
 
         Assert.Contains("Executed MQL query", message);
-        Assert.Contains(DbName + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : { \"$gt\" : 1900 } } }])",
+        Assert.Contains(_dbName + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : { \"$gt\" : 1900 } } }])",
             message);
     }
 
@@ -162,7 +162,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void First_writes_event_via_LoggerFactory_with_mql_when_sensitive_logging()
     {
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
 
         var item = db.Moons.First(m => m.yearOfDiscovery > 1900);
 
@@ -177,7 +177,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.Contains("Executed MQL query", message);
         Assert.Contains(
-            DbName
+            _dbName
             + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : { \"$gt\" : 1900 } } }, { \"$limit\" : NumberLong(1) }])",
             message);
     }
@@ -186,7 +186,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void Single_writes_event_via_LoggerFactory_with_mql_when_sensitive_logging()
     {
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory);
 
         var item = db.Moons.Single(m => m.yearOfDiscovery == 1949);
 
@@ -201,7 +201,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
 
         Assert.Contains("Executed MQL query", message);
         Assert.Contains(
-            DbName + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : 1949 } }, { \"$limit\" : NumberLong(2) }])",
+            _dbName + ".moons.aggregate([{ \"$match\" : { \"yearOfDiscovery\" : 1949 } }, { \"$limit\" : NumberLong(2) }])",
             message);
     }
 
@@ -209,7 +209,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void Query_writes_event_via_LoggerFactory_without_mql_when_no_sensitive_logging()
     {
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
 
         var items = db.Moons.Where(m => m.yearOfDiscovery > 1900).ToArray();
 
@@ -223,7 +223,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         ).message;
 
         Assert.Contains("Executed MQL query", message);
-        Assert.Contains($"{DbName}.moons.aggregate([?])", message);
+        Assert.Contains($"{_dbName}.moons.aggregate([?])", message);
         Assert.DoesNotContain("yearOfDiscovery", message);
     }
 
@@ -231,7 +231,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void First_writes_event_via_LoggerFactory_without_mql_when_no_sensitive_logging()
     {
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
 
         var item = db.Moons.FirstOrDefault(m => m.yearOfDiscovery > 1900);
 
@@ -245,7 +245,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         ).message;
 
         Assert.Contains("Executed MQL query", message);
-        Assert.Contains($"{DbName}.moons.aggregate([?])", message);
+        Assert.Contains($"{_dbName}.moons.aggregate([?])", message);
         Assert.DoesNotContain("yearOfDiscovery", message);
     }
 
@@ -253,7 +253,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     public void Single_writes_event_via_LoggerFactory_without_mql_when_no_sensitive_logging()
     {
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
-        var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
+        using var db = GuidesDbContext.Create(fixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
 
         var item = db.Moons.SingleOrDefault(m => m.yearOfDiscovery > 1900);
 
@@ -267,7 +267,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         ).message;
 
         Assert.Contains("Executed MQL query", message);
-        Assert.Contains($"{DbName}.moons.aggregate([?])", message);
+        Assert.Contains($"{_dbName}.moons.aggregate([?])", message);
         Assert.DoesNotContain("yearOfDiscovery", message);
     }
 
@@ -277,7 +277,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         List<string> logs = [];
 
         using var guidesFixture = new SampleGuidesFixture();
-        var db = GuidesDbContext.Create(guidesFixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(guidesFixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -309,7 +309,7 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
         var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
 
         using var guidesFixture = new SampleGuidesFixture();
-        var db = GuidesDbContext.Create(guidesFixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
+        using var db = GuidesDbContext.Create(guidesFixture.MongoDatabase, null, loggerFactory, sensitiveDataLogging: false);
 
         db.Planets.RemoveRange(db.Planets.Where(m => m.name.StartsWith("M")));
         foreach (var planet in db.Planets.Where(m => m.hasRings))

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
@@ -118,7 +118,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aGuid = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -136,7 +136,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aString = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -154,7 +154,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt16 = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -171,7 +171,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt16 = 0
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -189,7 +189,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt16 = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -207,7 +207,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt32 = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -224,7 +224,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt32 = 0
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -242,7 +242,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt32 = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -260,7 +260,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt64 = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -277,7 +277,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt64 = 0
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -295,7 +295,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), anInt64 = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -313,7 +313,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aByte = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -331,7 +331,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aChar = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -352,7 +352,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aDecimal = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -369,7 +369,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aDecimal = 0m
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -390,7 +390,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aDecimal = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -408,7 +408,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aSingle = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -425,7 +425,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aSingle = 0
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -443,7 +443,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aSingle = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -461,7 +461,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aDouble = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -478,7 +478,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aDouble = 0
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -496,7 +496,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aDouble = expected
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -512,7 +512,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aList = []
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -532,7 +532,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aList = expected
         };
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         db.Entities.Add(item);
         db.SaveChanges();
 
@@ -550,7 +550,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aList = []
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
@@ -570,7 +570,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), aList = expected
         };
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         db.Entities.Add(item);
         db.SaveChanges();
 
@@ -677,7 +677,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             _id = ObjectId.GenerateNewId(), Value = value
         });
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
@@ -50,7 +50,7 @@ public class DiscriminatorTests(TemporaryDatabaseFixture tempDatabase)
     public void Discriminators_throw_not_supported_if_configured()
     {
         var collection = tempDatabase.CreateTemporaryCollection<Vehicle>();
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<Vehicle>().HasDiscriminator(v => v.VehicleType);
         });

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ElementNameTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ElementNameTests.cs
@@ -72,7 +72,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
             dbContext.Entities.Add(new RenamedKeyElement {PrimaryKey = id, Name = expectedName});
             dbContext.SaveChanges();
         }
@@ -86,7 +86,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             // Find with EF
-            var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
             var found = dbContext.Entities.Single(f => f.PrimaryKey == id);
             Assert.Equal(expectedName, found.Name);
         }
@@ -108,7 +108,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
             dbContext.Entities.Add(
                 new RenamedNonKeyElements {_id = id, FirstName = expectedFirstName, LastName = expectedLastName});
             dbContext.SaveChanges();
@@ -124,7 +124,7 @@ public class ElementNameTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             // Find with EF
-            var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
             var found = dbContext.Entities.Single(f => f._id == id);
             Assert.Equal(expectedFirstName, found.FirstName);
             Assert.Equal(expectedLastName, found.LastName);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -51,7 +51,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         tempDatabase.CreateTemporaryCollection<IdIsString>().InsertOne(expected);
 
         var collection = GetCollection<IdIsObjectId>();
-        var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
 
         var found = db.Entities.First();
         Assert.Equal(expectedId, found._id);
@@ -68,7 +68,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         tempDatabase.CreateTemporaryCollection<IdIsString>().InsertOne(expected);
 
         var collection = GetCollection<IdIsObjectId>();
-        var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
 
         var found = db.Entities.First(e => e._id == expectedId);
         Assert.Equal(expectedId, found._id);
@@ -78,7 +78,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void ObjectId_can_serialize_to_string()
     {
         var collection = tempDatabase.CreateTemporaryCollection<IdIsObjectId>();
-        var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrObjectIdToMongoString);
 
         var original = new IdIsObjectId();
         db.Entities.Add(original);
@@ -104,7 +104,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         tempDatabase.CreateTemporaryCollection<IdIsObjectId>().InsertOne(expected);
 
         var collection = GetCollection<IdIsString>();
-        var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
+        using var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id.ToString(), found._id);
@@ -120,7 +120,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         tempDatabase.CreateTemporaryCollection<IdIsObjectId>().InsertOne(expected);
 
         var collection = GetCollection<IdIsString>();
-        var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
+        using var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
 
         var found = db.Entities.First(e => e._id == expected._id.ToString());
         Assert.Equal(expected._id.ToString(), found._id);
@@ -130,7 +130,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void String_can_serialize_to_ObjectId()
     {
         var collection = tempDatabase.CreateTemporaryCollection<IdIsString>();
-        var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
+        using var db = SingleEntityDbContext.Create(collection, ClrStringToMongoObjectId);
 
         var original = new IdIsString
         {
@@ -172,7 +172,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<ActiveIsBool>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
@@ -192,7 +192,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<ActiveIsBool>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
 
         var found = db.Entities.First(e => e.active == active);
         Assert.Equal(expected._id, found._id);
@@ -205,7 +205,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void Bool_can_serialize_to_string(bool active)
     {
         var collection = tempDatabase.CreateTemporaryCollection<ActiveIsBool>(nameof(Bool_can_serialize_to_string) + "_" + active);
-        var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrBoolToMongoString);
 
         var original = new ActiveIsBool
         {
@@ -249,7 +249,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
@@ -270,7 +270,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
 
         var found = db.Entities.First(e => e.days == days);
         Assert.Equal(expected._id, found._id);
@@ -284,7 +284,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void Int_can_serialize_to_string(int days)
     {
         var collection = tempDatabase.CreateTemporaryCollection<DaysIsInt>(nameof(Int_can_serialize_to_string) + "_" + days);
-        var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
+        using var db = SingleEntityDbContext.Create(collection, ClrIntToMongoString);
 
         var original = new DaysIsInt
         {
@@ -323,7 +323,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<DaysIsTimeSpan>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
+        using var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
@@ -344,7 +344,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<DaysIsInt>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
+        using var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
 
         var found = db.Entities.First(e => e.days == days);
         Assert.Equal(expected._id, found._id);
@@ -358,7 +358,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void TimeSpan_can_serialize_to_int(int days)
     {
         var collection = tempDatabase.CreateTemporaryCollection<DaysIsTimeSpan>(nameof(TimeSpan_can_serialize_to_int) + "_" + days);
-        var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
+        using var db = SingleEntityDbContext.Create(collection, ClrTimeSpanToMongoInt);
 
         var original = new DaysIsTimeSpan
         {
@@ -392,7 +392,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<DaysIsString>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
+        using var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
@@ -414,7 +414,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<DaysIsString>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<DaysIsString>().Property(d => d.days).HasConversion<int>();
         });
@@ -438,7 +438,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<DaysIsString>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
+        using var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
         var found = db.Entities.First(e => e.days == days.ToString());
         Assert.Equal(expected._id, found._id);
@@ -452,7 +452,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     public void String_can_serialize_to_int(int days)
     {
         var collection = tempDatabase.CreateTemporaryCollection<DaysIsString>(nameof(String_can_serialize_to_int) + "_" + days);
-        var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
+        using var db = SingleEntityDbContext.Create(collection, ClrStringToMongoInt);
 
         var original = new DaysIsString
         {
@@ -498,7 +498,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
+        using var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
@@ -521,7 +521,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
+        using var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
 
         var found = db.Entities.First(e => e.amount == amount);
         Assert.Equal(expected._id, found._id);
@@ -537,7 +537,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var amount = decimal.Parse(amountString);
         var collection =
             tempDatabase.CreateTemporaryCollection<AmountIsDecimal>(nameof(Decimal_can_serialize_to_Decimal128) + "_" + amount);
-        var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
+        using var db = SingleEntityDbContext.Create(collection, ClrDecimalToMongoDecimal128);
 
         var original = new AmountIsDecimal
         {
@@ -577,7 +577,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
+        using var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
 
         var found = db.Entities.First();
         Assert.Equal(expected._id, found._id);
@@ -598,7 +598,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDecimal>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
+        using var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
 
         var found = db.Entities.First(e => e.amount == decimal.Parse(amount));
         Assert.Equal(expected._id, found._id);
@@ -613,7 +613,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     {
         var collection =
             tempDatabase.CreateTemporaryCollection<AmountIsDecimal>(nameof(Decimal_can_serialize_to_string) + "_" + amount);
-        var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
+        using var db = SingleEntityDbContext.Create(collection, ClrDecimalToString);
 
         var original = new AmountIsDecimal
         {
@@ -650,7 +650,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDouble>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<AmountIsDouble>().Property(e => e.amount).HasConversion<string>();
         });
@@ -675,7 +675,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsDouble>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<AmountIsDouble>().Property(e => e.amount).HasConversion<string>();
         });
@@ -694,7 +694,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection =
             tempDatabase.CreateTemporaryCollection<AmountIsDouble>(nameof(Double_can_serialize_to_string_default)
                                                                    + "_" + amount);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<AmountIsDouble>().Property(e => e.amount).HasConversion<string>();
         });
@@ -732,7 +732,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsGuid>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<AmountIsGuid>().Property(e => e.amount).HasConversion<string>();
         });
@@ -758,7 +758,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         docs.InsertOne(expected);
 
         var collection = GetCollection<AmountIsGuid>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<AmountIsGuid>().Property(e => e.amount).HasConversion<string>();
         });
@@ -779,7 +779,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         var collection =
             tempDatabase.CreateTemporaryCollection<AmountIsGuid>(nameof(Guid_can_serialize_to_string_default) + "_"
                 + amountString.Substring(6));
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<AmountIsGuid>().Property(e => e.amount).HasConversion<string>();
         });
@@ -809,7 +809,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var collection = GetCollection<IdIsString>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<IdIsString>().Property(e => e._id).HasConversion<ObjectId>();
         });
@@ -831,7 +831,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var collection = GetCollection<IdIsString>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<IdIsString>().Property(e => e._id).HasConversion<ObjectId>();
         });
@@ -847,7 +847,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
     {
         var docs = tempDatabase.CreateTemporaryCollection<IdIsString>(
             nameof(String_can_serialize_to_ObjectId_default) + "_" + id.Substring(6));
-        var db = SingleEntityDbContext.Create(docs, mb =>
+        using var db = SingleEntityDbContext.Create(docs, mb =>
         {
             mb.Entity<IdIsString>().Property(e => e._id).HasConversion<ObjectId>();
         });
@@ -875,7 +875,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         });
 
         var collection = GetCollection<IdIsObjectId>(docs.CollectionNamespace.CollectionName);
-        var db = SingleEntityDbContext.Create(collection, mb =>
+        using var db = SingleEntityDbContext.Create(collection, mb =>
         {
             mb.Entity<IdIsObjectId>().Property(e => e._id).HasConversion<string>();
         });

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
@@ -71,13 +71,13 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
         var location = new Geolocation(1.1, 2.2);
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new OwnedEntityRemappingEntity
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new OwnedEntityRemappingEntity
             {
                 _id = id,
                 Location = location
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -96,12 +96,12 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
         const string name = "The quick brown fox";
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new NonKeyRemappingEntity
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new NonKeyRemappingEntity
             {
                 _id = id, RemapThisToName = name
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -120,12 +120,12 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
         const string name = "The quick brown fox";
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new KeyRemappingEntity
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new KeyRemappingEntity
             {
                 _id = id, name = name
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -144,16 +144,16 @@ public class BsonElementAttributeConventionTests(TemporaryDatabaseFixture tempDa
         const string name = "The quick brown fox";
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var entity = new KeyRemappingEntity
             {
                 _id = id, name = name
             };
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
 
-            dbContext.Entities.Remove(entity);
-            dbContext.SaveChanges();
+            db.Entities.Remove(entity);
+            db.SaveChanges();
         }
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
@@ -56,12 +56,12 @@ public class BsonIgnoreAttributeConventionTests(TemporaryDatabaseFixture tempDat
         const string name = "The quick brown fox";
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new IgnoredPropertiesEntity
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new IgnoredPropertiesEntity
             {
                 _id = id, KeepMe = name, IgnoreMe = "a", AndMe = true
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
@@ -83,12 +83,12 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
         var location = new Geolocation(1.1, 2.2);
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new OwnedEntityRemappingEntity
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new OwnedEntityRemappingEntity
             {
                 _id = id, Location = location
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -108,12 +108,12 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
         var name = "The quick brown fox";
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new NonKeyRemappingEntity
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new NonKeyRemappingEntity
             {
                 _id = id, RemapThisToName = name
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -132,12 +132,12 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
         var name = "The quick brown fox";
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new KeyRemappingEntity
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new KeyRemappingEntity
             {
                 _id = id, name = name
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -156,16 +156,16 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
         var name = "The quick brown fox";
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var entity = new KeyRemappingEntity
             {
                 _id = id, name = name
             };
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
 
-            dbContext.Entities.Remove(entity);
-            dbContext.SaveChanges();
+            db.Entities.Remove(entity);
+            db.SaveChanges();
         }
 
         {
@@ -179,9 +179,9 @@ public class ColumnAttributeConventionTests : IClassFixture<TemporaryDatabaseFix
     {
         var collection = _tempDatabase.CreateTemporaryCollection<TypeNameSpecifyingEntity>();
 
-        var dbContext = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
-        var ex = Assert.Throws<NotSupportedException>(() => dbContext.Entities.FirstOrDefault());
+        var ex = Assert.Throws<NotSupportedException>(() => db.Entities.FirstOrDefault());
         Assert.Contains(nameof(ColumnAttribute.TypeName), ex.Message);
         Assert.Contains(nameof(TypeNameSpecifyingEntity), ex.Message);
         Assert.Contains(nameof(TypeNameSpecifyingEntity.TypeNameNotPermitted), ex.Message);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
@@ -71,9 +71,9 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         var name = Guid.NewGuid().ToString();
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new UnderscoreIdNamedProperty {_id = id, name = name});
-            dbContext.SaveChanges();
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new UnderscoreIdNamedProperty {_id = id, name = name});
+            db.SaveChanges();
         }
 
         {
@@ -86,8 +86,8 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
 
         {
             // Find with EF
-            var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entities.Single(f => f._id == id);
+            using var db = SingleEntityDbContext.Create(collection);
+            var found = db.Entities.Single(f => f._id == id);
             Assert.Equal(name, found.name);
         }
     }
@@ -101,9 +101,9 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         var name = Guid.NewGuid().ToString();
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new IdNamedProperty {Id = id, name = name});
-            dbContext.SaveChanges();
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new IdNamedProperty {Id = id, name = name});
+            db.SaveChanges();
         }
 
         {
@@ -115,8 +115,8 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
 
         {
             // Find with EF
-            var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entities.Single(f => f.Id == id);
+            using var db = SingleEntityDbContext.Create(collection);
+            var found = db.Entities.Single(f => f.Id == id);
             Assert.Equal(name, found.name);
         }
     }
@@ -130,10 +130,10 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         var name = Guid.NewGuid().ToString();
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var entity = new ColumnAttributedIdProperty {MyPrimaryKey = id, name = name};
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
         }
 
         {
@@ -146,8 +146,8 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
 
         {
             // Find with EF
-            var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entities.Single(f => f.MyPrimaryKey == id);
+            using var db = SingleEntityDbContext.Create(collection);
+            var found = db.Entities.Single(f => f.MyPrimaryKey == id);
             Assert.Equal(name, found.name);
         }
     }
@@ -161,10 +161,10 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
         var name = Guid.NewGuid().ToString();
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var entity = new Product {ProductId = id, name = name};
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
         }
 
         {
@@ -176,8 +176,8 @@ public class MongoPrimaryKeyDiscoveryConventionTests : IClassFixture<TemporaryDa
 
         {
             // Find with EF
-            var dbContext = SingleEntityDbContext.Create(collection);
-            var found = dbContext.Entities.Single(f => f.ProductId == id);
+            using var db = SingleEntityDbContext.Create(collection);
+            var found = db.Entities.Single(f => f.ProductId == id);
             Assert.Equal(name, found.name);
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CollectionsResponseTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CollectionsResponseTests.cs
@@ -4,7 +4,7 @@ using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
 [XUnitCollection(nameof(SampleGuidesFixture))]
-public class CollectionsResponseTests
+public class CollectionsResponseTests : IDisposable, IAsyncDisposable
 {
     private readonly GuidesDbContext _db;
 
@@ -40,4 +40,10 @@ public class CollectionsResponseTests
         var result = await _db.Planets.ToArrayAsync();
         Assert.Equal(8, result.Length);
     }
+    
+    public void Dispose()
+        => _db.Dispose();
+
+    public async ValueTask DisposeAsync()
+        => await _db.DisposeAsync();
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CompositeKeyQueryTests.cs
@@ -31,9 +31,9 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Should_query_by_key_component()
     {
-        var dbContext = CreateContext();
+        using var db = CreateContext();
 
-        var result = dbContext.Entities.Where(e => e.Key1 == "two").ToList();
+        var result = db.Entities.Where(e => e.Key1 == "two").ToList();
 
         Assert.Equal(2, result.Count);
         Assert.All(result, e => Assert.Equal("two", e.Key1));
@@ -42,9 +42,9 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Should_query_by_key_components()
     {
-        var dbContext = CreateContext();
+        using var db = CreateContext();
 
-        var result = dbContext.Entities.Where(e => e.Key1 == "two" && e.Key2 == 3).ToList();
+        var result = db.Entities.Where(e => e.Key1 == "two" && e.Key2 == 3).ToList();
 
         Assert.Single(result);
         Assert.All(result, e => Assert.Equal("two", e.Key1));
@@ -54,9 +54,9 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Should_query_by_key_component_with_gt()
     {
-        var dbContext = CreateContext();
+        using var db = CreateContext();
 
-        var result = dbContext.Entities.Where(e => e.Key2 > 2).ToList();
+        var result = db.Entities.Where(e => e.Key2 > 2).ToList();
 
         Assert.Single(result);
         Assert.All(result, e => Assert.True(e.Key2 > 2));
@@ -67,8 +67,8 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _temporaryDatabase.CreateTemporaryCollection<Entity>(name);
 
         {
-            var context = SingleEntityDbContext.Create(collection, ConfigureContext);
-            context.Entities.AddRange(
+            using var db = SingleEntityDbContext.Create(collection, ConfigureContext);
+            db.Entities.AddRange(
             [
                 new Entity
                 {
@@ -84,7 +84,7 @@ public class CompositeKeyQueryTests : IClassFixture<TemporaryDatabaseFixture>
                 }
             ]);
 
-            context.SaveChanges();
+            db.SaveChanges();
         }
 
         return SingleEntityDbContext.Create(collection, ConfigureContext);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FirstSingleTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FirstSingleTests.cs
@@ -19,7 +19,7 @@ using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
 [XUnitCollection(nameof(SampleGuidesFixture))]
-public class FirstSingleTests
+public class FirstSingleTests : IDisposable, IAsyncDisposable
 {
     private readonly GuidesDbContext _db;
 
@@ -111,4 +111,10 @@ public class FirstSingleTests
         var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.Single(p => p.orderFromSun > 5));
         Assert.Equal("Sequence contains more than one element", ex.Message);
     }
+    
+    public void Dispose()
+        => _db.Dispose();
+
+    public async ValueTask DisposeAsync()
+        => await _db.DisposeAsync();
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/InvalidQueryTranslationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/InvalidQueryTranslationTests.cs
@@ -36,7 +36,7 @@ public class InvalidQueryTranslationTests : IClassFixture<TemporaryDatabaseFixtu
     [Fact]
     public void ExecuteDelete_throws_invalid_operation_exception()
     {
-        var db = SingleEntityDbContext.Create(_tempDatabase.CreateTemporaryCollection<SimpleEntity>());
+        using var db = SingleEntityDbContext.Create(_tempDatabase.CreateTemporaryCollection<SimpleEntity>());
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.ExecuteDelete());
         Assert.Contains("ExecuteDelete", ex.Message);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -32,7 +32,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.Single();
 
@@ -52,7 +52,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         ]);
 
         var collection = _tempDatabase.MongoDatabase.GetCollection<PersonWithOptionalLocation>("personNoLocation");
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var person = db.Entities.First();
         Assert.NotNull(person);
@@ -65,7 +65,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First(e => e.location.latitude > 0.00m);
 
@@ -79,7 +79,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
         collection.WriteTestDocs(PersonWithCity1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First(e => e.location.city.name == "San Diego");
 
@@ -93,7 +93,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithMissingLocation1);
-        var db = SingleEntityDbContext.Create(collection,
+        using var db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(false); });
 
         var actual = db.Entities.Where(p => p.name == "Elizabeth").ToList();
@@ -108,7 +108,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithMissingLocation1);
-        var db = SingleEntityDbContext.Create(collection,
+        using var db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(); });
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.Where(p => p.name != "bob").ToList());
@@ -121,7 +121,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.Where(p => p.name != "bob").ToList();
 
@@ -146,13 +146,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
             };
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             db.Entities.Add(expected);
             db.SaveChanges();
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var actual = db.Entities.First(p => p.name == "Charlie");
 
             Assert.Equal(expected.name, actual.name);
@@ -186,13 +186,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             db.Entities.Add(expected);
             db.SaveChanges();
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var actual = db.Entities.First(p => p.name == "Alfred");
 
             Assert.Equal(expected.name, actual.name);
@@ -235,7 +235,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
                 children = []
             }
         ]);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First();
         Assert.Empty(actual.children);
@@ -251,7 +251,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
                 children = []
             }
         ]);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First();
         Assert.NotNull(actual.children);
@@ -268,7 +268,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
                 children = null
             }
         ]);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First();
         Assert.Null(actual.children);
@@ -284,7 +284,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
                 children = null
             }
         ]);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First();
         Assert.Null(actual.children);
@@ -295,7 +295,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<MissingNullableCollection>();
         collection.WriteTestDocs([new MissingNullableCollection()]);
-        var db = SingleEntityDbContext.Create<MissingNullableCollection, SimpleNullableCollection>(collection);
+        using var db = SingleEntityDbContext.Create<MissingNullableCollection, SimpleNullableCollection>(collection);
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.First());
         Assert.Contains(nameof(SimpleNullableCollection.children), ex.Message);
@@ -306,7 +306,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<MissingNullableCollection>();
         collection.WriteTestDocs([new MissingNullableCollection()]);
-        var db = SingleEntityDbContext.Create<MissingNullableCollection, SimpleNullableCollection>(collection);
+        using var db = SingleEntityDbContext.Create<MissingNullableCollection, SimpleNullableCollection>(collection);
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.First());
         Assert.Contains(nameof(SimpleNullableCollection.children), ex.Message);
@@ -317,7 +317,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
         collection.WriteTestDocs(PersonWithCity1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.Single();
 
@@ -332,7 +332,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
         collection.WriteTestDocs(PersonWithCity1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.Where(p => p.name != "bob").ToList();
 
@@ -349,7 +349,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
         collection.WriteTestDocs(PersonWithLocations1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.Where(p => p.name != "bob").ToList();
 
@@ -419,13 +419,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             db.Entities.Add(entity);
             db.SaveChanges();
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var actual = db.Entities.FirstOrDefault();
 
             Assert.NotNull(actual);
@@ -440,7 +440,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     public void OwnedEntity_with_ienumerable_non_list_or_array_throws()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithIEnumerableLocations>();
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var entity = new PersonWithIEnumerableLocations
         {
@@ -463,7 +463,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
 
             var original = new PersonWithMultipleLocations
             {
@@ -492,7 +492,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
 
             var found = db.Entities.Single();
             Assert.Equal(2, found.locations.Count);
@@ -507,7 +507,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var found = db.Entities.Single();
 
             Assert.Empty(found.locations);
@@ -520,7 +520,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithTwoLocations>();
         var expected = PersonWithTwoLocations1[0];
         collection.WriteTestDocs(PersonWithTwoLocations1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.FirstOrDefault();
 
@@ -542,13 +542,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             db.Entities.Add(expected);
             db.SaveChanges();
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var actual = db.Entities.FirstOrDefault();
 
             Assert.NotNull(actual);
@@ -566,7 +566,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         var expected = PersonWithLocation1[0];
         collection.WriteTestDocs(PersonWithLocation1);
-        var db = SingleEntityDbContext.Create(collection,
+        using var db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().OwnsOne(p => p.location, r => r.HasElementName("location")); });
 
         var actual = db.Entities.First(e => e.location.latitude == expected.location.latitude);
@@ -581,7 +581,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var expected = PersonWithLocations1[0];
         collection.WriteTestDocs(PersonWithLocations1);
 
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First(e => e.locations.Any(l => l.latitude == expected.locations[0].latitude));
 
@@ -593,7 +593,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
         collection.WriteTestDocs(PersonWithLocations1);
-        var db = SingleEntityDbContext.Create(collection);
+        using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.First(e => e.locations.Any(l => l.latitude == 40.1m && l.longitude != 0m));
 
@@ -609,7 +609,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         var expected = PersonWithLocation1[0];
         collection.WriteTestDocs(PersonWithLocation1);
-        var db = SingleEntityDbContext.Create(collection,
+        using var db = SingleEntityDbContext.Create(collection,
             mb => { mb.Entity<PersonWithLocation>().OwnsOne(p => p.location, r => r.HasElementName("location")); });
 
         var actual = db.Entities.FirstOrDefault();
@@ -627,13 +627,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<FirstLevel>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             db.Entities.Add(FirstLevel1);
             db.SaveChanges();
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var actual = db.Entities.FirstOrDefault();
 
             Assert.NotNull(actual);
@@ -651,13 +651,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<FirstLevel>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             db.Entities.Add(FirstLevel1);
             db.SaveChanges();
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var actual = db.Entities.FirstOrDefault(e => e.children.Any(f => f.children.Any(g => g.name == expectedName)));
 
             Assert.NotNull(actual);
@@ -675,13 +675,13 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<FirstLevel>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             db.Entities.Add(FirstLevel1);
             db.SaveChanges();
         }
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var actual = db.Entities.FirstOrDefault(e
                 => e.children.Any(f => f.children.Any(g => g.reference.name == expectedReference.name)));
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -77,20 +77,20 @@ public class ProjectionTests
     public void Select_projection_to_constructor_initializer()
     {
         var results = _planets.Select(p => new NamedContainer<Planet> {Name = p.name, Item = p});
-        Assert.All(results, r => { Assert.Equal(r.Name, r?.Item?.name); });
+        Assert.All(results, r => { Assert.Equal(r.Name, r.Item?.name); });
     }
 
     [Fact(Skip = "Requires Select projection rewriting")]
     public void Select_projection_to_constructor_params()
     {
         var results = _planets.Select(p => new NamedContainer<Planet>(p, p.name));
-        Assert.All(results, r => { Assert.Equal(r.Name, r?.Item?.name); });
+        Assert.All(results, r => { Assert.Equal(r.Name, r.Item?.name); });
     }
 
     [Fact(Skip = "Requires Select projection rewriting")]
     public void Select_projection_to_constructor_params_and_initializer()
     {
         var results = _planets.Select(p => new NamedContainer<Planet>(p) {Name = p.name});
-        Assert.All(results, r => { Assert.Equal(r.Name, r?.Item?.name); });
+        Assert.All(results, r => { Assert.Equal(r.Name, r.Item?.name); });
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
@@ -19,7 +19,7 @@ using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
 [XUnitCollection(nameof(SampleGuidesFixture))]
-public class TopScalarTests
+public class TopScalarTests : IDisposable, IAsyncDisposable
 {
     private readonly GuidesDbContext _db;
 
@@ -196,4 +196,10 @@ public class TopScalarTests
         var result = await _db.Planets.Where(p => p.orderFromSun < 5).AnyAsync(p => p.hasRings);
         Assert.False(result);
     }
+
+    public void Dispose()
+        => _db.Dispose();
+
+    public async ValueTask DisposeAsync()
+        => await _db.DisposeAsync();
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
@@ -20,7 +20,7 @@ using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
 [XUnitCollection(nameof(SampleGuidesFixture))]
-public class WhereTests
+public class WhereTests : IDisposable, IAsyncDisposable
 {
     private readonly IMongoDatabase _mongoDatabase;
     private readonly GuidesDbContext _db;
@@ -218,7 +218,7 @@ public class WhereTests
     [Fact]
     public void Where_string_list_contains()
     {
-        var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
+        using var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
         var results = db.Entities.Where(p => p.mainAtmosphere.Contains("H2")).ToArray();
         Assert.Equal(4, results.Length);
         Assert.All(results, p => Assert.Contains("H2", p.mainAtmosphere));
@@ -227,7 +227,7 @@ public class WhereTests
     [Fact]
     public void Where_string_list_not_contains()
     {
-        var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
+        using var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
         var results = db.Entities.Where(p => !p.mainAtmosphere.Contains("H2")).ToArray();
         Assert.Equal(4, results.Length);
         Assert.All(results, p => Assert.DoesNotContain("H2", p.mainAtmosphere));
@@ -236,7 +236,7 @@ public class WhereTests
     [Fact]
     public void Where_string_list_count()
     {
-        var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
+        using var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
         var results = db.Entities.Where(p => p.mainAtmosphere.Count == 2).ToArray();
         Assert.Single(results);
         Assert.Equal(2, results[0].mainAtmosphere.Count);
@@ -245,9 +245,15 @@ public class WhereTests
     [Fact]
     public void Where_string_list_any()
     {
-        var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
+        using var db = SingleEntityDbContext.Create(_mongoDatabase.GetCollection<PlanetListVersion>("planets"));
         var results = db.Entities.Where(p => p.mainAtmosphere.Any()).ToArray();
         Assert.Equal(7, results.Length);
         Assert.All(results, p => Assert.NotEmpty(p.mainAtmosphere));
     }
+
+    public void Dispose()
+        => _db.Dispose();
+
+    public async ValueTask DisposeAsync()
+        => await _db.DisposeAsync();
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/TransactionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/TransactionTests.cs
@@ -33,7 +33,7 @@ public class TransactionTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void MongoTransactionManager_throws_if_transaction_attempted()
     {
-        var db = SingleEntityDbContext.Create(_tempDatabase.CreateTemporaryCollection<SimpleEntity>());
+        using var db = SingleEntityDbContext.Create(_tempDatabase.CreateTemporaryCollection<SimpleEntity>());
 
         var ex = Assert.Throws<NotSupportedException>(() => db.Database.BeginTransaction());
         Assert.Contains("does not support transactions", ex.Message);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
@@ -70,17 +70,17 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Add_simple_entity_with_generated_ObjectId()
     {
-        IMongoCollection<SimpleEntity> collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
-        SingleEntityDbContext<SimpleEntity> dbContext = SingleEntityDbContext.Create(collection);
+        var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
 
-        SimpleEntity expected = new()
+        var expected = new SimpleEntity
         {
             _id = ObjectId.GenerateNewId(), name = "Generated"
         };
-        dbContext.Entities.Add(expected);
-        dbContext.SaveChanges();
+        db.Entities.Add(expected);
+        db.SaveChanges();
 
-        Assert.Same(expected, dbContext.Entities.First());
+        Assert.Same(expected, db.Entities.First());
 
         // Check with C# Driver for second opinion
         var directFound = collection.Find(f => f._id == expected._id).Single();
@@ -91,17 +91,17 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Add_simple_entity_with_unset_ObjectId()
     {
-        IMongoCollection<SimpleEntity> collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
-        SingleEntityDbContext<SimpleEntity> dbContext = SingleEntityDbContext.Create(collection);
+        var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
 
-        SimpleEntity expected = new()
+        var expected = new SimpleEntity
         {
             name = "Not Set"
         };
-        dbContext.Entities.Add(expected);
-        dbContext.SaveChanges();
+        db.Entities.Add(expected);
+        db.SaveChanges();
 
-        Assert.Same(expected, dbContext.Entities.First());
+        Assert.Same(expected, db.Entities.First());
 
         // Check with C# Driver for second opinion
         var directFound = collection.Find(f => f._id == expected._id).Single();
@@ -114,17 +114,17 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Add_simple_entity_with_empty_ObjectId()
     {
-        IMongoCollection<SimpleEntity> collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
-        SingleEntityDbContext<SimpleEntity> dbContext = SingleEntityDbContext.Create(collection);
+        var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
+        using var db = SingleEntityDbContext.Create(collection);
 
-        SimpleEntity expected = new()
+        var expected = new SimpleEntity
         {
             _id = ObjectId.Empty, name = "Empty"
         };
-        dbContext.Entities.Add(expected);
-        dbContext.SaveChanges();
+        db.Entities.Add(expected);
+        db.SaveChanges();
 
-        Assert.Same(expected, dbContext.Entities.First());
+        Assert.Same(expected, db.Entities.First());
 
         // Check with C# Driver for second opinion
         var directFound = collection.Find(f => f._id == expected._id).Single();
@@ -137,9 +137,9 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Add_numeric_types_entity()
     {
-        IMongoCollection<NumericTypesEntity> collection = _tempDatabase.CreateTemporaryCollection<NumericTypesEntity>();
+        var collection = _tempDatabase.CreateTemporaryCollection<NumericTypesEntity>();
 
-        NumericTypesEntity expected = new()
+        var expected = new NumericTypesEntity
         {
             _id = Random.Next(),
             aDecimal = Random.NextDecimal(),
@@ -152,14 +152,14 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
         {
-            SingleEntityDbContext<NumericTypesEntity> dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(expected);
-            dbContext.SaveChanges();
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(expected);
+            db.SaveChanges();
         }
 
         {
-            SingleEntityDbContext<NumericTypesEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            var foundEntity = newDbContext.Entities.Single();
+            using var db = SingleEntityDbContext.Create(collection);
+            var foundEntity = db.Entities.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aDecimal, foundEntity.aDecimal);
             Assert.Equal(expected.aSingle, foundEntity.aSingle);
@@ -174,9 +174,9 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Add_clr_types_entity()
     {
-        IMongoCollection<OtherClrTypeEntity> collection = _tempDatabase.CreateTemporaryCollection<OtherClrTypeEntity>();
+        var collection = _tempDatabase.CreateTemporaryCollection<OtherClrTypeEntity>();
 
-        OtherClrTypeEntity expected = new()
+        var expected = new OtherClrTypeEntity
         {
             _id = Guid.NewGuid(),
             aString = "Some kind of string",
@@ -186,14 +186,14 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         };
 
         {
-            SingleEntityDbContext<OtherClrTypeEntity> dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(expected);
-            dbContext.SaveChanges();
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(expected);
+            db.SaveChanges();
         }
 
         {
-            SingleEntityDbContext<OtherClrTypeEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            var foundEntity = newDbContext.Entities.Single();
+            using var db = SingleEntityDbContext.Create(collection);
+            var foundEntity = db.Entities.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aString, foundEntity.aString);
             Assert.Equal(expected.aChar, foundEntity.aChar);
@@ -205,22 +205,22 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Add_mongo_types_entity()
     {
-        IMongoCollection<MongoSpecificTypeEntity> collection = _tempDatabase.CreateTemporaryCollection<MongoSpecificTypeEntity>();
+        var collection = _tempDatabase.CreateTemporaryCollection<MongoSpecificTypeEntity>();
 
-        MongoSpecificTypeEntity expected = new()
+        var expected = new MongoSpecificTypeEntity
         {
             _id = ObjectId.GenerateNewId(), aDecimal128 = new Decimal128(Random.NextDecimal())
         };
 
         {
-            SingleEntityDbContext<MongoSpecificTypeEntity> dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(expected);
-            dbContext.SaveChanges();
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(expected);
+            db.SaveChanges();
         }
 
         {
-            SingleEntityDbContext<MongoSpecificTypeEntity> newDbContext = SingleEntityDbContext.Create(collection);
-            var foundEntity = newDbContext.Entities.Single();
+            using var db = SingleEntityDbContext.Create(collection);
+            var foundEntity = db.Entities.Single();
             Assert.Equal(expected._id, foundEntity._id);
             Assert.Equal(expected.aDecimal128, foundEntity.aDecimal128);
         }
@@ -285,17 +285,17 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<Entity<TValue>>("EntityAddTestImpl", typeof(TValue), value);
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection);
-            dbContext.Entities.Add(new Entity<TValue>
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new Entity<TValue>
             {
                 _id = ObjectId.GenerateNewId(), Value = value
             });
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
-            var newDbContext = SingleEntityDbContext.Create(collection);
-            Entity<TValue> foundEntity = newDbContext.Entities.Single();
+            using var db = SingleEntityDbContext.Create(collection);
+            var foundEntity = db.Entities.Single();
             Assert.Equal(value, foundEntity.Value);
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/CompositeKeyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/CompositeKeyCrudTests.cs
@@ -35,13 +35,13 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
         var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
         }
 
         {
@@ -62,13 +62,13 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
         var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
         }
 
         {
@@ -93,16 +93,16 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
         var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
 
             entity.Data = "updated text";
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -121,17 +121,17 @@ public class CompositeKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id1), nameof(Entity.Id2));
             });
             var entity = new Entity {Id1 = "key", Id2 = 2, Data = "some text"};
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
 
-            dbContext.Remove(entity);
-            dbContext.SaveChanges();
+            db.Remove(entity);
+            db.SaveChanges();
         }
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/ContextTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/ContextTests.cs
@@ -24,7 +24,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public void SaveChanges_includes_insertion_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         const int insertCount = 10;
 
@@ -38,7 +38,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public async Task SaveChangesAsync_includes_insertion_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        await using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         const int insertCount = 9;
 
@@ -52,7 +52,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public void SaveChanges_includes_update_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         const int updateCount = 8;
         var items = Enumerable.Range(0, updateCount * 2)
@@ -72,7 +72,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public async Task SaveChangesAsync_includes_update_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        await using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         const int updateCount = 7;
         var items = Enumerable.Range(0, updateCount * 2)
@@ -92,7 +92,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public void SaveChanges_includes_delete_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         const int deleteCount = 6;
         var items = Enumerable.Range(0, deleteCount + 10)
@@ -111,7 +111,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public async Task SaveChangesAsync_includes_delete_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        await using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         const int deleteCount = 6;
         var items = Enumerable.Range(0, deleteCount * 2)
@@ -130,7 +130,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public void SaveChanges_combines_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         var items = Enumerable.Range(0, 4)
             .Select(i => new Customer("Generated " + i))
@@ -151,7 +151,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public async Task SaveChangesAsync_combines_counts()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
+        await using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<Customer>());
 
         var items = Enumerable.Range(0, 4)
             .Select(i => new Customer("Generated " + i))
@@ -172,7 +172,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public void SaveChanges_counts_only_documents_not_owned_entities()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<PeopleOnMoons>());
+        using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<PeopleOnMoons>());
 
         var item = new PeopleOnMoons("Space Adventurer");
         db.Entities.Add(item);
@@ -188,7 +188,7 @@ public class ContextTests(TemporaryDatabaseFixture tempDatabase) : IClassFixture
     [Fact]
     public async Task SaveChangesAsync_counts_only_documents_not_owned_entities()
     {
-        var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<PeopleOnMoons>());
+        await using var db = SingleEntityDbContext.Create(tempDatabase.CreateTemporaryCollection<PeopleOnMoons>());
 
         var item1 = new PeopleOnMoons("Captain A");
         var item2 = new PeopleOnMoons("Captain B");

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
@@ -57,13 +57,13 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntityWithStringId>();
         collection.InsertOne(new SimpleEntityWithStringId {_id = ObjectId.GenerateNewId().ToString(), name = "DeleteMe"});
 
-        var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entities.Single();
+        using var db = SingleEntityDbContext.Create(collection);
+        var entity = db.Entities.Single();
 
-        dbContext.Remove(entity);
-        dbContext.SaveChanges();
+        db.Remove(entity);
+        db.SaveChanges();
 
-        Assert.Empty(dbContext.Entities);
+        Assert.Empty(db.Entities);
     }
 
     [Fact]
@@ -72,13 +72,13 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntityWithObjectIdId>();
         collection.InsertOne(new SimpleEntityWithObjectIdId {_id = ObjectId.GenerateNewId(), name = "DeleteMe"});
 
-        var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entities.Single();
+        using var db = SingleEntityDbContext.Create(collection);
+        var entity = db.Entities.Single();
 
-        dbContext.Remove(entity);
-        dbContext.SaveChanges();
+        db.Remove(entity);
+        db.SaveChanges();
 
-        Assert.Empty(dbContext.Entities);
+        Assert.Empty(db.Entities);
     }
 
     [Fact]
@@ -87,13 +87,13 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntityWithGuidId>();
         collection.InsertOne(new SimpleEntityWithGuidId {_id = Guid.NewGuid(), name = "DeleteMe"});
 
-        var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entities.Single();
+        using var db = SingleEntityDbContext.Create(collection);
+        var entity = db.Entities.Single();
 
-        dbContext.Remove(entity);
-        dbContext.SaveChanges();
+        db.Remove(entity);
+        db.SaveChanges();
 
-        Assert.Empty(dbContext.Entities);
+        Assert.Empty(db.Entities);
     }
 
     [Fact]
@@ -102,12 +102,12 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
         var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntityWithIntId>();
         collection.InsertOne(new SimpleEntityWithIntId {_id = new Random().Next(), name = "DeleteMe"});
 
-        var dbContext = SingleEntityDbContext.Create(collection);
-        var entity = dbContext.Entities.Single();
+        using var db = SingleEntityDbContext.Create(collection);
+        var entity = db.Entities.Single();
 
-        dbContext.Remove(entity);
-        dbContext.SaveChanges();
+        db.Remove(entity);
+        db.SaveChanges();
 
-        Assert.Empty(dbContext.Entities);
+        Assert.Empty(db.Entities);
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/OwnedNavigationPropertyCrudTests.cs
@@ -34,7 +34,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCity
             {
                 Id = 1, Name = "John"
@@ -61,7 +61,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCity
             {
                 Id = 1,
@@ -93,7 +93,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCity
             {
                 Id = 1,
@@ -128,7 +128,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCity
             {
                 Id = 1,
@@ -166,7 +166,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCity>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCity
             {
                 Id = 1,
@@ -201,7 +201,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCities>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCities
             {
                 Id = 1, Name = "John"
@@ -228,7 +228,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCities>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCities
             {
                 Id = 1,
@@ -269,7 +269,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCities>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCities
             {
                 Id = 1,
@@ -312,7 +312,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCities>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCities
             {
                 Id = 1,
@@ -333,13 +333,12 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
             db.Entities.Add(person);
             db.SaveChanges();
 
-            person.Cities = person.Cities.Concat(new List<City>
-            {
+            person.Cities = person.Cities.Concat([
                 new City
                 {
                     Id = 3, Name = "Denver"
                 }
-            }).ToList();
+            ]).ToList();
             db.SaveChanges();
         }
 
@@ -362,7 +361,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCities>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCities
             {
                 Id = 1,
@@ -404,7 +403,7 @@ public class OwnedNavigationPropertyCrudTests : IClassFixture<TemporaryDatabaseF
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithCities>();
 
         {
-            var db = SingleEntityDbContext.Create(collection);
+            using var db = SingleEntityDbContext.Create(collection);
             var person = new PersonWithCities
             {
                 Id = 1,

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SimpleKeyCrudTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SimpleKeyCrudTests.cs
@@ -35,13 +35,13 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
         var entity = new Entity {Id = "key", Data = "some text"};
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
         }
 
         {
@@ -62,23 +62,23 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
         var entity = new Entity {Id = "key", Data = "some text"};
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
         }
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
 
-            var actual = dbContext.Entities.Single();
+            var actual = db.Entities.Single();
 
             Assert.Equal(entity.Id, actual.Id);
             Assert.Equal(entity.Data, actual.Data);
@@ -92,16 +92,16 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
         var entity = new Entity {Id = "key", Data = "some text"};
 
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
 
             entity.Data = "updated text";
-            dbContext.SaveChanges();
+            db.SaveChanges();
         }
 
         {
@@ -120,17 +120,17 @@ public class SimpleKeyCrudTests : IClassFixture<TemporaryDatabaseFixture>
     {
         var collection = _tempDatabase.CreateTemporaryCollection<Entity>();
         {
-            var dbContext = SingleEntityDbContext.Create(collection, builder =>
+            using var db = SingleEntityDbContext.Create(collection, builder =>
             {
                 builder.Entity<Entity>()
                     .HasKey(nameof(Entity.Id));
             });
             var entity = new Entity {Id = "key", Data = "some text"};
-            dbContext.Entities.Add(entity);
-            dbContext.SaveChanges();
+            db.Entities.Add(entity);
+            db.SaveChanges();
 
-            dbContext.Remove(entity);
-            dbContext.SaveChanges();
+            db.Remove(entity);
+            db.SaveChanges();
         }
 
         {

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoDbContextOptionsExtensionsTest.cs
@@ -30,7 +30,7 @@ public static class MongoDbContextOptionsExtensionsTest
     public static void Can_configure_connection_string_and_database_name(string connectionString, string databaseName)
     {
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddMongoDB<ApplicationDbContext>(connectionString, databaseName, mongoOptions => { },
+        serviceCollection.AddMongoDB<ApplicationDbContext>(connectionString, databaseName, _ => { },
             dbContextOptions => { dbContextOptions.EnableDetailedErrors(); });
 
         var services = serviceCollection.BuildServiceProvider(validateScopes: true);
@@ -54,7 +54,7 @@ public static class MongoDbContextOptionsExtensionsTest
         var mongoClient = new MongoClient();
 
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddMongoDB<ApplicationDbContext>(mongoClient, databaseName, mongoOptions => { },
+        serviceCollection.AddMongoDB<ApplicationDbContext>(mongoClient, databaseName, _ => { },
             dbContextOptions => { dbContextOptions.EnableDetailedErrors(); });
 
         var services = serviceCollection.BuildServiceProvider(validateScopes: true);

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoModelValidatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoModelValidatorTests.cs
@@ -75,7 +75,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_BsonRepresentationAttribute_is_on_entity_property()
     {
-        var db = SingleEntityDbContext.Create<UnsupportedBsonRepresentationEntity>();
+        using var db = SingleEntityDbContext.Create<UnsupportedBsonRepresentationEntity>();
 
         var ex = Assert.Throws<NotSupportedException>(() => db.Model);
         Assert.Contains(
@@ -87,7 +87,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_multiple_properties_attributed_to_same_element_name()
     {
-        var db = SingleEntityDbContext.Create<EntityWithTwoUnderscoreIds>();
+        using var db = SingleEntityDbContext.Create<EntityWithTwoUnderscoreIds>();
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Model);
         Assert.Contains($"'{nameof(EntityWithTwoUnderscoreIds)}'", ex.Message);
@@ -99,7 +99,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_multiple_properties_configured_to_same_element_name()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property(p => p.name1).HasElementName("name");
@@ -116,7 +116,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_property_element_name_starts_with_dollar_sign()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property(p => p.name1).HasElementName("$something");
@@ -131,7 +131,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_succeeds_if_property_element_name_ends_with_dollar_sign()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property(p => p.name1).HasElementName("something$");
@@ -143,7 +143,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_succeeds_if_property_element_name_contains_dollar_sign_not_at_the_start()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property(p => p.name1).HasElementName("some$thing");
@@ -155,7 +155,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_property_element_name_starts_with_dot()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property(p => p.name1).HasElementName(".something");
@@ -170,7 +170,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_property_element_name_ends_with_dot()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property(p => p.name1).HasElementName("something.");
@@ -185,7 +185,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_property_element_name_contains_dot()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property(p => p.name1).HasElementName("some.thing");
@@ -200,7 +200,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_multiple_navigations_configured_to_same_element_name()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First, r => r.HasElementName("location"));
@@ -217,7 +217,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_navigation_element_name_starts_with_dollar_sign()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First).HasElementName("$something");
@@ -232,7 +232,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_succeeds_if_navigation_element_name_ends_with_dollar_sign()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First).HasElementName("something$");
@@ -244,7 +244,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_succeeds_if_navigation_element_name_contains_dollar_sign_not_at_the_start()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First).HasElementName("some$thing");
@@ -256,7 +256,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_navigation_element_name_starts_with_dot()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First).HasElementName(".why");
@@ -271,7 +271,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_navigation_element_name_ends_with_dot()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First).HasElementName("notokay.");
@@ -286,7 +286,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_navigation_element_name_contains_dot()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First).HasElementName("one.dot.is.too.many");
@@ -301,7 +301,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_navigation_and_property_configured_to_same_element_name()
     {
-        var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
+        using var db = SingleEntityDbContext.Create<WithTwoOwnedEntities>(mb =>
         {
             var dneBuilder = mb.Entity<WithTwoOwnedEntities>();
             dneBuilder.OwnsOne(p => p.First, r => r.HasElementName("someTarget"));
@@ -318,7 +318,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_succeeds_when_primary_key_configured_correctly()
     {
-        var db = SingleEntityDbContext.Create<ConfiguredIdNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<ConfiguredIdNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<ConfiguredIdNamedEntity>();
             dneBuilder.HasKey(e => e.ThisWillBePrimaryKey);
@@ -331,7 +331,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_primary_key_conflicts_with_different_id_mapped_property()
     {
-        var db = SingleEntityDbContext.Create<ConfiguredIdNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<ConfiguredIdNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<ConfiguredIdNamedEntity>();
             dneBuilder.HasKey(e => e.ThisWillBePrimaryKey);
@@ -347,7 +347,7 @@ public static class MongoModelValidatorTests
     [Fact]
     public static void Validate_throws_when_entity_has_shadow_properties()
     {
-        var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
+        using var db = SingleEntityDbContext.Create<DoubleNamedEntity>(mb =>
         {
             var dneBuilder = mb.Entity<DoubleNamedEntity>();
             dneBuilder.Property<DateTime>("ShadowDateTime");

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConventionTests.cs
@@ -24,11 +24,11 @@ public static class BsonDateTimeOptionsAttributeConventionTests
     [Fact]
     public static void BsonDateTimeOptions_specified_properties_are_of_a_specified_kind()
     {
-        using var context = new BaseDbContext();
+        using var db = new BaseDbContext();
 
-        var local = context.GetProperty((DatesEntity d) => d.Local);
-        var utc = context.GetProperty((DatesEntity d) => d.Utc);
-        var unspecified = context.GetProperty((DatesEntity d) => d.Unspecified);
+        var local = db.GetProperty((DatesEntity d) => d.Local);
+        var utc = db.GetProperty((DatesEntity d) => d.Utc);
+        var unspecified = db.GetProperty((DatesEntity d) => d.Unspecified);
 
         Assert.Equal(DateTimeKind.Local, local?.GetDateTimeKind());
         Assert.Equal(DateTimeKind.Utc, utc?.GetDateTimeKind());
@@ -38,11 +38,11 @@ public static class BsonDateTimeOptionsAttributeConventionTests
     [Fact]
     public static void ModelBuilder_specified_kind_override_BsonDateTimeOptions_attribute()
     {
-        using var context = new ModelBuilderSpecifiedDbContext();
+        using var db = new ModelBuilderSpecifiedDbContext();
 
-        var localToUtc = context.GetProperty((DatesEntity d) => d.Local);
-        var utcToUnspecified = context.GetProperty((DatesEntity d) => d.Utc);
-        var unspecifiedToLocal = context.GetProperty((DatesEntity d) => d.Unspecified);
+        var localToUtc = db.GetProperty((DatesEntity d) => d.Local);
+        var utcToUnspecified = db.GetProperty((DatesEntity d) => d.Utc);
+        var unspecifiedToLocal = db.GetProperty((DatesEntity d) => d.Unspecified);
 
         Assert.Equal(DateTimeKind.Utc, localToUtc?.GetDateTimeKind());
         Assert.Equal(DateTimeKind.Unspecified, utcToUnspecified?.GetDateTimeKind());

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonElementAttributeConventionTests.cs
@@ -24,15 +24,15 @@ public static class BsonElementAttributeConventionTests
     [Fact]
     public static void BsonElement_specified_names_are_used_as_element_names()
     {
-        using var context = new BaseDbContext();
-        Assert.Equal("attributeSpecifiedName", context.GetProperty((Customer c) => c.Name)?.GetElementName());
+        using var db = new BaseDbContext();
+        Assert.Equal("attributeSpecifiedName", db.GetProperty((Customer c) => c.Name)?.GetElementName());
     }
 
     [Fact]
     public static void ModelBuilder_specified_names_override_BsonElement_names()
     {
-        using var context = new ModelBuilderSpecifiedDbContext();
-        Assert.Equal("fluentSpecifiedName", context.GetProperty((Customer c) => c.Name)?.GetElementName());
+        using var db = new ModelBuilderSpecifiedDbContext();
+        Assert.Equal("fluentSpecifiedName", db.GetProperty((Customer c) => c.Name)?.GetElementName());
     }
 
     class Customer

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonIdAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonIdAttributeConventionTests.cs
@@ -23,15 +23,15 @@ public static class BsonIdAttributeConventionTests
     [Fact]
     public static void BsonId_specified_properties_sets_property_to_key()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonId>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonId>();
 
-        var attributedProperty = context.GetProperty((EntityWithBsonId e) => e.AttributedKey);
+        var attributedProperty = db.GetProperty((EntityWithBsonId e) => e.AttributedKey);
 
         Assert.NotNull(attributedProperty);
         Assert.Equal("_id", attributedProperty.GetElementName());
         Assert.True(attributedProperty.IsKey());
 
-        var unattributedProperty = context.GetProperty((EntityWithBsonId e) => e.UnattributedKey);
+        var unattributedProperty = db.GetProperty((EntityWithBsonId e) => e.UnattributedKey);
         Assert.NotNull(unattributedProperty);
         Assert.Equal("UnattributedKey", unattributedProperty.GetElementName());
         Assert.False(unattributedProperty.IsKey());
@@ -40,20 +40,20 @@ public static class BsonIdAttributeConventionTests
     [Fact]
     public static void ModelBuilder_specified_names_override_BsonId_key()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonId>(mb => mb.Entity<EntityWithBsonId>(e =>
+        using var db = SingleEntityDbContext.Create<EntityWithBsonId>(mb => mb.Entity<EntityWithBsonId>(e =>
         {
             e.Property(p => p.UnattributedKey).HasElementName("_id");
             e.HasKey(p => p.UnattributedKey);
             e.Property(p => p.AttributedKey).HasElementName("notId");
         }));
 
-        var attributedProperty = context.GetProperty((EntityWithBsonId e) => e.AttributedKey);
+        var attributedProperty = db.GetProperty((EntityWithBsonId e) => e.AttributedKey);
 
         Assert.NotNull(attributedProperty);
         Assert.Equal("notId", attributedProperty.GetElementName());
         Assert.False(attributedProperty.IsKey());
 
-        var unattributedProperty = context.GetProperty((EntityWithBsonId e) => e.UnattributedKey);
+        var unattributedProperty = db.GetProperty((EntityWithBsonId e) => e.UnattributedKey);
         Assert.NotNull(unattributedProperty);
         Assert.Equal("_id", unattributedProperty.GetElementName());
         Assert.True(unattributedProperty.IsKey());

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConventionTests.cs
@@ -24,9 +24,9 @@ public static class BsonIgnoreAttributeConventionTests
     [Fact]
     public static void BsonIgnored_specified_properties_are_unmapped()
     {
-        using var context = new BaseDbContext();
+        using var db = new BaseDbContext();
 
-        var property = context.GetProperty((Customer c) => c.IgnoreMe);
+        var property = db.GetProperty((Customer c) => c.IgnoreMe);
 
         Assert.Null(property);
     }
@@ -34,9 +34,9 @@ public static class BsonIgnoreAttributeConventionTests
     [Fact]
     public static void ModelBuilder_specified_names_override_BsonIgnored_attribute()
     {
-        using var context = new ModelBuilderSpecifiedDbContext();
+        using var db = new ModelBuilderSpecifiedDbContext();
 
-        var property = context.GetProperty((Customer c) => c.IgnoreMe);
+        var property = db.GetProperty((Customer c) => c.IgnoreMe);
 
         Assert.NotNull(property);
     }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonRequiredAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonRequiredAttributeConventionTests.cs
@@ -24,9 +24,9 @@ public static class BsonRequiredAttributeConventionTests
     [Fact]
     public static void BsonRequired_specified_properties_are_required()
     {
-        using var context = new BaseDbContext();
+        using var db = new BaseDbContext();
 
-        var property = context.GetProperty((Customer c) => c.RequireMe);
+        var property = db.GetProperty((Customer c) => c.RequireMe);
 
         Assert.False(property?.IsNullable);
     }
@@ -34,9 +34,9 @@ public static class BsonRequiredAttributeConventionTests
     [Fact]
     public static void ModelBuilder_specified_not_required_override_BsonRequired_attribute()
     {
-        using var context = new ModelBuilderSpecifiedDbContext();
+        using var db = new ModelBuilderSpecifiedDbContext();
 
-        var property = context.GetProperty((Customer c) => c.RequireMe);
+        var property = db.GetProperty((Customer c) => c.RequireMe);
 
         Assert.True(property?.IsNullable);
     }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonUnsupportedAttributesConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/BsonAttributes/BsonUnsupportedAttributesConventionTests.cs
@@ -24,10 +24,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonSerializer_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonSerializerProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonSerializerProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonSerializerProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonSerializerProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonSerializerProperty)}.{nameof(EntityWithBsonSerializerProperty.AttributedSerializer)}'",
             ex.Message);
@@ -45,10 +45,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonExtraElements_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonExtraElementsProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonExtraElementsProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonExtraElementsProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonExtraElementsProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonExtraElementsProperty)}.{nameof(EntityWithBsonExtraElementsProperty.AttributedSerializer)}'",
             ex.Message);
@@ -66,10 +66,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonRepresentation_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonRepresentationProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonRepresentationProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonRepresentationProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonRepresentationProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonRepresentationProperty)}.{nameof(EntityWithBsonRepresentationProperty.AttributedSerializer)}'",
             ex.Message);
@@ -87,10 +87,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonDefaultValue_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonDefaultValueProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonDefaultValueProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonDefaultValueProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonDefaultValueProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonDefaultValueProperty)}.{nameof(EntityWithBsonDefaultValueProperty.AttributedSerializer)}'",
             ex.Message);
@@ -108,10 +108,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonGuidRepresentation_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonGuidRepresentationProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonGuidRepresentationProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonGuidRepresentationProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonGuidRepresentationProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonGuidRepresentationProperty)}.{
                 nameof(EntityWithBsonGuidRepresentationProperty.AttributedSerializer)}'", ex.Message);
@@ -129,10 +129,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonTimeSpanOptions_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonTimeSpanOptionsProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonTimeSpanOptionsProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonTimeSpanOptionsProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonTimeSpanOptionsProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonTimeSpanOptionsProperty)}.{nameof(EntityWithBsonTimeSpanOptionsProperty.AttributedSerializer)
             }'", ex.Message);
@@ -150,10 +150,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonDictionaryOptions_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonDictionaryOptionsProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonDictionaryOptionsProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonDictionaryOptionsProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonDictionaryOptionsProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonDictionaryOptionsProperty)}.{
                 nameof(EntityWithBsonDictionaryOptionsProperty.AttributedSerializer)}'", ex.Message);
@@ -171,10 +171,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonIgnoreIfDefault_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonIgnoreIfDefaultProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonIgnoreIfDefaultProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonIgnoreIfDefaultProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonIgnoreIfDefaultProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonIgnoreIfDefaultProperty)}.{nameof(EntityWithBsonIgnoreIfDefaultProperty.AttributedSerializer)
             }'", ex.Message);
@@ -192,10 +192,10 @@ public static class BsonUnsupportedAttributeConventionTests
     [Fact]
     public static void BsonIgnoreIfNull_is_not_supported_on_property()
     {
-        using var context = SingleEntityDbContext.Create<EntityWithBsonIgnoreIfNullProperty>();
+        using var db = SingleEntityDbContext.Create<EntityWithBsonIgnoreIfNullProperty>();
 
         var ex = Assert.Throws<NotSupportedException>(()
-            => context.GetProperty((EntityWithBsonIgnoreIfNullProperty e) => e.AttributedSerializer));
+            => db.GetProperty((EntityWithBsonIgnoreIfNullProperty e) => e.AttributedSerializer));
         Assert.Contains(
             $"'{nameof(EntityWithBsonIgnoreIfNullProperty)}.{nameof(EntityWithBsonIgnoreIfNullProperty.AttributedSerializer)}'",
             ex.Message);

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionAttributeConventionTests.cs
@@ -24,15 +24,15 @@ public static class CollectionAttributeConventionTests
     [Fact]
     public static void Collection_attribute_specified_names_are_used_as_collection_names()
     {
-        using var context = new BaseDbContext();
-        Assert.Equal("attributedCollection", context.GetCollectionName<Customer>());
+        using var db = new BaseDbContext();
+        Assert.Equal("attributedCollection", db.GetCollectionName<Customer>());
     }
 
     [Fact]
     public static void Model_builder_specified_names_override_collection_attribute_names()
     {
-        using var context = new ModelBuilderSpecifiedDbContext();
-        Assert.Equal("namedCollection", context.GetCollectionName<Customer>());
+        using var db = new ModelBuilderSpecifiedDbContext();
+        Assert.Equal("namedCollection", db.GetCollectionName<Customer>());
     }
 
     [Collection("attributedCollection")]

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionNameFromDbSetConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/CollectionNameFromDbSetConventionTests.cs
@@ -24,15 +24,15 @@ public static class CollectionNameFromDbSetConventionTests
     [Fact]
     public static void DbSet_names_are_used_as_collection_names()
     {
-        using var context = new UnnamedCollectionsDbContext();
-        Assert.Equal("Customers", context.GetCollectionName<Customer>());
+        using var db = new UnnamedCollectionsDbContext();
+        Assert.Equal("Customers", db.GetCollectionName<Customer>());
     }
 
     [Fact]
     public static void Explicit_collection_names_can_be_set()
     {
-        using var context = new NamedCollectionsDbContext();
-        Assert.Equal("customersCollection", context.GetCollectionName<Customer>());
+        using var db = new NamedCollectionsDbContext();
+        Assert.Equal("customersCollection", db.GetCollectionName<Customer>());
     }
 
     class Customer

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
@@ -26,15 +26,15 @@ public static class ColumnAttributeConventionTests
     [Fact]
     public static void ColumnAttribute_specified_names_are_used_as_element_names()
     {
-        using var context = new BaseDbContext();
-        Assert.Equal("attributeSpecifiedName", GetElementName(context, (Customer c) => c.Name));
+        using var db = new BaseDbContext();
+        Assert.Equal("attributeSpecifiedName", GetElementName(db, (Customer c) => c.Name));
     }
 
     [Fact]
     public static void ModelBuilder_specified_field_names_override_ColumnAttribute_names()
     {
-        using var context = new ModelBuilderSpecifiedDbContext();
-        Assert.Equal("fluentSpecifiedName", GetElementName(context, (Customer c) => c.Name));
+        using var db = new ModelBuilderSpecifiedDbContext();
+        Assert.Equal("fluentSpecifiedName", GetElementName(db, (Customer c) => c.Name));
     }
 
     static string GetElementName<TEntity, TProperty>(DbContext context, Expression<Func<TEntity, TProperty>> propertyExpression)

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/DateTimeKindConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/DateTimeKindConventionTests.cs
@@ -1,17 +1,17 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using Microsoft.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.Metadata.Conventions;
@@ -37,7 +37,6 @@ public class DateTimeKindConventionTests
         Assert.Equal(value, entity.GetProperty(nameof(TestEntity.NullableDateTimeProperty)).GetDateTimeKind());
         Assert.Equal(DateTimeKind.Unspecified, entity.GetProperty(nameof(TestEntity.StringProperty)).GetDateTimeKind());
     }
-
 
     private class TestEntity
     {

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
@@ -24,10 +24,9 @@ public static class PrimaryKeyDiscoveryConventionTests
     [Fact]
     public static void Id_fields_are_identified_as_primary_keys_when_strings()
     {
-        using var context = new MyDbContext();
+        using var db = new MyDbContext();
 
-        var keys = context.Model.FindEntityType(typeof(Vendor))!.GetKeys().ToArray();
-
+        var keys = db.Model.FindEntityType(typeof(Vendor))!.GetKeys().ToArray();
         var expectedProperty = Utilities.GetPropertyInfo((Vendor v) => v._id);
 
         Assert.Single(keys);
@@ -37,10 +36,9 @@ public static class PrimaryKeyDiscoveryConventionTests
     [Fact]
     public static void Id_field_are_identified_as_primary_keys_when_objectids()
     {
-        using var context = new MyDbContext();
+        using var db = new MyDbContext();
 
-        var keys = context.Model.FindEntityType(typeof(Customer))!.GetKeys().ToArray();
-
+        var keys = db.Model.FindEntityType(typeof(Customer))!.GetKeys().ToArray();
         var expectedProperty = Utilities.GetPropertyInfo((Customer c) => c._id);
 
         Assert.Single(keys);

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoCollectionExpressionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoCollectionExpressionTests.cs
@@ -52,9 +52,9 @@ public static class MongoCollectionExpressionTests
     [Fact]
     public static void Can_set_properties_from_constructor()
     {
-        var context = new CollectionDbContext();
+        using var db = new CollectionDbContext();
 
-        foreach (var entityType in context.Model.GetEntityTypes())
+        foreach (var entityType in db.Model.GetEntityTypes())
         {
             var actual = new MongoCollectionExpression(entityType);
             Assert.Equal(entityType, actual.EntityType);

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoQueryExpressionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Expressions/MongoQueryExpressionTests.cs
@@ -42,8 +42,8 @@ public static class MongoQueryExpressionTests
     [Fact]
     public static void Set_collection_to_entity_passed_in_constructor()
     {
-        var context = new QueryDbContext();
-        var expectedEntityType = context.Model.GetEntityTypes().First();
+        using var db = new QueryDbContext();
+        var expectedEntityType = db.Model.GetEntityTypes().First();
 
         var actual = new MongoQueryExpression(expectedEntityType);
 


### PR DESCRIPTION
Cleans up the unit and functional tests a little, specifically:

- Always use "db" instead of "dbContext" or "context" 
- Add additional context warning suppression configuration to prevent CI and code coverage warnings
- Dispose of the DbContext in a lot more places