### PR TITLE
EF-131: Support matching on owned entity values

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -42,7 +42,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     }
 
     [Fact]
-    public void OwnedEntity_nested_one_level_where_null()
+    public void OwnedEntity_nested_one_level_where_not_null()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
@@ -56,7 +56,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     }
 
     [Fact]
-    public void OwnedEntity_nested_one_level_where_not_null()
+    public void OwnedEntity_nested_one_level_where_null()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithOptionalLocation>();
         collection.WriteTestDocs([new PersonWithOptionalLocation { _id = ObjectId.GenerateNewId(), name = "Milton" }]);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -42,6 +42,103 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     }
 
     [Fact]
+    public void OwnedEntity_nested_one_level_where_null()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        collection.WriteTestDocs(PersonWithLocation1);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var actual = db.Entities.Where(e => e.location != null).First();
+
+        Assert.Equal("Carmen", actual.name);
+        Assert.Equal(Location1.latitude, actual.location.latitude);
+        Assert.Equal(Location1.longitude, actual.location.longitude);
+    }
+
+    [Fact]
+    public void OwnedEntity_nested_one_level_where_not_null()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithOptionalLocation>();
+        collection.WriteTestDocs([new PersonWithOptionalLocation { _id = ObjectId.GenerateNewId(), name = "Milton" }]);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var actual = db.Entities.Where(e => e.location == null).First();
+
+        Assert.Equal("Milton", actual.name);
+        Assert.Null(actual.location);
+    }
+
+    [Fact]
+    public void OwnedEntity_nested_one_level_first_matching_location()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        collection.WriteTestDocs(PersonWithLocation1);
+        collection.WriteTestDocs(Person2WithLocation1);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var location = db.Entities.First(p => p.name == "Carmen").location;
+        var actual = db.Entities.First(p => p.location == location && p.name != "Carmen");
+
+        Assert.Equal("Milton", actual.name);
+        Assert.Equal(Location1.latitude, actual.location.latitude);
+        Assert.Equal(Location1.longitude, actual.location.longitude);
+    }
+
+    [Fact]
+    public void OwnedEntity_nested_one_level_first_no_matching_location()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        collection.WriteTestDocs(PersonWithLocation1);
+        collection.WriteTestDocs(Person2WithLocation1);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var location = db.Entities.First(p => p.name == "Carmen").location;
+        var actual = db.Entities.FirstOrDefault(p => p.location != location);
+
+        Assert.Null(actual);
+    }
+
+    [Fact]
+    public void OwnedEntity_nested_one_level_first_match_location_property()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
+        collection.WriteTestDocs(PersonWithLocation1);
+        collection.WriteTestDocs(Person2WithLocation1);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var location = db.Entities.First(p => p.name == "Carmen").location;
+        var actual = db.Entities.FirstOrDefault(p => p.location.latitude == location.latitude && p.name != "Carmen");
+
+        Assert.Equal("Milton", actual.name);
+    }
+
+    [Fact]
+    public void OwnedEntity_nested_one_level_collection_match()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
+        collection.WriteTestDocs(PersonWithLocations1);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var location = db.Entities.First().locations[1];
+        var actual = db.Entities.FirstOrDefault(p => p.locations.Contains(location));
+
+        Assert.Equal("Damien", actual.name);
+    }
+
+    [Fact]
+    public void OwnedEntity_nested_one_level_collection_not_match()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<PersonWithMultipleLocations>();
+        collection.WriteTestDocs(PersonWithLocations1);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var location = db.Entities.First().locations[1];
+        var actual = db.Entities.FirstOrDefault(p => !p.locations.Contains(location));
+
+        Assert.Equal("Carmen", actual.name);
+    }
+
+    [Fact]
     public void OwnedEntity_missing_document_element_does_not_throw()
     {
         _tempDatabase.CreateTemporaryCollection<Person>("personNoLocation").WriteTestDocs([
@@ -799,6 +896,14 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         new()
         {
             name = "Carmen", location = Location1
+        }
+    ];
+
+    private static readonly PersonWithLocation[] Person2WithLocation1 =
+    [
+        new()
+        {
+            name = "Milton", location = Location1
         }
     ];
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -69,7 +69,7 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
     }
 
     [Fact]
-    public void OwnedEntity_nested_one_level_first_matching_location()
+    public void OwnedEntity_nested_one_level_first_matching_location_throws()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
@@ -77,15 +77,14 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         using var db = SingleEntityDbContext.Create(collection);
 
         var location = db.Entities.First(p => p.name == "Carmen").location;
-        var actual = db.Entities.First(p => p.location == location && p.name != "Carmen");
 
-        Assert.Equal("Milton", actual.name);
-        Assert.Equal(Location1.latitude, actual.location.latitude);
-        Assert.Equal(Location1.longitude, actual.location.longitude);
+        var ex = Assert.Throws<NotSupportedException>(() => db.Entities.First(p => p.location == location && p.name != "Carmen"));
+        Assert.Contains(nameof(Location), ex.Message);
+        Assert.Contains("unique fields", ex.Message);
     }
 
     [Fact]
