### PR TITLE
EF-155: Create empty collections when inside CreateDatabase

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Query;
 
@@ -50,46 +51,38 @@ public interface IMongoClientWrapper
     /// <summary>
     /// Create a new database with the name specified in the connection options.
     /// </summary>
-    /// <remarks>
-    /// The database is not actually created until the first document is inserted.
-    /// </remarks>
-    /// <returns><c>true</c> if the database was created, <c>false</c> if it already existed.</returns>
-    public bool CreateDatabase();
+    /// <remarks>If the database already exists only new collections will be created.</remarks>
+    /// <param name="model">The <see cref="IModel"/> that informs how the database should be created.</param>
+    /// <returns><c>true</c> if the database was created from scratch, <c>false</c> if it already existed.</returns>
+    public bool CreateDatabase(IModel model);
 
     /// <summary>
     /// Create a new database with the name specified in the connection options asynchronously.
     /// </summary>
-    /// <remarks>
-    /// The database is not actually created until the first document is inserted.
-    /// </remarks>
+    /// <remarks>If the database already exists only new collections will be created.</remarks>
+    /// <param name="model">The <see cref="IModel"/> that informs how the database should be created.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel this asynchronous request.</param>
     /// <returns>
     /// A <see cref="Task"/> that, when resolved, will be
-    /// <c>true</c> if the database was created, <c>false</c> if it already existed.
+    /// <c>true</c> if the database was created from scratch, <c>false</c> if it already existed.
     /// </returns>
-    public Task<bool> CreateDatabaseAsync(CancellationToken cancellationToken);
+    public Task<bool> CreateDatabaseAsync(IModel model, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete the database specified in the connection options.
     /// </summary>
-    /// <remarks>
-    /// Unlike <see cref="CreateDatabase"/> the database is actually deleted immediately.
-    /// </remarks>
     /// <returns><c>true</c> if the database was deleted, <c>false</c> if it did not exist.</returns>
     public bool DeleteDatabase();
 
     /// <summary>
     /// Delete the database specified in the connection options asynchronously.
     /// </summary>
-    /// <remarks>
-    /// Unlike <see cref="CreateDatabaseAsync"/> the database is actually deleted immediately.
-    /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel this asynchronous request.</param>
     /// <returns>
     /// A <see cref="Task"/> that, when resolved, will be
     /// <c>true</c> if the database was deleted, <c>false</c> if it already existed.
     /// </returns>
-    public Task<bool> DeleteDatabaseAsync(CancellationToken cancellationToken);
+    public Task<bool> DeleteDatabaseAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Determine if the database already exists or not.

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseCreator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseCreator.cs
@@ -15,6 +15,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
@@ -25,7 +26,10 @@ namespace MongoDB.EntityFrameworkCore.Storage;
 /// <remarks>
 /// This class is not typically used directly from application code.
 /// </remarks>
-public class MongoDatabaseCreator(IMongoClientWrapper clientWrapper) : IDatabaseCreator
+public class MongoDatabaseCreator(
+    IMongoClientWrapper clientWrapper,
+    ICurrentDbContext currentDbContext)
+    : IDatabaseCreator
 {
     /// <inheritdoc/>
     public bool EnsureDeleted()
@@ -37,11 +41,11 @@ public class MongoDatabaseCreator(IMongoClientWrapper clientWrapper) : IDatabase
 
     /// <inheritdoc/>
     public bool EnsureCreated()
-        => clientWrapper.CreateDatabase();
+        => clientWrapper.CreateDatabase(currentDbContext.Context.Model);
 
     /// <inheritdoc/>
     public Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = new())
-        => clientWrapper.CreateDatabaseAsync(cancellationToken);
+        => clientWrapper.CreateDatabaseAsync(currentDbContext.Context.Model, cancellationToken);
 
     /// <inheritdoc/>
     public bool CanConnect()

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DictionarySerializationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Serialization/DictionarySerializationTests.cs
@@ -61,6 +61,7 @@ public class DictionarySerializationTests(TemporaryDatabaseFixture tempDatabase)
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
+        Assert.NotNull(actual.aDictionary);
         Assert.Empty(actual.aDictionary);
     }
 
@@ -111,6 +112,7 @@ public class DictionarySerializationTests(TemporaryDatabaseFixture tempDatabase)
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
+        Assert.NotNull(actual.aDictionary);
         Assert.Empty(actual.aDictionary);
     }
 
@@ -145,6 +147,7 @@ public class DictionarySerializationTests(TemporaryDatabaseFixture tempDatabase)
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
+        Assert.NotNull(actual.aDictionary);
         Assert.Empty(actual.aDictionary);
     }
 
@@ -198,6 +201,7 @@ public class DictionarySerializationTests(TemporaryDatabaseFixture tempDatabase)
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
+        Assert.NotNull(actual.aDictionary);
         Assert.Empty(actual.aDictionary);
     }
 
