### PR TITLE
EF-154: Switch Guid binary format over to V3/Standard

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Query;
 
@@ -58,6 +59,11 @@ public class MongoQueryCompilationContext : QueryCompilationContext
     /// <inheritdoc />
     public override Func<QueryContext, TResult> CreateQueryExecutor<TResult>(Expression originalQuery)
     {
+        if (BsonDefaults.GuidRepresentationMode != GuidRepresentationMode.V3)
+        {
+            BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3;
+        }
+
         var query = Dependencies.QueryTranslationPreprocessorFactory.Create(this).Process(originalQuery);
         query = Dependencies.QueryableMethodTranslatingExpressionVisitorFactory.Create(this).Visit(query);
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
@@ -194,7 +194,7 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
             collection.InsertOne(new BsonGuidEntity {_id = ObjectId.GenerateNewId(), aGuid = expected});
         }
 
-        var collectionEf = tempDatabase.CreateTemporaryCollection<GuidEntity>();
+        var collectionEf = tempDatabase.GetExistingTemporaryCollection<GuidEntity>();
         using var db = SingleEntityDbContext.Create(collectionEf);
         var actual = db.Entities.FirstOrDefault();
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ClrTypeMappingTests.cs
@@ -16,6 +16,7 @@
 using System.Collections.ObjectModel;
 using System.Reflection;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Mapping;
 
@@ -38,6 +39,12 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
 
     class GuidEntity : IdEntity
     {
+        public Guid aGuid { get; set; }
+    }
+
+    class BsonGuidEntity : IdEntity
+    {
+        [BsonGuidRepresentation(GuidRepresentation.Standard)]
         public Guid aGuid { get; set; }
     }
 
@@ -180,15 +187,15 @@ public class ClrTypeMappingTests(TemporaryDatabaseFixture tempDatabase)
     [Fact]
     public void Guid_read()
     {
-        var collection = tempDatabase.CreateTemporaryCollection<GuidEntity>();
-
         var expected = Guid.NewGuid();
-        collection.InsertOne(new GuidEntity
-        {
-            _id = ObjectId.GenerateNewId(), aGuid = expected
-        });
 
-        using var db = SingleEntityDbContext.Create(collection);
+        {
+            var collection = tempDatabase.CreateTemporaryCollection<BsonGuidEntity>();
+            collection.InsertOne(new BsonGuidEntity {_id = ObjectId.GenerateNewId(), aGuid = expected});
+        }
+
+        var collectionEf = tempDatabase.CreateTemporaryCollection<GuidEntity>();
+        using var db = SingleEntityDbContext.Create(collectionEf);
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/DeleteEntityTests.cs
@@ -14,6 +14,7 @@
  */
 
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
@@ -41,6 +42,13 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
 
     class SimpleEntityWithGuidId
     {
+        public Guid _id { get; set; }
+        public string name { get; set; }
+    }
+
+    class BsonSimpleEntityWithGuidId
+    {
+        [BsonGuidRepresentation(GuidRepresentation.Standard)]
         public Guid _id { get; set; }
         public string name { get; set; }
     }
@@ -84,10 +92,13 @@ public class DeleteEntityTests : IClassFixture<TemporaryDatabaseFixture>
     [Fact]
     public void Entity_delete_with_guid_id()
     {
-        var collection = _tempDatabase.CreateTemporaryCollection<SimpleEntityWithGuidId>();
-        collection.InsertOne(new SimpleEntityWithGuidId {_id = Guid.NewGuid(), name = "DeleteMe"});
+        {
+            var collection = _tempDatabase.CreateTemporaryCollection<BsonSimpleEntityWithGuidId>();
+            collection.InsertOne(new BsonSimpleEntityWithGuidId {_id = Guid.NewGuid(), name = "DeleteMe"});
+        }
 
-        using var db = SingleEntityDbContext.Create(collection);
+        var collectionEf = _tempDatabase.GetExistingTemporaryCollection<SimpleEntityWithGuidId>();
+        using var db = SingleEntityDbContext.Create(collectionEf);
         var entity = db.Entities.Single();
 
         db.Remove(entity);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
@@ -15,6 +15,7 @@
 
 using System.Collections;
 using System.Runtime.CompilerServices;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
@@ -30,6 +31,7 @@ public class TemporaryDatabaseFixture : IDisposable, IAsyncDisposable
     {
         Client = TestServer.GetClient();
         MongoDatabase = Client.GetDatabase($"{TestDatabasePrefix}{TimeStamp}-{Interlocked.Increment(ref Count)}");
+        BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3; // We sometimes insert with C# Driver before firing up EF Provider
     }
 
     public IMongoDatabase MongoDatabase { get; }


### PR DESCRIPTION
Originally considered exposing an API to allow and specify how the Guid was stored but with the move to V3/Standard and the other formats effectively being deprecated it makes sense just to change the defaults.

This will be a breaking change and will need to be called out in the release notes.