### PR TITLE
EF-47: Dictionary & ReadOnlyDictionary property support

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/ChangeTracking/NullableStringDictionaryComparer.cs
+++ b/src/MongoDB.EntityFrameworkCore/ChangeTracking/NullableStringDictionaryComparer.cs
@@ -1,0 +1,116 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Originally from EFCore.Cosmos NullableStringDictionaryComparer.cs
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace MongoDB.EntityFrameworkCore.ChangeTracking;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public sealed class NullableStringDictionaryComparer<TElement, TCollection> : ValueComparer<TCollection>
+    where TCollection : class, IEnumerable<KeyValuePair<string, TElement?>>
+    where TElement : struct
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public NullableStringDictionaryComparer(ValueComparer elementComparer, bool readOnly)
+        : base(
+            (a, b) => Compare(a, b, (ValueComparer<TElement>)elementComparer),
+            o => GetHashCode(o, (ValueComparer<TElement>)elementComparer),
+            source => Snapshot(source, (ValueComparer<TElement>)elementComparer, readOnly))
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Type Type
+        => typeof(TCollection);
+
+    private static bool Compare(TCollection? a, TCollection? b, ValueComparer<TElement> elementComparer)
+    {
+        if (a is not IReadOnlyDictionary<string, TElement?> aDict)
+        {
+            return b is not IReadOnlyDictionary<string, TElement?>;
+        }
+
+        if (b is not IReadOnlyDictionary<string, TElement?> bDict || aDict.Count != bDict.Count)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(aDict, bDict))
+        {
+            return true;
+        }
+
+        foreach (var (key, element) in aDict)
+        {
+            if (!bDict.TryGetValue(key, out var bValue))
+            {
+                return false;
+            }
+
+            if (element is null)
+            {
+                if (bValue is null)
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
+            if (bValue is null || !elementComparer.Equals(element, bValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int GetHashCode(TCollection source, ValueComparer<TElement> elementComparer)
+    {
+        var nullableEqualityComparer = new NullableEqualityComparer<TElement>(elementComparer);
+        var hash = new HashCode();
+        foreach (var (key, element) in source)
+        {
+            hash.Add(key);
+            hash.Add(element, nullableEqualityComparer);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    private static TCollection Snapshot(TCollection source, ValueComparer<TElement> elementComparer, bool readOnly)
+    {
+        if (readOnly)
+        {
+            return source;
+        }
+
+        var snapshot = new Dictionary<string, TElement?>(((IReadOnlyDictionary<string, TElement?>)source).Count);
+        foreach (var (key, element) in source)
+        {
+            snapshot.Add(key, element is null ? null : elementComparer.Snapshot(element.Value));
+        }
+
+        return (TCollection)(object)snapshot;
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/ChangeTracking/StringDictionaryComparer.cs
+++ b/src/MongoDB.EntityFrameworkCore/ChangeTracking/StringDictionaryComparer.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Originally from EFCore.Cosmos StringDictionaryComparer.cs
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace MongoDB.EntityFrameworkCore.ChangeTracking;
+
+/// <summary>
+///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+///     any release. You should only use it directly in your code with extreme caution and knowing that
+///     doing so can result in application failures when updating to a new Entity Framework Core release.
+/// </summary>
+public sealed class StringDictionaryComparer<TElement, TCollection> : ValueComparer<TCollection>
+    where TCollection : class, IEnumerable<KeyValuePair<string, TElement>>
+{
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public StringDictionaryComparer(ValueComparer elementComparer, bool readOnly)
+        : base(
+            (a, b) => Compare(a, b, (ValueComparer<TElement>)elementComparer),
+            o => GetHashCode(o, (ValueComparer<TElement>)elementComparer),
+            source => Snapshot(source, (ValueComparer<TElement>)elementComparer, readOnly))
+    {
+    }
+
+    /// <summary>
+    ///     This is an internal API that supports the Entity Framework Core infrastructure and not subject to
+    ///     the same compatibility standards as public APIs. It may be changed or removed without notice in
+    ///     any release. You should only use it directly in your code with extreme caution and knowing that
+    ///     doing so can result in application failures when updating to a new Entity Framework Core release.
+    /// </summary>
+    public override Type Type
+        => typeof(TCollection);
+
+    private static bool Compare(TCollection? a, TCollection? b, ValueComparer<TElement> elementComparer)
+    {
+        if (a is not IReadOnlyDictionary<string, TElement> aDict)
+        {
+            return b is not IReadOnlyDictionary<string, TElement>;
+        }
+
+        if (b is not IReadOnlyDictionary<string, TElement> bDict || aDict.Count != bDict.Count)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(aDict, bDict))
+        {
+            return true;
+        }
+
+        foreach (var (key, element) in aDict)
+        {
+            if (!bDict.TryGetValue(key, out var bValue)
+                || !elementComparer.Equals(element, bValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int GetHashCode(TCollection source, ValueComparer<TElement> elementComparer)
+    {
+        var hash = new HashCode();
+        foreach (var (key, element) in source)
+        {
+            hash.Add(key);
+            hash.Add(element, elementComparer);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    private static TCollection Snapshot(TCollection source, ValueComparer<TElement> elementComparer, bool readOnly)
+    {
+        if (readOnly)
+        {
+            return source;
+        }
+
+        var snapshot = new Dictionary<string, TElement>(((IReadOnlyDictionary<string, TElement>)source).Count);
+        foreach (var (key, element) in source)
+        {
+            snapshot.Add(key, element is null ? default! : elementComparer.Snapshot(element));
+        }
+
+        return (TCollection)(object)snapshot;
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Serializers/CollectionSerializationProvider.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/CollectionSerializationProvider.cs
@@ -26,7 +26,8 @@ namespace MongoDB.EntityFrameworkCore.Serializers;
 
 internal class CollectionSerializationProvider : BsonSerializationProviderBase
 {
-    /// <inheritdoc/>
+    public static readonly CollectionSerializationProvider Instance = new();
+
     public override IBsonSerializer GetSerializer(Type type, IBsonSerializerRegistry serializerRegistry)
     {
         ArgumentNullException.ThrowIfNull(type);

--- a/src/MongoDB.EntityFrameworkCore/Serializers/DictionarySerializationProvider.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/DictionarySerializationProvider.cs
@@ -67,7 +67,7 @@ internal class DictionarySerializationProvider : BsonSerializationProviderBase
             return CreateGenericSerializer(typeof(DictionaryInterfaceImplementerSerializer<,,>), [concreteType, keyType, valueType], serializerRegistry);
         }
 
-        var readOnlyDictionaryInterface= genericTypeDefinition == typeof(IReadOnlyDictionary<,>)
+        var readOnlyDictionaryInterface = genericTypeDefinition == typeof(IReadOnlyDictionary<,>)
             ? type
             : type.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>));
 

--- a/src/MongoDB.EntityFrameworkCore/Serializers/DictionarySerializationProvider.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/DictionarySerializationProvider.cs
@@ -1,0 +1,87 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace MongoDB.EntityFrameworkCore.Serializers;
+
+internal class DictionarySerializationProvider : BsonSerializationProviderBase
+{
+    private static readonly Type[] SupportedDictionaryTypes =
+        [typeof(Dictionary<,>), typeof(IDictionary<,>), typeof(IReadOnlyDictionary<,>), typeof(ReadOnlyDictionary<,>)];
+
+    public static readonly DictionarySerializationProvider Instance = new();
+
+    public static bool Supports(Type type)
+        => type.IsGenericType && SupportedDictionaryTypes.Contains(type.GetGenericTypeDefinition());
+
+    public override IBsonSerializer GetSerializer(Type type, IBsonSerializerRegistry serializerRegistry)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        if (type is {IsGenericType: true, ContainsGenericParameters: true})
+        {
+            throw new ArgumentException($"Generic type '{type.ShortDisplayName()}' has unassigned generic type parameters.",
+                nameof(type));
+        }
+
+        return CreateDictionarySerializer(type, serializerRegistry)
+               ?? throw new ArgumentException($"No known serializer for type '{type.ShortDisplayName()}'.", nameof(type));
+    }
+
+    private IBsonSerializer? CreateDictionarySerializer(Type type, IBsonSerializerRegistry serializerRegistry)
+    {
+        var genericTypeDefinition = type.GetGenericTypeDefinition();
+
+        var dictionaryInterface = genericTypeDefinition == typeof(IDictionary<,>)
+            ? type
+            : type.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+
+        if (dictionaryInterface != null)
+        {
+            var genericArguments = dictionaryInterface.GetTypeInfo().GetGenericArguments();
+            var keyType = genericArguments[0];
+            var valueType = genericArguments[1];
+            var concreteType = type.IsInterface
+                ? typeof(Dictionary<,>).MakeGenericType(keyType, valueType)
+                : type;
+            return CreateGenericSerializer(typeof(DictionaryInterfaceImplementerSerializer<,,>), [concreteType, keyType, valueType], serializerRegistry);
+        }
+
+        var readOnlyDictionaryInterface= genericTypeDefinition == typeof(IReadOnlyDictionary<,>)
+            ? type
+            : type.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>));
+
+        if (readOnlyDictionaryInterface != null)
+        {
+            var genericArguments = readOnlyDictionaryInterface.GetTypeInfo().GetGenericArguments();
+            var keyType = genericArguments[0];
+            var valueType = genericArguments[1];
+            var concreteType = type.IsInterface
+                ? typeof(ReadOnlyDictionary<,>).MakeGenericType(keyType, valueType)
+                : type;
+            return CreateGenericSerializer(typeof(ReadOnlyDictionaryInterfaceImplementerSerializer<,,>), [concreteType, keyType, valueType], serializerRegistry);
+        }
+
+        return null;
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/SerializationHelper.cs
@@ -139,7 +139,10 @@ internal static class SerializationHelper
             _ when type.IsEnum => EnumSerializer.Create(type),
             {IsGenericType: true} when type.GetGenericTypeDefinition() == typeof(Nullable<>)
                 => CreateNullableSerializer(type.GetGenericArguments()[0]),
-            {IsGenericType: true} or {IsArray: true} => new CollectionSerializationProvider().GetSerializer(type),
+            {IsGenericType: true} when DictionarySerializationProvider.Supports(type)
+                => DictionarySerializationProvider.Instance.GetSerializer(type),
+            {IsGenericType: true} or {IsArray: true}
+                => CollectionSerializationProvider.Instance.GetSerializer(type),
 
             _ => throw new NotSupportedException($"No known serializer for type '{type.ShortDisplayName()}'."),
         };

--- a/src/MongoDB.EntityFrameworkCore/TypeExtensionMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/TypeExtensionMethods.cs
@@ -93,6 +93,16 @@ internal static class TypeExtensions
         }
     }
 
+    internal static bool HasInterface(this Type type, Type[] interfaces)
+    {
+        var typeToConsider = !type.IsGenericType || type.IsGenericTypeDefinition
+            ? type
+            : type.GetGenericTypeDefinition();
+
+        return interfaces.Contains(typeToConsider) ||
+               typeToConsider.GetInterfaces().Any(i => i.IsGenericType && interfaces.Contains(i.GetGenericTypeDefinition()));
+    }
+
     /// <summary>
     /// Create a nullable version of a <see cref="Type"/>.
     /// </summary>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereDictionaryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereDictionaryTests.cs
@@ -1,0 +1,373 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+[XUnitCollection("WhereTests")]
+public class WhereDictionaryTests(TemporaryDatabaseFixture tempDatabase)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    class DictionaryEntity
+    {
+        public ObjectId _id { get; set; }
+        public Dictionary<string, string> Dictionary { get; set; }
+    }
+
+    class DictionaryIntEntity
+    {
+        public ObjectId _id { get; set; }
+        public Dictionary<string, int> Dictionary { get; set; }
+    }
+
+    class IDictionaryIntEntity
+    {
+        public ObjectId _id { get; set; }
+        public IDictionary<string, int> Dictionary { get; set; }
+    }
+
+    class IReadOnlyDictionaryIntEntity
+    {
+        public ObjectId _id { get; set; }
+        public IReadOnlyDictionary<string, int> Dictionary { get; set; }
+    }
+
+    [Fact]
+    public void Where_Dictionary_contains_key()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key1", "value1"}, {"key2", null!}}
+                },
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key2", "value2"}}
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
+            var found = Assert.Single(results);
+            Assert.Equal(2, found.Dictionary.Count);
+        }
+    }
+
+    [Fact]
+    public void Where_Dictionary_key_equals_value()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key1", "value1"}, {"key2", null!}}
+                },
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key2", "value2"}}
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary["key2"] == "value2").ToArray();
+            var found = Assert.Single(results);
+            var entry = Assert.Single(found.Dictionary);
+            Assert.Equal("key2", entry.Key);
+            Assert.Equal("value2", entry.Value);
+        }
+    }
+
+    [Fact]
+    public void Where_Dictionary_key_equals_null()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key1", "value1"}, {"key2", null!}}
+                },
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key2", "value2"}}
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary["key2"] == null!).ToArray();
+            var found = Assert.Single(results);
+            Assert.Equal("value1", Assert.Contains("key1", found.Dictionary));
+        }
+    }
+
+    [Fact]
+    public void Where_Dictionary_key_not_equals_null()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key1", "value1"}, {"key2", null!}}
+                },
+                new DictionaryEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, string> {{"key1", null!}}
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+
+            var results = db.Entities.Where(e => e.Dictionary["key1"] != null!).ToArray();
+            var found = Assert.Single(results);
+            Assert.Equal("value1", Assert.Contains("key1", found.Dictionary));
+        }
+    }
+
+    [Fact]
+    public void Where_Dictionary_value_in_range()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryIntEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new DictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 10}, {"key2", 50}}
+                },
+                new DictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 72}, {"key2", 100}}
+                },
+                new DictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 100}, {"key2", 500}}
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary["key1"] >= 72 && e.Dictionary["key2"] < 101).ToArray();
+            var found = Assert.Single(results);
+            Assert.Equal(100, Assert.Contains("key2", found.Dictionary));
+        }
+    }
+
+    [Fact]
+    public void Where_IDictionary_contains_key()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryIntEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new IDictionaryIntEntity {_id = ObjectId.GenerateNewId(), Dictionary = new Dictionary<string, int> {{"key1", 1}}},
+                new IDictionaryIntEntity {_id = ObjectId.GenerateNewId(), Dictionary = new Dictionary<string, int> {{"key2", 2}}});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
+            Assert.Single(results);
+        }
+    }
+
+    [Fact]
+    public void Where_IDictionary_key_equals_value()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryIntEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new IDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 1}}
+                },
+                new IDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key2", 2}}
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary["key2"] == 2).ToArray();
+            var found = Assert.Single(results);
+            var entry = Assert.Single(found.Dictionary);
+            Assert.Equal("key2", entry.Key);
+            Assert.Equal(2, entry.Value);
+        }
+    }
+
+    [Fact]
+    public void Where_IDictionary_value_in_range()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryIntEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new IDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 10}, {"key2", 50}}
+                },
+                new IDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 72}, {"key2", 100}}
+                },
+                new IDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 100}, {"key2", 500}}
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary["key1"] >= 72 && e.Dictionary["key2"] < 101).ToArray();
+            var found = Assert.Single(results);
+            Assert.Equal(100, Assert.Contains("key2", found.Dictionary));
+        }
+    }
+
+    [Fact]
+    public void Where_ReadOnlyDictionary_contains_key()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IReadOnlyDictionaryIntEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new IReadOnlyDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(), Dictionary = new Dictionary<string, int> {{"key1", 1}}.AsReadOnly()
+                },
+                new IReadOnlyDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(), Dictionary = new Dictionary<string, int> {{"key2", 2}}.AsReadOnly()
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
+            Assert.Single(results);
+        }
+    }
+
+    [Fact(Skip = "IReadOnly.this[] not supported in C# Driver LINQ v3 yet")]
+    public void Where_ReadOnlyDictionary_key_equals_value()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IReadOnlyDictionaryIntEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new IReadOnlyDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(), Dictionary = new Dictionary<string, int> {{"key1", 1}}.AsReadOnly()
+                },
+                new IReadOnlyDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(), Dictionary = new Dictionary<string, int> {{"key2", 2}}.AsReadOnly()
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.Where(e => e.Dictionary["key2"] == 2).ToArray();
+            var found = Assert.Single(results);
+            var entry = Assert.Single(found.Dictionary);
+            Assert.Equal("key2", entry.Key);
+            Assert.Equal(2, entry.Value);
+        }
+    }
+
+    [Fact]
+    public void Where_ReadOnlyDictionary_value_in_range()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IReadOnlyDictionaryIntEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new IReadOnlyDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(), Dictionary = new Dictionary<string, int>().AsReadOnly()
+                },
+                new IReadOnlyDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 10}, {"key2", 50}}.AsReadOnly()
+                },
+                new IReadOnlyDictionaryIntEntity
+                {
+                    _id = ObjectId.GenerateNewId(),
+                    Dictionary = new Dictionary<string, int> {{"key1", 100}, {"key2", 500}}.AsReadOnly()
+                });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var results = db.Entities.ToList();
+            Assert.Equal(3, results.Count);
+        }
+    }
+}
+

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/CollectionSerializationTests.cs
@@ -144,6 +144,45 @@ public class CollectionSerializationTests : BaseSerializationTests
     }
 
 