-    public void OwnedEntity_nested_one_level_first_no_matching_location()
+    public void OwnedEntity_nested_one_level_first_no_matching_location_throws()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<PersonWithLocation>();
         collection.WriteTestDocs(PersonWithLocation1);
@@ -93,9 +92,10 @@ public class OwnedEntityTests : IClassFixture<TemporaryDatabaseFixture>
         using var db = SingleEntityDbContext.Create(collection);
 
         var location = db.Entities.First(p => p.name == "Carmen").location;
-        var actual = db.Entities.FirstOrDefault(p => p.location != location);
 
-        Assert.Null(actual);
+        var ex = Assert.Throws<NotSupportedException>(() => db.Entities.FirstOrDefault(p => p.location != location));
+        Assert.Contains(nameof(Location), ex.Message);
+        Assert.Contains("unique fields", ex.Message);
     }
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
@@ -251,7 +251,7 @@ public class WhereTests : IDisposable, IAsyncDisposable
         Assert.All(results, p => Assert.NotEmpty(p.mainAtmosphere));
     }
 
-    [Fact]
+    [Fact(Skip = "Errors wiuth MongoDB < 5.0")]
     public void Where_entity_equal_null()
     {
         var actual = _db.Planets.FirstOrDefault(p => p == null);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
@@ -251,6 +251,39 @@ public class WhereTests : IDisposable, IAsyncDisposable
         Assert.All(results, p => Assert.NotEmpty(p.mainAtmosphere));
     }
 
+    [Fact]
+    public void Where_entity_equal_null()
+    {
+        var actual = _db.Planets.FirstOrDefault(p => p == null);
+        Assert.Null(actual);
+    }
+
+    [Fact]
+    public void Where_entity_not_equal_null()
+    {
+        var actual = _db.Planets.First(p => p != null);
+        Assert.NotNull(actual);
+    }
+
+    [Fact]
+    public void Where_entity_equal_throws()
+    {
+        var first = _db.Planets.First();
+        var ex = Assert.Throws<NotSupportedException>(() => _db.Planets.Where(p => p == first).ToList());
+        Assert.Contains(nameof(Planet._id), ex.Message);
+        Assert.Contains(nameof(Planet), ex.Message);
+    }
+
+    [Fact]
+    public void Where_entity_not_equal_throws()
+    {
+        var orderedPlanets = _db.Planets.OrderBy(p => p.name);
+        var first = orderedPlanets.First();
+        var ex = Assert.Throws<NotSupportedException>(() => orderedPlanets.First(p => p != first));
+        Assert.Contains(nameof(Planet._id), ex.Message);
+        Assert.Contains(nameof(Planet), ex.Message);
+    }
+
     public void Dispose()
         => _db.Dispose();
 


### PR DESCRIPTION
Previously we did not support matching entire owned entities for where/contains/first etc. 

This adds support for that by ensuring the entity serializer can serialize the EF entity back to the Bson document for matching.

Fixes EF-131.