### PR TITLE
BsonType configuration 

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
@@ -92,13 +92,13 @@ public static class MongoPropertyBuilderExtensions
     /// Configures the <see cref="BsonType"/> that the property is stored as when targeting MongoDB.
     /// </summary>
     /// <param name="propertyBuilder">The builder for the property being configured.</param>
-    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as
+    /// or <see langword="null" /> to unset the configuration and use the default.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static PropertyBuilder HasBsonType(
         this PropertyBuilder propertyBuilder,
-        BsonType bsonType)
+        BsonType? bsonType)
     {
-        ArgumentNullException.ThrowIfNull(bsonType);
         propertyBuilder.Metadata.SetBsonType(bsonType);
         return propertyBuilder;
     }
@@ -108,11 +108,12 @@ public static class MongoPropertyBuilderExtensions
     /// </summary>
     /// <typeparam name="TProperty">The type of the property being configured.</typeparam>
     /// <param name="propertyBuilder">The builder for the property being configured.</param>
-    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as
+    /// or <see langword="null" /> to unset the configuration and use the default.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static PropertyBuilder<TProperty> HasBsonType<TProperty>(
         this PropertyBuilder<TProperty> propertyBuilder,
-        BsonType bsonType)
+        BsonType? bsonType)
         => (PropertyBuilder<TProperty>)HasBsonType((PropertyBuilder)propertyBuilder, bsonType);
 
     /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
@@ -1,20 +1,21 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 using System;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Metadata;
 
 // ReSharper disable once CheckNamespace
@@ -53,34 +54,6 @@ public static class MongoPropertyBuilderExtensions
         => (PropertyBuilder<TProperty>)HasElementName((PropertyBuilder)propertyBuilder, name);
 
     /// <summary>
-    /// Configures the <see cref="DateTimeKind"/> for the property.
-    /// </summary>
-    /// <param name="propertyBuilder">The builder for the property being configured.</param>
-    /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> to use for the property.</param>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static PropertyBuilder HasDateTimeKind(
-        this PropertyBuilder propertyBuilder,
-        DateTimeKind dateTimeKind)
-    {
-        propertyBuilder.Metadata.SetDateTimeKind(dateTimeKind);
-        return propertyBuilder;
-    }
-
-    /// <summary>
-    /// Configures the <see cref="DateTimeKind"/> for the property.
-    /// </summary>
-    /// <param name="propertyBuilder">The builder for the property being configured.</param>
-    /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> to use for the property.</param>
-    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
-    public static IConventionPropertyBuilder HasDateTimeKind(
-        this IConventionPropertyBuilder propertyBuilder,
-        DateTimeKind dateTimeKind)
-    {
-        propertyBuilder.Metadata.SetDateTimeKind(dateTimeKind);
-        return propertyBuilder;
-    }
-
-    /// <summary>
     /// Configures the document element that the property is mapped to when targeting MongoDB.
     /// If an empty string is supplied then the property will not be persisted.
     /// </summary>
@@ -114,4 +87,94 @@ public static class MongoPropertyBuilderExtensions
         string? name,
         bool fromDataAnnotation = false)
         => propertyBuilder.CanSetAnnotation(MongoAnnotationNames.ElementName, name, fromDataAnnotation);