@@ -259,6 +263,7 @@ public class DictionarySerializationTests(TemporaryDatabaseFixture tempDatabase)
         var actual = db.Entities.FirstOrDefault();
 
         Assert.NotNull(actual);
+        Assert.NotNull(actual.aDictionary);
         Assert.Empty(actual.aDictionary);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoClientWrapperTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoClientWrapperTests.cs
@@ -1,0 +1,230 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.EntityFrameworkCore.Storage;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Storage;
+
+public class MongoClientWrapperTests
+{
+    [Fact]
+    public void CreateDatabase_creates_database()
+    {
+        using var database = new TemporaryDatabaseFixture();
+        var context = MyContext.CreateCollectionOptions(database.MongoDatabase);
+        var client = context.GetService<IMongoClientWrapper>();
+
+        {
+            var didCreate = client.CreateDatabase(context.Model);
+            Assert.True(didCreate);
+            var collectionNames = database.MongoDatabase.ListCollectionNames().ToList();
+            Assert.Equal(3, collectionNames.Count);
+            Assert.Contains("Customers", collectionNames);
+            Assert.Contains("Orders", collectionNames);
+            Assert.Contains("Addresses", collectionNames);
+        }
+
+        {
+            var didCreateSecondTime = client.CreateDatabase(context.Model);
+            Assert.False(didCreateSecondTime);
+            var collectionNames = database.MongoDatabase.ListCollectionNames().ToList();
+            Assert.Equal(3, collectionNames.Count);
+        }
+    }
+
+    [Fact]
+    public async Task CreateDatabaseAsync_creates_database()
+    {
+        await using var database = new TemporaryDatabaseFixture();
+        var context = MyContext.CreateCollectionOptions(database.MongoDatabase);
+        var client = context.GetService<IMongoClientWrapper>();
+
+        {
+            var didCreate = await client.CreateDatabaseAsync(context.Model);
+            Assert.True(didCreate);
+            var collectionNames = (await database.MongoDatabase.ListCollectionNamesAsync()).ToList();
+            Assert.Equal(3, collectionNames.Count);
+            Assert.Contains("Customers", collectionNames);
+            Assert.Contains("Orders", collectionNames);
+            Assert.Contains("Addresses", collectionNames);
+        }
+
+        {
+            var didCreateSecondTime = await client.CreateDatabaseAsync(context.Model);
+            Assert.False(didCreateSecondTime);
+            var collectionNames = (await database.MongoDatabase.ListCollectionNamesAsync()).ToList();
+            Assert.Equal(3, collectionNames.Count);
+        }
+    }
+
+    [Fact]
+    public void CreateDatabase_does_not_affect_existing_collections()
+    {
+        const int expectedMaxDocs = 1234;
+        const int expectedMaxSize = 56789;
+
+        using var database = new TemporaryDatabaseFixture();
+
+        {
+            database.MongoDatabase.CreateCollection("Customers",
+                new CreateCollectionOptions {MaxDocuments = expectedMaxDocs, MaxSize = expectedMaxSize, Capped = true});
+            var collection = database.MongoDatabase.GetCollection<Customer>("Customers");
+            collection.InsertOne(new Customer {Name = "John Doe"});
+        }
+
+        {
+            var context = MyContext.CreateCollectionOptions(database.MongoDatabase);
+            var client = context.GetService<IMongoClientWrapper>();
+
+            var didCreate = client.CreateDatabase(context.Model);
+            Assert.False(didCreate);
+            var collections = database.MongoDatabase.ListCollections().ToList();
+
+            Assert.Equal(3, collections.Count);
+            var allNames = collections.Select(c => c["name"].AsString).ToArray();
+            Assert.Contains("Customers", allNames);
+            Assert.Contains("Orders", allNames);
+            Assert.Contains("Addresses", allNames);
+
+            var collection = database.MongoDatabase.GetCollection<Customer>("Customers");
+            Assert.Equal(1, collection.CountDocuments(FilterDefinition<Customer>.Empty));
+
+            var customerCollectionOptions = collections.Single(c => c["name"].AsString == "Customers")["options"];
+            Assert.True(customerCollectionOptions["capped"].AsBoolean);
+            Assert.Equal(expectedMaxDocs, customerCollectionOptions["max"].AsInt32);
+            Assert.Equal(expectedMaxSize, customerCollectionOptions["size"].AsInt32);
+        }
+    }
+
+    [Fact]
+    public async Task CreateDatabaseAsync_does_not_affect_existing_collections()
+    {
+        const long expectedMaxDocs = 1234;
+        const long expectedMaxSize = 56789;
+
+        await using var database = new TemporaryDatabaseFixture();
+
+        {
+            await database.MongoDatabase.CreateCollectionAsync("Customers",
+                new CreateCollectionOptions {MaxDocuments = expectedMaxDocs, MaxSize = expectedMaxSize, Capped = true});
+            var collection = database.MongoDatabase.GetCollection<Customer>("Customers");
+            await collection.InsertOneAsync(new Customer {Name = "John Doe"});
+        }
+
+        {
+            var context = MyContext.CreateCollectionOptions(database.MongoDatabase);
+            var client = context.GetService<IMongoClientWrapper>();
+
+            var didCreate = await client.CreateDatabaseAsync(context.Model);
+            Assert.False(didCreate);
+            var collections = (await database.MongoDatabase.ListCollectionsAsync()).ToList();
+
+            var allNames = collections.Select(c => c["name"].AsString).ToArray();
+            Assert.Contains("Customers", allNames);
+            Assert.Contains("Orders", allNames);
+            Assert.Contains("Addresses", allNames);
+
+            var collection = database.MongoDatabase.GetCollection<Customer>("Customers");
+            Assert.Equal(1, await collection.CountDocumentsAsync(FilterDefinition<Customer>.Empty));
+
+            var customerCollectionOptions = collections.Single(c => c["name"].AsString == "Customers")["options"];
+            Assert.True(customerCollectionOptions["capped"].AsBoolean);
+            Assert.Equal(expectedMaxDocs, customerCollectionOptions["max"].AsInt32);
+            Assert.Equal(expectedMaxSize, customerCollectionOptions["size"].AsInt32);
+        }
+    }
+
+    [Fact]
+    public void DeleteDatabase_deletes_database()
+    {
+        using var database = new TemporaryDatabaseFixture();
+        var context = MyContext.CreateCollectionOptions(database.MongoDatabase);
+        var client = context.GetService<IMongoClientWrapper>();
+
+        Assert.False(client.DatabaseExists());
+
+        client.CreateDatabase(context.Model);
+        Assert.True(client.DatabaseExists());
+
+        client.DeleteDatabase();
+        Assert.False(client.DatabaseExists());
+    }
+
+    [Fact]
+    public async Task DeleteDatabaseAsync_deletes_database()
+    {
+        await using var database = new TemporaryDatabaseFixture();
+        var context = MyContext.CreateCollectionOptions(database.MongoDatabase);
+        var client = context.GetService<IMongoClientWrapper>();
+
+        Assert.False(await client.DatabaseExistsAsync());
+
+        await client.CreateDatabaseAsync(context.Model);
+        Assert.True(await client.DatabaseExistsAsync());
+
+        await client.DeleteDatabaseAsync();
+        Assert.False(await client.DatabaseExistsAsync());
+    }
+
+    class MyContext(
+        DbContextOptions options,
+        Action<ModelBuilder>? modelBuilderAction = null)
+        : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; }
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<Address> Addresses { get; set; }
+
+        private static DbContextOptions<MyContext> CreateOptions(IMongoDatabase database)
+            => new DbContextOptionsBuilder<MyContext>()
+                .UseMongoDB(database.Client, database.DatabaseNamespace.DatabaseName)
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options;
+
+        public static MyContext CreateCollectionOptions(
+            IMongoDatabase database,
+            Action<ModelBuilder>? modelBuilderAction = null)
+            => new(CreateOptions(database), modelBuilderAction);
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilderAction?.Invoke(modelBuilder);
+        }
+    }
+
+    class Customer
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    class Order
+    {
+        public ObjectId Id { get; set; }
+        public string OrderRef { get; set; }
+    }
+
+    class Address
+    {
+        public ObjectId Id { get; set; }
+        public string PostCode { get; set; }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoDatabaseCreatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoDatabaseCreatorTests.cs
@@ -21,7 +21,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Storage;
 public class MongoDatabaseCreatorTests
 {
     [Fact]
-    public void EnsureCreated_returns_true_when_database_does_not_exist()
+    public void EnsureCreated_returns_true_when_database_did_not_exist()
     {
         using var database = new TemporaryDatabaseFixture();
         using var db = GuidesDbContext.Create(database.MongoDatabase);
@@ -41,7 +41,7 @@ public class MongoDatabaseCreatorTests
     }
 
     [Fact]
-    public async Task EnsureCreatedAsync_returns_true_when_database_does_not_exist()
+    public async Task EnsureCreatedAsync_returns_true_when_database_did_not_exist()
     {
         await using var database = new TemporaryDatabaseFixture();
         await using var db = GuidesDbContext.Create(database.MongoDatabase);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
@@ -96,7 +96,6 @@ public class TemporaryDatabaseFixture : IDisposable, IAsyncDisposable
     {
     }
 
-    public async ValueTask DisposeAsync()
-    {
-    }
+    public ValueTask DisposeAsync()
+        => ValueTask.CompletedTask;
 }


### PR DESCRIPTION
CreateDatabase(Async) was previously a no-op as we allowed the database and collections to create on-demand.

Now that transactions are enabled by default there are some situations where creating a collection or database inside the transaction can cause issues.

Instead now we will create any missing empty collections from inside CreateDatabase to avoid these situations as it should be called at app start-up outside of any transaction.