### PR TITLE
Fix exception caused by sequential single/first calls

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -40,7 +39,6 @@ public class MongoClientWrapper : IMongoClientWrapper
     private readonly IDiagnosticsLogger<DbLoggerCategory.Database.Command> _commandLogger;
     private readonly IMongoClient _client;
     private readonly IMongoDatabase _database;
-    private PropertyInfo? _getLoggedStages;
     private string DatabaseName => _database.DatabaseNamespace.DatabaseName;
 
     /// <summary>
@@ -88,8 +86,8 @@ public class MongoClientWrapper : IMongoClientWrapper
         var result = executableQuery.Provider.Execute<T>(executableQuery.Query);
 
         // We need to get this via reflection from the Mongo C# Driver for now.
-        _getLoggedStages ??= executableQuery.Provider.GetType().GetProperty("LoggedStages");
-        if (_getLoggedStages?.GetValue(executableQuery.Provider) is BsonDocument[] loggedStages)
+        var getLoggedStages = executableQuery.Provider.GetType().GetProperty("LoggedStages");
+        if (getLoggedStages?.GetValue(executableQuery.Provider) is BsonDocument[] loggedStages)
         {
             _commandLogger.ExecutedMqlQuery(executableQuery.CollectionNamespace, loggedStages);
         }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FirstSingleTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/FirstSingleTests.cs
@@ -19,14 +19,9 @@ using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 
 [XUnitCollection(nameof(SampleGuidesFixture))]
-public class FirstSingleTests : IDisposable, IAsyncDisposable
+public class FirstSingleTests(SampleGuidesFixture fixture) : IDisposable, IAsyncDisposable
 {
-    private readonly GuidesDbContext _db;
-
-    public FirstSingleTests(SampleGuidesFixture fixture)
-    {
-        _db = GuidesDbContext.Create(fixture.MongoDatabase);
-    }
+    private readonly GuidesDbContext _db = GuidesDbContext.Create(fixture.MongoDatabase);
 
     [Fact]
     public void First()
@@ -43,10 +38,57 @@ public class FirstSingleTests : IDisposable, IAsyncDisposable
     }
 
     [Fact]
+    public void FirstOrDefault()
+    {
+        var result = _db.Planets.OrderBy(p => p.name).FirstOrDefault();
+        Assert.NotNull(result);
+        Assert.Equal("Earth", result.name);
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync()
+    {
+        var result = await _db.Planets.OrderBy(p => p.name).FirstOrDefaultAsync();
+        Assert.NotNull(result);
+        Assert.Equal("Earth", result.name);
+    }
+
+    [Fact]
+    public void FirstOrDefault_with_two_different_types_sequentially()
+    {
+        var planet = _db.Planets.FirstOrDefault();
+        Assert.NotNull(planet);
+
+        var moon = _db.Moons.FirstOrDefault();
+        Assert.NotNull(moon);
+    }
+
+    [Fact]
     public void First_with_no_result()
     {
         var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.Skip(100).First());
         Assert.Equal("Sequence contains no elements", ex.Message);
+    }
+
+    [Fact]
+    public async Task FirstAsync_with_no_result()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.Skip(100).FirstAsync());
+        Assert.Equal("Sequence contains no elements", ex.Message);
+    }
+
+    [Fact]
+    public void FirstOrDefault_with_no_result()
+    {
+        var result = _db.Planets.Skip(100).FirstOrDefault();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_with_no_result()
+    {
+        var result = await _db.Planets.Skip(100).FirstOrDefaultAsync();
+        Assert.Null(result);
     }
 
     [Fact]
@@ -57,10 +99,54 @@ public class FirstSingleTests : IDisposable, IAsyncDisposable
     }
 
     [Fact]
+    public async Task FirstAsync_predicate()
+    {
+        var result = await _db.Planets.FirstAsync(p => p.orderFromSun == 1);
+        Assert.Equal("Mercury", result.name);
+    }
+
+    [Fact]
+    public void FirstOrDefault_predicate()
+    {
+        var result = _db.Planets.FirstOrDefault(p => p.orderFromSun == 1);
+        Assert.NotNull(result);
+        Assert.Equal("Mercury", result.name);
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_predicate()
+    {
+        var result = await _db.Planets.FirstOrDefaultAsync(p => p.orderFromSun == 1);
+        Assert.NotNull(result);
+        Assert.Equal("Mercury", result.name);
+    }
+
+    [Fact]
     public void First_predicate_no_results()
     {
         var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.First(p => p.orderFromSun == 10));
         Assert.Equal("Sequence contains no elements", ex.Message);
+    }
+
+    [Fact]
+    public async Task FirstAsync_predicate_no_results()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.FirstAsync(p => p.orderFromSun == 10));
+        Assert.Equal("Sequence contains no elements", ex.Message);
+    }
+
+    [Fact]
+    public void FirstOrDefault_predicate_no_results()
+    {
+        var result = _db.Planets.FirstOrDefault(p => p.orderFromSun == 10);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FirstOrDefaultAsync_predicate_no_results()
+    {
+        var result = await _db.Planets.FirstOrDefaultAsync(p => p.orderFromSun == 10);
+        Assert.Null(result);
     }
 
     [Fact]
@@ -78,6 +164,22 @@ public class FirstSingleTests : IDisposable, IAsyncDisposable
     }
 
     [Fact]