+
+    /// <summary>
+    /// Configures the <see cref="BsonType"/> that the property is stored as when targeting MongoDB.
+    /// </summary>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static PropertyBuilder HasBsonType(
+        this PropertyBuilder propertyBuilder,
+        BsonType bsonType)
+    {
+        ArgumentNullException.ThrowIfNull(bsonType);
+        propertyBuilder.Metadata.SetBsonType(bsonType);
+        return propertyBuilder;
+    }
+
+    /// <summary>
+    /// Configures the <see cref="BsonType"/> that the property is stored as when targeting MongoDB.
+    /// </summary>
+    /// <typeparam name="TProperty">The type of the property being configured.</typeparam>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static PropertyBuilder<TProperty> HasBsonType<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder,
+        BsonType bsonType)
+        => (PropertyBuilder<TProperty>)HasBsonType((PropertyBuilder)propertyBuilder, bsonType);
+
+    /// <summary>
+    /// Configures the <see cref="BsonType"/> that the property is stored as when targeting MongoDB.
+    /// If a null value is supplied then a default storage type based on the property type will be used.
+    /// </summary>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The same builder instance if the configuration was applied, <see langword="null" /> otherwise.</returns>
+    public static IConventionPropertyBuilder? HasBsonType(
+        this IConventionPropertyBuilder propertyBuilder,
+        BsonType? bsonType,
+        bool fromDataAnnotation = false)
+    {
+        if (!CanSetBsonType(propertyBuilder, bsonType, fromDataAnnotation))
+        {
+            return null;
+        }
+
+        propertyBuilder.Metadata.SetBsonType(bsonType, fromDataAnnotation);
+        return propertyBuilder;
+    }
+
+    /// <summary>
+    /// Returns a value indicating whether the given <see cref="BsonType"/> can be set.
+    /// </summary>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store this property as.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the <see cref="BsonType"/> can be set, <see langword="false"/> if not.</returns>
+    public static bool CanSetBsonType(
+        this IConventionPropertyBuilder propertyBuilder,
+        BsonType? bsonType,
+        bool fromDataAnnotation = false)
+        => propertyBuilder.CanSetAnnotation(MongoAnnotationNames.BsonType, bsonType, fromDataAnnotation);
+
+    /// <summary>
+    /// Configures the <see cref="DateTimeKind"/> for the property.
+    /// </summary>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> to use for the property.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static PropertyBuilder HasDateTimeKind(
+        this PropertyBuilder propertyBuilder,
+        DateTimeKind dateTimeKind)
+    {
+        propertyBuilder.Metadata.SetDateTimeKind(dateTimeKind);
+        return propertyBuilder;
+    }
+
+    /// <summary>
+    /// Configures the <see cref="DateTimeKind"/> for the property.
+    /// </summary>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> to use for the property.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static IConventionPropertyBuilder HasDateTimeKind(
+        this IConventionPropertyBuilder propertyBuilder,
+        DateTimeKind dateTimeKind)
+    {
+        propertyBuilder.Metadata.SetDateTimeKind(dateTimeKind);
+        return propertyBuilder;
+    }
 }

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Metadata;
 
@@ -56,7 +57,15 @@ public static class MongoPropertyExtensions
         return property.Name;
     }
 
