### PR TITLE
Clean up some conventions

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CamelCaseElementNameConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CamelCaseElementNameConvention.cs
@@ -17,29 +17,14 @@ using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 
 namespace MongoDB.EntityFrameworkCore.Metadata.Conventions;
 
 /// <summary>
 /// A convention that configures the element name for entity properties by using a camel-case naming convention.
 /// </summary>
-public class CamelCaseElementNameConvention : IPropertyAddedConvention, INavigationAddedConvention
+public sealed class CamelCaseElementNameConvention : IPropertyAddedConvention, INavigationAddedConvention
 {
-    /// <summary>
-    /// Creates a <see cref="CamelCaseElementNameConvention" />.
-    /// </summary>
-    /// <param name="dependencies">Parameter object containing dependencies for this convention.</param>
-    public CamelCaseElementNameConvention(ProviderConventionSetBuilderDependencies dependencies)
-    {
-        Dependencies = dependencies;
-    }
-
-    /// <summary>
-    ///  Dependencies this convention uses.
-    /// </summary>
-    protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
-
     /// <summary>
     /// For every property that is added to the model set the element name to be the camel case
     /// version of the property name with symbols being removed and considered word separators.

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CollectionNameFromDbSetConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CollectionNameFromDbSetConvention.cs
@@ -26,9 +26,9 @@ namespace MongoDB.EntityFrameworkCore.Metadata.Conventions;
 /// <summary>
 /// A convention that configures the collection name based on the <see cref="DbSet{TEntity}" /> property name.
 /// </summary>
-public class CollectionNameFromDbSetConvention : IEntityTypeAddedConvention
+public sealed class CollectionNameFromDbSetConvention : IEntityTypeAddedConvention
 {
-    private readonly IDictionary<Type, string> _sets = new Dictionary<Type, string>();
+    private readonly Dictionary<Type, string> _sets = new();
 
     /// <summary>
     /// Creates a <see cref="CollectionNameFromDbSetConvention" /> with required dependencies.
@@ -54,17 +54,10 @@ public class CollectionNameFromDbSetConvention : IEntityTypeAddedConvention
         {
             _sets.Remove(type);
         }
-
-        Dependencies = dependencies;
     }
 
-    /// <summary>
-    ///  Dependencies this convention uses.
-    /// </summary>
-    protected virtual ProviderConventionSetBuilderDependencies Dependencies { get; }
-
     /// <inheritdoc />
-    public virtual void ProcessEntityTypeAdded(
+    public void ProcessEntityTypeAdded(
         IConventionEntityTypeBuilder entityTypeBuilder,
         IConventionContext<IConventionEntityTypeBuilder> context)
     {

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
@@ -42,7 +42,6 @@ public class ColumnAttributeConvention :
     {
     }
 
-
     /// <summary>
     /// For every property added to the model that has a <see cref="ColumnAttribute"/>
     /// use the specified name as an annotation to configure the element name used in BSON documents.

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoRelationshipDiscoveryConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoRelationshipDiscoveryConvention.cs
@@ -26,6 +26,10 @@ namespace MongoDB.EntityFrameworkCore.Metadata.Conventions;
 /// </summary>
 public class MongoRelationshipDiscoveryConvention : RelationshipDiscoveryConvention
 {
+    /// <summary>
+    /// Creates a <see cref="MongoRelationshipDiscoveryConvention"/>.
+    /// </summary>
+    /// <param name="dependencies">The <see cref="MongoRelationshipDiscoveryConvention"/> required by this convention.</param>
     public MongoRelationshipDiscoveryConvention(ProviderConventionSetBuilderDependencies dependencies)
         : base(dependencies)
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/CamelCaseElementNameConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/CamelCaseElementNameConventionTests.cs
@@ -49,9 +49,7 @@ public class CamelCaseElementNameConventionTests(TemporaryDatabaseFixture tempDa
 
         protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
         {
-            configurationBuilder.Conventions.Add(serviceProvider =>
-                new CamelCaseElementNameConvention(serviceProvider
-                    .GetRequiredService<ProviderConventionSetBuilderDependencies>()));
+            configurationBuilder.Conventions.Add(_ => new CamelCaseElementNameConvention());
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
Minor clean-up to some conventions for performance and ease of use.

Aware of small breaks, will add to the docs for 8.1.0