+    public static readonly TheoryData<string[][]> ArrayOfArraysData =
+    [
+        [],
+        [
+            new [] { "a", "b", "c" },
+            new [] { "d" }
+        ]
+    ];
+
+    [Theory]
+    [MemberData(nameof(ArrayOfArraysData))]
+    public void String_array_of_arrays_round_trips(string[][] expected)
+    {
+        var collection =
+            TempDatabase.CreateTemporaryCollection<StringArrayOfArraysEntity>(nameof(String_array_of_arrays_round_trips)
+                                                                              + expected.Length);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new StringArrayOfArraysEntity
+            {
+                arrayOfStringArray = expected
+            });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = db.Entities.FirstOrDefault();
+            Assert.NotNull(result);
+            Assert.Equal(expected, result.arrayOfStringArray);
+        }
+    }
+
+    class StringArrayOfArraysEntity : BaseIdEntity
+    {
+        public string[][] arrayOfStringArray { get; set; }
+    }
+
     [Theory]
     [InlineData]
     [InlineData("abc", "def", "ghi", "and the rest")]

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DictionarySerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DictionarySerializationTests.cs
@@ -1,0 +1,301 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.ObjectModel;
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Serialization;
+
+public class DictionarySerializationTests(TemporaryDatabaseFixture tempDatabase)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    class DictionaryEntityBase<T>
+    {
+        public ObjectId _id { get; set; }
+        public Dictionary<string, T>? aDictionary { get; set; } = new();
+    }
+
+    class IDictionaryEntityBase<T>
+    {
+        public ObjectId _id { get; set; }
+        public IDictionary<string, T>? aDictionary { get; set; } = new Dictionary<string, T>();
+    }
+
+    class IReadOnlyDictionaryEntityBase<T>
+    {
+        public ObjectId _id { get; set; }
+        public IReadOnlyDictionary<string, T>? aDictionary { get; set; } = ReadOnlyDictionary<string, T>.Empty;
+    }
+
+    class DictionaryStringValuesEntity : DictionaryEntityBase<string>;
+
+    class IDictionaryStringValuesEntity : IDictionaryEntityBase<string>;
+
+    class IReadOnlyDictionaryStringValuesEntity : IReadOnlyDictionaryEntityBase<string>;
+
+    class DictionaryIntValuesEntity : DictionaryEntityBase<int>;
+
+    class IDictionaryIntValuesEntity : IDictionaryEntityBase<int>;
+
+    class DictionaryStringArrayValuesEntity : DictionaryEntityBase<string[]>;
+
+    [Fact]
+    public void Dictionary_string_values_read_empty()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryStringValuesEntity>();
+        collection.InsertOne(new DictionaryStringValuesEntity {_id = ObjectId.GenerateNewId()});
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Empty(actual.aDictionary);
+    }
+
+    [Fact]
+    public void Dictionary_string_values_read_null()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryStringValuesEntity>();
+        collection.InsertOne(new DictionaryStringValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = null});
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Null(actual.aDictionary);
+    }
+
+    [Fact]
+    public void Dictionary_string_values_write_read_with_items()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryStringValuesEntity>();
+        var expected = new Dictionary<string, string>
+        {
+            {"Season", "Summer"}, {"Temperature", "35'"}, {"Clouds", "None"}, {"Wind", "Breeze"}
+        };
+        var item = new DictionaryStringValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = expected};
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(item);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var actual = db.Entities.FirstOrDefault();
+            Assert.NotNull(actual);
+            Assert.Equal(expected, actual.aDictionary);
+        }
+    }
+
+    [Fact]
+    public void Dictionary_int_values_read_empty()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryIntValuesEntity>();
+        collection.InsertOne(new DictionaryIntValuesEntity {_id = ObjectId.GenerateNewId()});
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Empty(actual.aDictionary);
+    }
+
+    [Fact]
+    public void Dictionary_int_values_write_read_with_items()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryIntValuesEntity>();
+        var expected = new Dictionary<string, int> {{"Season", 2}, {"Temperature", 35}, {"Clouds", 0}, {"Wind", 11}};
+        var item = new DictionaryIntValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = expected};
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(item);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var actual = db.Entities.FirstOrDefault();
+            Assert.NotNull(actual);
+            Assert.Equal(expected, actual.aDictionary);
+        }
+    }
+
+    [Fact]
+    public void IDictionary_string_values_read_empty()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryStringValuesEntity>();
+        collection.InsertOne(new IDictionaryStringValuesEntity {_id = ObjectId.GenerateNewId()});
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Empty(actual.aDictionary);
+    }
+
+    [Fact]
+    public void IDictionary_string_values_read_null()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryStringValuesEntity>();
+        collection.InsertOne(new IDictionaryStringValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = null});
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Null(actual.aDictionary);
+    }
+
+    [Fact]
+    public void IDictionary_string_values_write_read_with_items()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryStringValuesEntity>();
+        var expected = new Dictionary<string, string>
+        {
+            {"Season", "Summer"}, {"Temperature", "35'"}, {"Clouds", "None"}, {"Wind", "Breeze"}
+        };
+        var item = new IDictionaryStringValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = expected};
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(item);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var actual = db.Entities.FirstOrDefault();
+            Assert.NotNull(actual);
+            Assert.Equal(expected, actual.aDictionary);
+        }
+    }
+
+    [Fact]
+    public void IDictionary_int_values_read_empty()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryIntValuesEntity>();
+        collection.InsertOne(new IDictionaryIntValuesEntity
+        {
+            _id = ObjectId.GenerateNewId(), aDictionary = new Dictionary<string, int>()
+        });
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Empty(actual.aDictionary);
+    }
+
+    [Fact]
+    public void IDictionary_int_values_write_read_with_items()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IDictionaryIntValuesEntity>();
+        var expected = new Dictionary<string, int> {{"Season", 2}, {"Temperature", 35}, {"Clouds", 0}, {"Wind", 11}};
+        var item = new IDictionaryIntValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = expected};
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(item);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var actual = db.Entities.FirstOrDefault();
+            Assert.NotNull(actual);
+            Assert.Equal(expected, actual.aDictionary);
+        }
+    }
+
+    [Fact(Skip = "Dictionary with collection value types is currently broken")]
+    public void Dictionary_string_array_values_write_read_with_items()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<DictionaryStringArrayValuesEntity>();
+        var expected = new Dictionary<string, string[]>
+        {
+            {"Seasons", ["Summer", "Autumn", "Winter", "Spring"]},
+            {"Temperature", ["35'", "42'"]},
+            {"Clouds", ["None", "Light", "Many"]},
+            {"Wind", ["Breeze", "Gale", "Storm"]}
+        };
+        var item = new DictionaryStringArrayValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = expected};
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(item);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var actual = db.Entities.FirstOrDefault();
+            Assert.NotNull(actual);
+            Assert.Equal(expected, actual.aDictionary);
+        }
+    }
+
+    [Fact]
+    public void IReadOnlyDictionary_string_values_read_empty()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IReadOnlyDictionaryStringValuesEntity>();
+        collection.InsertOne(new IReadOnlyDictionaryStringValuesEntity {_id = ObjectId.GenerateNewId()});
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Empty(actual.aDictionary);
+    }
+
+    [Fact]
+    public void IReadOnlyDictionary_string_values_read_null()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IReadOnlyDictionaryStringValuesEntity>();
+        collection.InsertOne(new IReadOnlyDictionaryStringValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = null});
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var actual = db.Entities.FirstOrDefault();
+
+        Assert.NotNull(actual);
+        Assert.Null(actual.aDictionary);
+    }
+
+    [Fact]
+    public void IReadOnlyDictionary_string_values_write_read_with_items()
+    {
+        var collection = tempDatabase.CreateTemporaryCollection<IReadOnlyDictionaryStringValuesEntity>();
+        var expected = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
+        {
+            {"Season", "Summer"}, {"Temperature", "35'"}, {"Clouds", "None"}, {"Wind", "Breeze"}
+        });
+        var item = new IReadOnlyDictionaryStringValuesEntity {_id = ObjectId.GenerateNewId(), aDictionary = expected};
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(item);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var actual = db.Entities.FirstOrDefault();
+            Assert.NotNull(actual);
+            Assert.Equal(expected, actual.aDictionary);
+        }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/UpdateEntityTests.cs
@@ -14,6 +14,7 @@
  */
 
 using System.Reflection;