-    public static bool IsOwnedTypeKey(this IProperty property)
+    /// <summary>
+    /// Returns the <see cref="BsonType"/> the property is stored as when targeting MongoDB.
+    /// </summary>
+    /// <param name="property">The <see cref="IReadOnlyProperty"/> to obtain the element name for.</param>
+    /// <returns>Returns the <see cref="BsonType"/> the property is stored as.</returns>
+    public static BsonType? GetBsonType(this IReadOnlyProperty property)
+        => (BsonType?)property[MongoAnnotationNames.BsonType];
+
+    internal static bool IsOwnedTypeKey(this IProperty property)
     {
         var entityType = (IReadOnlyEntityType)property.DeclaringType;
         if (entityType.IsDocumentRoot())
@@ -108,6 +117,36 @@ public static class MongoPropertyExtensions
     public static ConfigurationSource? GetElementNameConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(MongoAnnotationNames.ElementName)?.GetConfigurationSource();
 
+    /// <summary>
+    /// Sets the document <see cref="BsonType"/> that the property is stored as to when targeting MongoDB.
+    /// </summary>
+    /// <param name="property">The <see cref="IMutableProperty"/> to set the element name for.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> this property should be stored as.</param>
+    public static void SetBsonType(this IMutableProperty property, BsonType? bsonType)
+        => property.SetOrRemoveAnnotation(MongoAnnotationNames.BsonType, bsonType);
+
+    /// <summary>
+    /// Sets the document <see cref="BsonType"/> that the property is stored as to when targeting MongoDB.
+    /// </summary>
+    /// <param name="property">The <see cref="IConventionProperty"/> to set the element name for.</param>
+    /// <param name="bsonType">The name of the element that should be used.</param>
+    /// <param name="fromDataAnnotation"><see langword="true"/> if the configuration was specified using a data annotation, <see langword="false"/> if not.</param>
+    /// <returns>The configured <see cref="BsonType"/> the property will be stored as.</returns>
+    public static BsonType? SetBsonType(
+        this IConventionProperty property,
+        BsonType? bsonType,
+        bool fromDataAnnotation = false)
+        => (BsonType?)property.SetOrRemoveAnnotation(MongoAnnotationNames.BsonType, bsonType, fromDataAnnotation)?.Value;
+
+    /// <summary>
+    /// Gets the <see cref="ConfigurationSource" /> the <see cref="BsonType"/> that the property stored as to when targeting MongoDB.
+    /// </summary>
+    /// <param name="property">The <see cref="IConventionProperty"/> to obtain the storage <see cref="BsonType"/> for.</param>
+    /// <returns>
+    /// The <see cref="ConfigurationSource" /> the <see cref="BsonType"/> was specified by for this property.
+    /// </returns>
+    public static ConfigurationSource? GetBsonTypeConfigurationSource(this IConventionProperty property)
+        => property.FindAnnotation(MongoAnnotationNames.BsonType)?.GetConfigurationSource();
 
     /// <summary>
     /// Sets the <see cref="DateTimeKind"/> of the DateTime property is mapped to when targeting MongoDB.

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
@@ -120,16 +120,18 @@ public static class MongoPropertyExtensions
     /// <summary>
     /// Sets the document <see cref="BsonType"/> that the property is stored as to when targeting MongoDB.
     /// </summary>
-    /// <param name="property">The <see cref="IMutableProperty"/> to set the element name for.</param>
-    /// <param name="bsonType">The <see cref="BsonType"/> this property should be stored as.</param>
+    /// <param name="property">The <see cref="IMutableProperty"/> to set the BsonType for.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> this property should be stored as
+    /// or <see langword="null" /> to unset the value and use the default.</param>
     public static void SetBsonType(this IMutableProperty property, BsonType? bsonType)
         => property.SetOrRemoveAnnotation(MongoAnnotationNames.BsonType, bsonType);
 
     /// <summary>
     /// Sets the document <see cref="BsonType"/> that the property is stored as to when targeting MongoDB.
     /// </summary>
-    /// <param name="property">The <see cref="IConventionProperty"/> to set the element name for.</param>
-    /// <param name="bsonType">The name of the element that should be used.</param>
+    /// <param name="property">The <see cref="IConventionProperty"/> to set the BsonType for.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> this property should be stored as
+    /// or <see langword="null" /> to unset the value and use the default.</param>
     /// <param name="fromDataAnnotation"><see langword="true"/> if the configuration was specified using a data annotation, <see langword="false"/> if not.</param>
     /// <returns>The configured <see cref="BsonType"/> the property will be stored as.</returns>
     public static BsonType? SetBsonType(

--- a/src/MongoDB.EntityFrameworkCore/Metadata/MongoAnnotationNames.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/MongoAnnotationNames.cs
@@ -45,4 +45,9 @@ public static class MongoAnnotationNames
     /// The key for NotSupportedAttribute annotations.
     /// </summary>
     public const string NotSupportedAttributes = Prefix + nameof(NotSupportedAttributes);
+
+    /// <summary>
+    /// The key for BsonType annotations.
+    /// </summary>
+    public const string BsonType = Prefix + nameof(BsonType);
 }

--- a/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
@@ -88,7 +88,7 @@ internal static class SerializationHelper
 
         var typeSerializer = CreateTypeSerializer(property.ClrType, property);
 
-        // Apple HasBsonType configuration if set
+        // Apply HasBsonType configuration if set
         var bsonType = property.GetBsonType();
         if (bsonType != null && typeSerializer is IRepresentationConfigurable representationConfigurable)
         {
@@ -101,7 +101,6 @@ internal static class SerializationHelper
     private static IBsonSerializer CreateTypeSerializer(Type type, IReadOnlyProperty property = null)
         => type switch
         {
-            // CLR Types
             _ when type == typeof(bool) => BooleanSerializer.Instance,
             _ when type == typeof(byte) => new ByteSerializer(),
             _ when type == typeof(char) => new CharSerializer(),
@@ -113,6 +112,7 @@ internal static class SerializationHelper
             _ when type == typeof(short) => new Int16Serializer(),
             _ when type == typeof(int) => Int32Serializer.Instance,
             _ when type == typeof(long) => Int64Serializer.Instance,
+            _ when type == typeof(ObjectId) => ObjectIdSerializer.Instance,
             _ when type == typeof(TimeSpan) => new TimeSpanSerializer(),
             _ when type == typeof(sbyte) => new SByteSerializer(),
             _ when type == typeof(float) => new SingleSerializer(),
@@ -120,17 +120,10 @@ internal static class SerializationHelper
             _ when type == typeof(ushort) => new UInt16Serializer(),
             _ when type == typeof(uint) => new UInt32Serializer(),
             _ when type == typeof(ulong) => new UInt64Serializer(),
+            _ when type == typeof(Decimal128) => new Decimal128Serializer(),
             _ when type.IsEnum => EnumSerializer.Create(type),
-
-            // Nullable
             {IsGenericType: true} when type.GetGenericTypeDefinition() == typeof(Nullable<>)
                 => CreateNullableSerializer(type.GetGenericArguments()[0]),
-
-            // Mongo structs
-            _ when type == typeof(ObjectId) => ObjectIdSerializer.Instance,
-            _ when type == typeof(Decimal128) => new Decimal128Serializer(),
-
-            // Lists & Arrays
             {IsGenericType: true} or {IsArray: true} => new CollectionSerializationProvider().GetSerializer(type),
 
             _ => throw new NotSupportedException($"No known serializer for type '{type.ShortDisplayName()}'."),

--- a/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
@@ -86,12 +86,22 @@ internal static class SerializationHelper
             return serializer ?? throw new InvalidOperationException($"Unable to create serializer to handle '{converter.GetType().ShortDisplayName()}'");
         }
 
-        return CreateTypeSerializer(property.ClrType, property);
+        var typeSerializer = CreateTypeSerializer(property.ClrType, property);
+
+        // Apple HasBsonType configuration if set
+        var bsonType = property.GetBsonType();
+        if (bsonType != null && typeSerializer is IRepresentationConfigurable representationConfigurable)
+        {
+            typeSerializer = representationConfigurable.WithRepresentation(bsonType.Value);
+        }
+
+        return typeSerializer;
     }
 
     private static IBsonSerializer CreateTypeSerializer(Type type, IReadOnlyProperty property = null)
         => type switch
         {
+            // CLR Types
             _ when type == typeof(bool) => BooleanSerializer.Instance,
             _ when type == typeof(byte) => new ByteSerializer(),
             _ when type == typeof(char) => new CharSerializer(),
@@ -103,7 +113,6 @@ internal static class SerializationHelper
             _ when type == typeof(short) => new Int16Serializer(),
             _ when type == typeof(int) => Int32Serializer.Instance,
             _ when type == typeof(long) => Int64Serializer.Instance,
-            _ when type == typeof(ObjectId) => ObjectIdSerializer.Instance,
             _ when type == typeof(TimeSpan) => new TimeSpanSerializer(),
             _ when type == typeof(sbyte) => new SByteSerializer(),
             _ when type == typeof(float) => new SingleSerializer(),
@@ -111,11 +120,19 @@ internal static class SerializationHelper
             _ when type == typeof(ushort) => new UInt16Serializer(),
             _ when type == typeof(uint) => new UInt32Serializer(),
             _ when type == typeof(ulong) => new UInt64Serializer(),
-            _ when type == typeof(Decimal128) => new Decimal128Serializer(),
             _ when type.IsEnum => EnumSerializer.Create(type),
+
+            // Nullable
             {IsGenericType: true} when type.GetGenericTypeDefinition() == typeof(Nullable<>)
                 => CreateNullableSerializer(type.GetGenericArguments()[0]),
+
+            // Mongo structs
+            _ when type == typeof(ObjectId) => ObjectIdSerializer.Instance,
+            _ when type == typeof(Decimal128) => new Decimal128Serializer(),
+
+            // Lists & Arrays
             {IsGenericType: true} or {IsArray: true} => new CollectionSerializationProvider().GetSerializer(type),
+
             _ => throw new NotSupportedException($"No known serializer for type '{type.ShortDisplayName()}'."),
         };
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Exerciser.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Exerciser.cs
@@ -1,0 +1,165 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests;
+
+public class EntityWithValue<T>
+{
+    public ObjectId _id { get; set; }
+    public T value { get; set; }
+}
+
+public class EntityWithId<T>
+{
+    public T _id { get; set; }
+}
+
+public static class Exerciser
+{
+    public static void TestConvertedValueRoundTrip<TEntity, TStorage>(
+        TemporaryDatabaseFixture database,
+        TEntity expectedValue,
+        Func<TEntity, TStorage> converter,
+        Action<ModelBuilder>? modelConfig = default,
+        Func<TEntity, TEntity>? roundForComparison = default,
+        [CallerMemberName] string? caller = default)
+    {
+        roundForComparison ??= e => e;
+        var collectionName = caller + expectedValue;
+        var collection = database.CreateTemporaryCollection<EntityWithValue<TEntity>>(collectionName);
+
+        var expected = new EntityWithValue<TEntity>
+        {
+            _id = ObjectId.GenerateNewId(), value = expectedValue
+        };
+
+        modelConfig ??= _ => { };
+
+        {
+            // Test creation via EF
+            using var db = SingleEntityDbContext.Create(collection, modelConfig);
+            db.Entities.Add(expected);
+            Assert.Equal(1, db.SaveChanges());
+        }
+
+        {
+            // Test retrieval via EF
+            using var db = SingleEntityDbContext.Create(collection, modelConfig);
+            var found = db.Entities.First();
+            Assert.Equal(roundForComparison(expectedValue), roundForComparison(found.value));
+            Assert.Equal(expected._id, found._id);
+        }
+
+        {
+            // Test MongoDB C# driver retrieval
+            var mongoCollection = database.GetExistingTemporaryCollection<EntityWithValue<TStorage>>(collectionName);
+            var found = mongoCollection.AsQueryable().First();
+            Assert.Equal(converter(expectedValue), found.value);
+            Assert.Equal(expected._id, found._id);
+        }
+
+        {
+            // Test query via EF
+            using var db = SingleEntityDbContext.Create(collection, modelConfig);
+            var found = db.Entities.First(e => e.value.Equals(expectedValue));
+            Assert.Equal(roundForComparison(expectedValue), roundForComparison(found.value));
+            Assert.Equal(expected._id, found._id);
+        }
+
+        {
+            // Create native one in MongoDB C# Driver & read via EF
+            var mongoCollectionName = collectionName + "_";
+            var mongoCollection = database.CreateTemporaryCollection<EntityWithValue<TStorage>>(mongoCollectionName);
+            var expectedMongo = new EntityWithValue<TStorage>
+            {
+                _id = ObjectId.GenerateNewId(), value = converter(expectedValue)
+            };
+            mongoCollection.InsertOne(expectedMongo);
+
+            var efCollection = database.GetExistingTemporaryCollection<EntityWithValue<TEntity>>(mongoCollectionName);
+            using var db = SingleEntityDbContext.Create(efCollection, modelConfig);
+            var found = db.Entities.First();
+            Assert.Equal(roundForComparison(expectedValue), roundForComparison(found.value));
+        }
+    }
+
+    public static void TestConvertedIdRoundTrip<TEntity, TStorage>(
+        TemporaryDatabaseFixture database,
+        TEntity expectedId,
+        Func<TEntity, TStorage> converter,
+        Action<ModelBuilder>? modelConfig = default,
+        [CallerMemberName] string? caller = default)
+    {
+        var collectionName = caller + expectedId;
+        var collection = database.CreateTemporaryCollection<EntityWithId<TEntity>>(collectionName);
+
+        var expected = new EntityWithId<TEntity>
+        {
+            _id = expectedId
+        };
+
+        modelConfig ??= _ => { };
+
+        // Test creation via EF
+        {
+            using var db = SingleEntityDbContext.Create(collection, modelConfig);
+            db.Entities.Add(expected);
+
+            Assert.Equal(1, db.SaveChanges());
+        }
+
+        // Test retrieval via EF
+        {
+            using var db = SingleEntityDbContext.Create(collection, modelConfig);
+            var found = db.Entities.First();
+            Assert.Equal(expectedId, found._id);
+        }
+
+        {
+            // Test MongoDB C# driver retrieval
+            var mongoCollection = database.GetExistingTemporaryCollection<EntityWithId<TStorage>>(collectionName);
+            var found = mongoCollection.AsQueryable().First();
+            Assert.Equal(converter(expectedId), found._id);
+        }
+
+        {
+            // Test query via EF
+            using var db = SingleEntityDbContext.Create(collection, modelConfig);
+            var found = db.Entities.First(e => e._id.Equals(expectedId));
+            Assert.Equal(expected._id, found._id);
+        }
+
+        {
+            // Create native one in MongoDB C# Driver & read via EF
+            var mongoCollectionName = collectionName + "_";
+            var mongoCollection = database.CreateTemporaryCollection<EntityWithId<TStorage>>(mongoCollectionName);
+            var expectedMongo = new EntityWithId<TStorage>
+            {
+                _id = converter(expectedId)
+            };
+            mongoCollection.InsertOne(expectedMongo);
+
+            var efCollection = database.GetExistingTemporaryCollection<EntityWithId<TEntity>>(mongoCollectionName);
+            using var db = SingleEntityDbContext.Create(efCollection, modelConfig);
+            var found = db.Entities.First();
+            Assert.Equal(expectedId, found._id);
+        }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/BsonTypeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/BsonTypeTests.cs
@@ -1,0 +1,140 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+
+// ReSharper disable UseCollectionExpression - XUnit.NET TheoryData does not support collection initializers
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Mapping;
+
+[XUnitCollection("MappingTests")]
+public class BsonTypeTests(TemporaryDatabaseFixture tempDatabase)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    [Fact]
+    public void String_clr_with_ObjectId_storage()
+        => Exerciser.TestConvertedIdRoundTrip(tempDatabase,
+            ObjectId.GenerateNewId().ToString(),
+            a => new ObjectId(a),
+            mb => mb.Entity<EntityWithId<string>>().Property(e => e._id).HasBsonType(BsonType.ObjectId));
+
+    public static readonly TheoryData<decimal> ConstrainedDecimalData
+        = new() {0m, 1m, -1m, 1.1m, -1.1m};
+
+    [Theory]
+    [MemberData(nameof(ConstrainedDecimalData))]
+    public void Decimal_clr_with_Decimal128_storage(decimal expectedValue)
+        => Exerciser.TestConvertedValueRoundTrip(tempDatabase,
+            expectedValue,
+            a => new Decimal128(a),
+            mb => mb.Entity<EntityWithId<ObjectId>>().Property(e => e._id).HasBsonType(BsonType.Decimal128));
+
+    public static readonly TheoryData<int> IntData
+        = new() {0, 1, -1, int.MaxValue, int.MinValue};
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void Int_clr_with_String_storage(int expectedValue)
+        => TestValueRoundTripToString(expectedValue);
+
+    public static readonly TheoryData<double> DoubleData
+        = new() {0d, 1d, -1d, 1.2d, -1.2d, double.MaxValue, double.MinValue};
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void Double_clr_with_String_storage(double expectedValue)
+        => TestValueRoundTripToString(expectedValue);
+
+    public static readonly TheoryData<float> FloatData
+        = new() {0f, 1f, -1f, 1.1f, -1.1f, float.MaxValue, float.MinValue};
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void Float_clr_with_String_storage(float expectedValue)
+        => TestValueRoundTripToString(expectedValue);
+
+    public static readonly TheoryData<decimal> DecimalData
+        = new() {0m, 1m, -1m, 1.1m, -1.1m, decimal.MaxValue, decimal.MinValue};
+
+    [Theory]
+    [MemberData(nameof(DecimalData))]
+    public void Decimal_clr_with_String_storage(decimal expectedValue)
+        => TestValueRoundTripToString(expectedValue);
+
+    public static readonly TheoryData<Guid> GuidData
+        = new()
+        {
+            Guid.Empty,
+            Guid.NewGuid(),
+            Guid.Parse("f81d4fae-7dec-11d0-a765-00a0c91e6bf6"),
+            Guid.Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+            Guid.Parse("27701bfc-78d0-4e2b-92ca-193cea53fa30"),
+            Guid.Parse("1c8b3375-a836-5722-9e30-570df2fe82e5"),
+            Guid.Parse("9c115909-ac69-48ee-9583-b972a69fbc51")
+        };
+
+    [Theory]
+    [MemberData(nameof(GuidData))]
+    public void Guid_clr_with_String_storage(Guid expectedValue)
+        => TestValueRoundTripToString(expectedValue);
+
+    public static readonly TheoryData<TimeSpan> TimeSpanData
+        = new() {TimeSpan.Zero, TimeSpan.MaxValue, TimeSpan.MinValue, TimeSpan.FromDays(2), TimeSpan.FromHours(-1)};
+
+    [Theory]
+    [MemberData(nameof(TimeSpanData))]
+    public void TimeSpan_clr_with_String_storage(TimeSpan expectedValue)
+        => TestValueRoundTripToString(expectedValue);
+
+    public static readonly TheoryData<DateTime> DateTimeData
+        = new() { DateTime.Now, DateTime.Now.AddYears(500), DateTime.Now.AddYears(-500) };
+
+    [Theory]
+    [MemberData(nameof(DateTimeData))]
+    public void DateTime_clr_with_String_storage(DateTime expectedValue)
+        => Exerciser.TestConvertedValueRoundTrip(tempDatabase,
+            expectedValue.ToBsonPrecision(),
+            converter: a => a.ToBsonPrecision().ToUniversalTime(),
+            mb => mb.Entity<EntityWithValue<DateTime>>().Property(e => e.value)
+                .HasDateTimeKind(DateTimeKind.Local)
+                .HasBsonType(BsonType.String));
+
+    public static readonly TheoryData<DateTime> UtcDateTimeData
+        = new() { DateTime.UtcNow, DateTime.UtcNow.AddYears(500), DateTime.UtcNow.AddYears(-500) };
+
+    [Theory]
+    [MemberData(nameof(UtcDateTimeData))]
+    public void DateTime_clr_with_DateTime_storage(DateTime expectedValue)
+        => Exerciser.TestConvertedValueRoundTrip(tempDatabase,
+            expectedValue,
+            a => a.ToBsonPrecision(),
+            mb => mb.Entity<EntityWithValue<DateTime>>().Property(e => e.value)
+                .HasDateTimeKind(DateTimeKind.Utc)
+                .HasBsonType(BsonType.DateTime),
+            d => d.ToBsonPrecision());
+
+    private void TestValueRoundTripToString<T>(
+        T expectedValue,
+        [CallerMemberName] string? caller = default)
+    {
+        Exerciser.TestConvertedValueRoundTrip(tempDatabase,
+            expectedValue,
+            a => a?.ToString(),
+            mb => mb.Entity<EntityWithValue<T>>().Property(e => e.value).HasBsonType(BsonType.String),
+            caller: caller);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DateAndTimeSerializationTests.cs
@@ -38,7 +38,7 @@ public class DateAndTimeSerializationTests(TemporaryDatabaseFixture tempDatabase
             var collection = TempDatabase.GetExistingTemporaryCollection<UtcDateTimeEntity>();
             var result = collection.AsQueryable().First();
             Assert.NotNull(result);
-            Assert.Equal(expected.ToExpectedPrecision(), result.aDateTime.ToExpectedPrecision());
+            Assert.Equal(expected.ToBsonPrecision(), result.aDateTime.ToBsonPrecision());
         }
     }
 
@@ -59,7 +59,7 @@ public class DateAndTimeSerializationTests(TemporaryDatabaseFixture tempDatabase
             var collection = TempDatabase.GetExistingTemporaryCollection<LocalDateTimeEntity>();
             var result = collection.AsQueryable().First();
             Assert.NotNull(result);
-            Assert.Equal(expected.ToExpectedPrecision(), result.aDateTime.ToExpectedPrecision());
+            Assert.Equal(expected.ToBsonPrecision(), result.aDateTime.ToBsonPrecision());
         }
     }
 
@@ -105,7 +105,7 @@ public class DateAndTimeSerializationTests(TemporaryDatabaseFixture tempDatabase
             using var db = SingleEntityDbContext.Create(collection);
             var result = db.Entities.FirstOrDefault();
             Assert.NotNull(result);
-            Assert.Equal(expected.Value.ToExpectedPrecision(), result.aNullableDateTime.Value.ToExpectedPrecision());
+            Assert.Equal(expected.Value.ToBsonPrecision(), result.aNullableDateTime.Value.ToBsonPrecision());
         }
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/AddEntityTests.cs
@@ -198,7 +198,7 @@ public class AddEntityTests : IClassFixture<TemporaryDatabaseFixture>
             Assert.Equal(expected.aString, foundEntity.aString);
             Assert.Equal(expected.aChar, foundEntity.aChar);
             Assert.Equal(expected.aGuid, foundEntity.aGuid);
-            Assert.Equal(expected.aDateTime.ToExpectedPrecision(), foundEntity.aDateTime.ToExpectedPrecision());
+            Assert.Equal(expected.aDateTime.ToBsonPrecision(), foundEntity.aDateTime.ToBsonPrecision());
         }
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
@@ -102,7 +102,7 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
             Assert.Equal(entity._id, foundEntity._id);
             Assert.Equal(entity.session, foundEntity.session);
             Assert.Equal(entity.lastCount, foundEntity.lastCount);
-            Assert.Equal(entity.lastModified.ToExpectedPrecision(), foundEntity.lastModified.ToExpectedPrecision());
+            Assert.Equal(entity.lastModified.ToBsonPrecision(), foundEntity.lastModified.ToBsonPrecision());
         }
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/ExtensionMethods.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/ExtensionMethods.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
@@ -36,9 +37,12 @@ internal static class ExtensionMethods
     public static short NextInt16(this Random random)
         => (short)random.Next(1, short.MaxValue);
 
