### PR TITLE
EF-140: Third Party Dependencies Report for Entity Framework

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,7 @@
+{
+  "serialNumber": "urn:uuid:abde4013-504f-45bb-9bdc-2ffa7b4bf591",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}


### PR DESCRIPTION
Empty SBOM since EF doesn't have any third party dependencies matching the SSDLC spec criteria.