### PR TITLE
Enable tests fixed by updates to EF/Driver

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EveryTypeEntityType.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EveryTypeEntityType.cs
@@ -196,7 +196,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Design
                 clrType: typeof(long));
             aLongRepresentedAsAInt.AddAnnotation("Mongo:BsonRepresentation", new Dictionary<string, object> { ["BsonType"] = BsonType.Int32, ["AllowOverflow"] = true, ["AllowTruncation"] = true });
 
-           var aShort = runtimeEntityType.AddProperty(
+            var aShort = runtimeEntityType.AddProperty(
                 "aShort",
                 typeof(short),
                 propertyInfo: typeof(CompiledModelTests.EveryType).GetProperty("aShort", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/SimpleContextModelBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/SimpleContextModelBuilder.cs
@@ -20,7 +20,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Design
             EveryTypeEntityType.CreateAnnotations(everyType);
             OwnedEntityEntityType.CreateAnnotations(ownedEntity);
 
-            AddAnnotation("ProductVersion", "8.0.6");
+            AddAnnotation("ProductVersion", "8.0.7");
         }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereDictionaryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereDictionaryTests.cs
@@ -307,9 +307,9 @@ public class WhereDictionaryTests(TemporaryDatabaseFixture tempDatabase)
             var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
             Assert.Single(results);
         }
-    }
+   }
 
-    [Fact(Skip = "IReadOnly.this[] not supported in C# Driver LINQ v3 yet")]
+    [Fact]
     public void Where_ReadOnlyDictionary_key_equals_value()
     {
         var collection = tempDatabase.CreateTemporaryCollection<IReadOnlyDictionaryIntEntity>();

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereTests.cs
@@ -251,7 +251,7 @@ public class WhereTests : IDisposable, IAsyncDisposable
         Assert.All(results, p => Assert.NotEmpty(p.mainAtmosphere));
     }
 
-    [Fact(Skip = "Errors wiuth MongoDB < 5.0")]
+    [Fact]
     public void Where_entity_equal_null()
     {
         var actual = _db.Planets.FirstOrDefault(p => p == null);


### PR DESCRIPTION
Just removes the skip from two tests which are now fine to run as well as a two regenerated test files.