-    public static string ToExpectedPrecision(this DateTime dateTime)
-        =>  dateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffK");
-
     public static void WriteTestDocs<T>(this IMongoCollection<T> collection, IEnumerable<T> docs)
         => collection.BulkWrite(docs.Select(p => new InsertOneModel<T>(p)));
+
+    public static DateTime ToBsonPrecision(this DateTime dateTime)
+    {
+        var bsonDateTime = new BsonDateTime(dateTime);
+        return dateTime.Kind == DateTimeKind.Utc ? bsonDateTime.ToUniversalTime() : bsonDateTime.ToLocalTime();
+    }
 }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoPropertyBuilderExtensionsTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoPropertyBuilderExtensionsTests.cs
@@ -14,11 +14,29 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.UnitTests.Extensions;
 
 public class MongoPropertyBuilderExtensionsTests
 {
+    [Theory]
+    [InlineData(BsonType.String)]
+    [InlineData(BsonType.Double)]
+    [InlineData(BsonType.Decimal128)]
+    [InlineData(BsonType.Int64)]
+    [InlineData(null)]
+    public void HasBsonType_can_set_value_on_property(BsonType? value)
+    {
+        var model = new ModelBuilder();
+        var entity = model.Entity<TestEntity>();
+
+        entity.Property(e => e.DateTimeProperty).HasBsonType(value);
+
+        var property = entity.Metadata.GetProperty(nameof(TestEntity.DateTimeProperty));
+        Assert.Equal(value, property.GetBsonType());
+    }
+
     [Theory]
     [InlineData(DateTimeKind.Local)]
     [InlineData(DateTimeKind.Utc)]


### PR DESCRIPTION
Provides a `HasBsonType` fluent API that allows the model builder to configure specific properties to be stored as specific BSON types.

Fixes EF-127

A subsequent PR will further expose this feature out so that `BsonRepresentation` attributes can be recognized (EF-44)