+using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
@@ -48,14 +49,21 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
         public DateTime lastModified { get; set; }
     }
 
+    class DictionaryEntity : SimpleEntity
+    {
+        public Dictionary<string, string> dictionary { get; set; } = new();
+    }
+
+    class DictionaryOfDictionaryEntity : SimpleEntity
+    {
+        public Dictionary<string, Dictionary<string, string>> dictionary { get; set; } = new();
+    }
+
     [Fact]
     public void Update_simple_entity()
     {
         var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntity>();
-        var entity = new SimpleEntity
-        {
-            _id = ObjectId.GenerateNewId(), name = "Before"
-        };
+        var entity = new SimpleEntity {_id = ObjectId.GenerateNewId(), name = "Before"};
 
         {
             using var db = SingleEntityDbContext.Create(collection);
@@ -70,6 +78,194 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
             var foundEntity = db.Entities.Single();
             Assert.Equal(entity._id, foundEntity._id);
             Assert.Equal("After", foundEntity.name);
+        }
+    }
+
+    [Fact]
+    public void Update_dictionary_entity()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<DictionaryEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new DictionaryEntity
+            {
+                _id = ObjectId.GenerateNewId(),
+                name = "My Post",
+                dictionary = new Dictionary<string, string> {{"author", "Damien"}, {"category", "technology"}}
+            });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var changeDictionaryValue = db.Entities.First();
+            changeDictionaryValue.dictionary["author"] = "Bob";
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            Assert.Equal("Bob", Assert.Contains("author", db.Entities.Single().dictionary));
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary.Remove("category");
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            Assert.DoesNotContain("category", db.Entities.Single().dictionary);
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary.Add("rating", "5");
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            Assert.Equal("5", Assert.Contains("rating", db.Entities.Single().dictionary));
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary.Clear();
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            Assert.Empty(db.Entities.Single().dictionary);
+        }
+
+        Action<ModelBuilder> allowNullModel =
+            mb => mb.Entity<DictionaryEntity>().Property(e => e.dictionary).IsRequired(false);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, allowNullModel);
+            db.Entities.First().dictionary = null!;
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, allowNullModel);
+            Assert.Null(db.Entities.Single().dictionary);
+        }
+    }
+
+   [Fact]
+    public void Update_dictionary_of_dictionary_entity()
+    {
+        var collection = _tempDatabase.CreateTemporaryCollection<DictionaryOfDictionaryEntity>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new DictionaryOfDictionaryEntity
+            {
+                _id = ObjectId.GenerateNewId(),
+                name = "My Post",
+                dictionary = new Dictionary<string, Dictionary<string, string>>
+                {
+                    {"A", new Dictionary<string, string> {{"name", "Damien"}, { "category", "technology" }}},
+                    {"B", new Dictionary<string, string> {{"name", "Bob" }, { "category", "social"}}}
+                }
+            });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary["A"] = new Dictionary<string, string> {{"name1", "Damien1"}};
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var entity = db.Entities.Single();
+            Assert.Equal(2, entity.dictionary.Count);
+            var a = Assert.Single(Assert.Contains("A", entity.dictionary));
+            Assert.Equal("name1", a.Key);
+            Assert.Equal("Damien1", a.Value);
+            var b = Assert.Contains("B", entity.dictionary);
+            Assert.Equal(2, b.Count);
+            Assert.Single(b, x => x is {Key: "name", Value: "Bob"});
+            Assert.Single(b, x => x is {Key: "category", Value: "social"});
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary["A"] = new Dictionary<string, string>();
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var entity = db.Entities.Single();
+            Assert.Equal(2, entity.dictionary.Count);
+            Assert.Empty(Assert.Contains("A", entity.dictionary));
+            var b = Assert.Contains("B", entity.dictionary);
+            Assert.Equal(2, b.Count);
+            Assert.Single(b, x => x is {Key: "name", Value: "Bob"});
+            Assert.Single(b, x => x is {Key: "category", Value: "social"});
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary.Remove("B");
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var entity = db.Entities.Single();
+            Assert.Empty(Assert.Single(entity.dictionary).Value);
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary.Add("Z", new Dictionary<string, string> { { "name", "Art" }});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var entity = db.Entities.Single();
+            Assert.Equal(2, entity.dictionary.Count);
+            Assert.Empty(Assert.Single(entity.dictionary, x => x.Key == "A").Value);
+            var z = Assert.Contains("Z", entity.dictionary);
+            Assert.Single(z, x => x is {Key: "name", Value: "Art"});
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.First().dictionary["Z"] = null!;
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var entity = db.Entities.Single();
+            Assert.Equal(2, entity.dictionary.Count);
+            var z = Assert.Contains("Z", entity.dictionary);
+            Assert.Null(z);
+        }
+
+        Action<ModelBuilder> allowNullModel =
+            mb => mb.Entity<DictionaryOfDictionaryEntity>().Property(e => e.dictionary).IsRequired(false);
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, allowNullModel);
+            db.Entities.First().dictionary = null!;
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, allowNullModel);
+            Assert.Null(db.Entities.Single().dictionary);
         }
     }
 
@@ -131,10 +327,7 @@ public class UpdateEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var entity = new Entity<TValue>
-            {
-                _id = ObjectId.GenerateNewId(), Value = initialValue
-            };
+            var entity = new Entity<TValue> {_id = ObjectId.GenerateNewId(), Value = initialValue};
             db.Entities.Add(entity);
             db.SaveChanges();
             entity.Value = updatedValue;


### PR DESCRIPTION
Implements EF-47 for Dictionary/ReadOnlyDictionary support.

Note: One test is disabled as there is a bug in the C# Driver that prevents this indexers being used on IReadOnlyDictionary. Being tracked as CSHARP-5171,