### PR TITLE
EF-142: Log MQL even when LINQ driver throws.

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
@@ -164,7 +164,16 @@ internal sealed class QueryingEnumerable<TSource, TTarget> : IAsyncEnumerable<TT
             {
                 EntityFrameworkEventSource.Log.QueryExecuting();
 
-                _enumerator = _queryContext.MongoClient.Execute<TSource>(_executableQuery, out logAction).GetEnumerator();
+                try
+                {
+                    _enumerator = _queryContext.MongoClient.Execute<TSource>(_executableQuery, out logAction).GetEnumerator();
+                }
+                catch
+                {
+                    // Ensure we log the query even when C# Driver throws
+                    logAction?.Invoke();
+                    throw;
+                }
 
                 _queryContext.InitializeStateManager(_standAloneStateManager);
             }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestServer.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestServer.cs
@@ -30,4 +30,8 @@ internal static class TestServer
 
     public static IMongoClient GetClient()
         => MongoClient;
+
+    public static readonly IMongoClient BrokenClient
+        = new MongoClient(new MongoClientSettings { Server = new MongoServerAddress("localhost", 27000), ServerSelectionTimeout = TimeSpan.Zero, ConnectTimeout = TimeSpan.FromSeconds(1)});
+
 }


### PR DESCRIPTION
Previously if the LINQ provider threw the MQL would not be logged.

This change ensures we always log the MQL even if it does throw as it is very useful in debugging certain throwing scenarios.

Small test cleanup in the touched LoggingTests to reduce boilerplate in finding the correct log entry.

Fixes EF-142