### PR TITLE
Upgrade to C# Driver 2.26.0

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 
@@ -31,6 +32,11 @@ using BulkWriteEventDefinition = EventDefinition<string, CollectionNamespace, lo
 /// </summary>
 internal static class MongoLoggerExtensions
 {
+    internal static void ExecutedMqlQuery(
+        this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
+        MongoExecutableQuery mongoExecutableQuery)
+        => ExecutedMqlQuery(diagnostics, mongoExecutableQuery.CollectionNamespace, mongoExecutableQuery.Provider.LoggedStages);
+
     public static void ExecutedMqlQuery(
         this IDiagnosticsLogger<DbLoggerCategory.Database.Command> diagnostics,
         CollectionNamespace collectionNamespace,

--- a/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
+++ b/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.UnitTests" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.26.0" />
     <PackageReference Remove="Microsoft.SourceLink.GitHub"/>
   </ItemGroup>
 </Project>

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
@@ -1,22 +1,22 @@
 ﻿/* Copyright 2023-present MongoDB Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace MongoDB.EntityFrameworkCore.Query;
 
@@ -26,6 +26,6 @@ namespace MongoDB.EntityFrameworkCore.Query;
 /// </summary>
 /// <param name="Query">A LINQ query <see cref="Expression"/> compatible with the MongoDB LINQ provider.</param>
 /// <param name="Cardinality">Whether many or a single result are expected (or enforced) as a <see cref="ResultCardinality"/>.</param>
-/// <param name="Provider">The MongoDB V3 LINQ <see cref="IQueryProvider"/> that will execute this query.</param>
+/// <param name="Provider">The MongoDB V3 LINQ <see cref="IMongoQueryProvider"/> that will execute this query.</param>
 /// <param name="CollectionNamespace">The <see cref="CollectionNamespace"/> this query will run against.</param>
-public record MongoExecutableQuery(Expression Query, ResultCardinality Cardinality, IQueryProvider Provider, CollectionNamespace CollectionNamespace);
+public record MongoExecutableQuery(Expression Query, ResultCardinality Cardinality, IMongoQueryProvider Provider, CollectionNamespace CollectionNamespace);

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -77,7 +77,7 @@ public class MongoClientWrapper : IMongoClientWrapper
         }
 
         var queryable = (IMongoQueryable<T>)executableQuery.Provider.CreateQuery<T>(executableQuery.Query);
-        log = () => _commandLogger.ExecutedMqlQuery(executableQuery.CollectionNamespace, queryable.LoggedStages);
+        log = () => _commandLogger.ExecutedMqlQuery(executableQuery);
         return queryable;
     }
 
@@ -90,23 +90,12 @@ public class MongoClientWrapper : IMongoClientWrapper
         }
         catch
         {
-            // Ensure we log the query even when C# Driver throws
-            LogQuery();
+            _commandLogger.ExecutedMqlQuery(executableQuery);
             throw;
         }
 
-        LogQuery();
+        _commandLogger.ExecutedMqlQuery(executableQuery);
         return [result];
-
-        void LogQuery()
-        {
-            // We need to get this via reflection from the Mongo C# Driver for now.
-            var getLoggedStages = executableQuery.Provider.GetType().GetProperty("LoggedStages");
-            if (getLoggedStages?.GetValue(executableQuery.Provider) is BsonDocument[] loggedStages)
-            {
-                _commandLogger.ExecutedMqlQuery(executableQuery.CollectionNamespace, loggedStages);
-            }
-        }
     }
 
     /// <summary>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -178,7 +178,7 @@ public class ValueConverterTests(TemporaryDatabaseFixture tempDatabase)
         Assert.Equal(active, found.active);
     }
 
-    [Theory(Skip = "Currently not able to map CLR bool in C# Driver to non-bool types when querying")]
+    [Theory]
     [InlineData([true])]
     [InlineData([false])]
     public void Bool_can_query_against_string(bool active)


### PR DESCRIPTION
As well as updating the NuGet reference there are two small changes that directly relate to 2.26.0:

1. The unit test that previously failed because of a bug in the C# Driver is now re-enabled
2. The logging code no longer needs to use reflection and is cleaned up to reflect the simpler pattern