+    public void SingleOrDefault()
+    {
+        var result = _db.Planets.Where(p => p.name == "Earth").SingleOrDefault();
+        Assert.NotNull(result);
+        Assert.Equal("Earth", result.name);
+    }
+
+    [Fact]
+    public async Task SingleOrDefaultAsync()
+    {
+        var result = await _db.Planets.Where(p => p.name == "Earth").SingleOrDefaultAsync();
+        Assert.NotNull(result);
+        Assert.Equal("Earth", result.name);
+    }
+
+    [Fact]
     public void Single_with_no_results()
     {
         var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.Skip(100).Single());
@@ -85,9 +187,51 @@ public class FirstSingleTests : IDisposable, IAsyncDisposable
     }
 
     [Fact]
+    public async Task SingleAsync_with_no_results()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.Skip(100).SingleAsync());
+        Assert.Equal("Sequence contains no elements", ex.Message);
+    }
+
+    [Fact]
+    public void SingleOrDefault_with_no_results()
+    {
+        var result = _db.Planets.Skip(100).SingleOrDefault();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SingleOrDefaultAsync_with_no_results()
+    {
+        var results = await _db.Planets.Skip(100).SingleOrDefaultAsync();
+        Assert.Null(results);
+    }
+
+    [Fact]
     public void Single_with_more_than_one_result()
     {
         var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.Skip(4).Single());
+        Assert.Equal("Sequence contains more than one element", ex.Message);
+    }
+
+    [Fact]
+    public async Task SingleAsync_with_more_than_one_result()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.Skip(4).SingleAsync());
+        Assert.Equal("Sequence contains more than one element", ex.Message);
+    }
+
+    [Fact]
+    public void SingleOrDefault_with_more_than_one_result()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.Skip(4).SingleOrDefault());
+        Assert.Equal("Sequence contains more than one element", ex.Message);
+    }
+
+    [Fact]
+    public async Task SingleOrDefaultAsync_with_more_than_one_result()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.Skip(4).SingleOrDefaultAsync());
         Assert.Equal("Sequence contains more than one element", ex.Message);
     }
 
@@ -99,10 +243,54 @@ public class FirstSingleTests : IDisposable, IAsyncDisposable
     }
 
     [Fact]
+    public async Task SingleAsync_predicate()
+    {
+        var result = await _db.Planets.SingleAsync(p => p.orderFromSun == 1);
+        Assert.Equal("Mercury", result.name);
+    }
+
+    [Fact]
+    public void SingleOrDefault_predicate()
+    {
+        var result = _db.Planets.SingleOrDefault(p => p.orderFromSun == 1);
+        Assert.NotNull(result);
+        Assert.Equal("Mercury", result.name);
+    }
+
+    [Fact]
+    public async Task SingleOrDefaultAsync_predicate()
+    {
+        var result = await _db.Planets.SingleOrDefaultAsync(p => p.orderFromSun == 1);
+        Assert.NotNull(result);
+        Assert.Equal("Mercury", result.name);
+    }
+
+    [Fact]
     public void Single_predicate_no_results()
     {
         var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.Single(p => p.orderFromSun == 10));
         Assert.Equal("Sequence contains no elements", ex.Message);
+    }
+
+    [Fact]
+    public async Task SingleAsync_predicate_no_results()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.SingleAsync(p => p.orderFromSun == 10));
+        Assert.Equal("Sequence contains no elements", ex.Message);
+    }
+
+    [Fact]
+    public void SingleOrDefault_predicate_no_results()
+    {
+        var result = _db.Planets.SingleOrDefault(p => p.orderFromSun == 10);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SingleOrDefaultAsync_predicate_no_results()
+    {
+        var result = await _db.Planets.SingleOrDefaultAsync(p => p.orderFromSun == 10);
+        Assert.Null(result);
     }
 
     [Fact]
@@ -111,7 +299,28 @@ public class FirstSingleTests : IDisposable, IAsyncDisposable
         var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.Single(p => p.orderFromSun > 5));
         Assert.Equal("Sequence contains more than one element", ex.Message);
     }
-    
+
+    [Fact]
+    public async Task SingleAsync_predicate_with_more_than_one_result()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.SingleAsync(p => p.orderFromSun > 5));
+        Assert.Equal("Sequence contains more than one element", ex.Message);
+    }
+
+    [Fact]
+    public void SingleOrDefault_predicate_with_more_than_one_result()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => _db.Planets.SingleOrDefault(p => p.orderFromSun > 5));
+        Assert.Equal("Sequence contains more than one element", ex.Message);
+    }
+
+    [Fact]
+    public async Task SingleOrDefaultAsync_predicate_with_more_than_one_result()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _db.Planets.SingleOrDefaultAsync(p => p.orderFromSun > 5));
+        Assert.Equal("Sequence contains more than one element", ex.Message);
+    }
+
     public void Dispose()
         => _db.Dispose();
 


### PR DESCRIPTION
A late change in 8.0.0 included a workaround for logging first/single calls which uses reflection.

Unfortunately the caching mechanism fails on subsequent calls when the underlying query type changes and the MongoClientWrapper is being reused.

This stops trying to cache the reflection call. A newer version of the Mongo C# Driver will remove the need to reflect entirely.

Also took the opportunity to increase test coverage.

Fixes EF-120