### PR TITLE
Use Mongo C# Driver for enum mapping over built-in EF converters

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMappingSource.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMappingSource.cs
@@ -47,7 +47,7 @@ public class MongoTypeMappingSource(TypeMappingSourceDependencies dependencies)
     private MongoTypeMapping? FindPrimitiveMapping(in TypeMappingInfo mappingInfo)
     {
         var clrType = mappingInfo.ClrType!;
-        if (clrType is {IsValueType: true, IsEnum: false} || clrType == typeof(string))
+        if (clrType is {IsValueType: true} || clrType == typeof(string))
         {
             return new MongoTypeMapping(clrType);
         }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
@@ -956,10 +956,12 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
     [InlineData(typeof(TestEnum), TestEnum.EnumValue1)]
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue0)]
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue1)]
+    [InlineData(typeof(TestEnum?), null)]
     [InlineData(typeof(TestByteEnum), TestByteEnum.EnumValue0)]
     [InlineData(typeof(TestByteEnum), TestByteEnum.EnumValue1)]
     [InlineData(typeof(TestByteEnum?), TestByteEnum.EnumValue0)]
     [InlineData(typeof(TestByteEnum?), TestByteEnum.EnumValue1)]
+    [InlineData(typeof(TestByteEnum?), null)]
     [InlineData(typeof(int[]), null)]
     [InlineData(typeof(int[]), new[]
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
@@ -231,6 +231,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [InlineData(typeof(TestEnum), TestEnum.EnumValue1)]
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue0)]
     [InlineData(typeof(TestEnum?), TestEnum.EnumValue1)]
+    [InlineData(typeof(TestEnum?), null)]
     [InlineData(typeof(int[]), null)]
     [InlineData(typeof(int[]), new[]
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
@@ -110,7 +110,9 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [InlineData(typeof(TestEnum), TestEnum.Value0, TestEnum.Value1)]
     [InlineData(typeof(TestEnum), TestEnum.Value1, TestEnum.Value0)]
     [InlineData(typeof(TestEnum?), TestEnum.Value0, TestEnum.Value1)]
-    public void Entity_update_tests(Type valueType, object initialValue, object updatedValue)
+    [InlineData(typeof(TestEnum?), TestEnum.Value0, null)]
+    [InlineData(typeof(TestEnum?), null, TestEnum.Value1)]
+    public void Entity_update_tests(Type valueType, object? initialValue, object? updatedValue)
     {
         var methodInfo = GetType().GetMethod(nameof(EntityAddTestImpl), BindingFlags.Instance | BindingFlags.NonPublic)!;
         methodInfo.MakeGenericMethod(valueType).Invoke(this, [initialValue, updatedValue]);


### PR DESCRIPTION
The built-in converters don't handle null internally (we have a separate issue to tackle that for non-enum value converters)

This changes Enum handling to go back to our built-in conversion which will also retain better compatibility with the C# driver.

Fixes EF-128