### PR TITLE
Add multi-collection transaction tests

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SaveChangesTransactionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SaveChangesTransactionTests.cs
@@ -16,6 +16,7 @@
 using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Update;
 
@@ -127,7 +128,7 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
     [Theory]
     [InlineData(AutoTransactionBehavior.WhenNeeded)]
     [InlineData(AutoTransactionBehavior.Never)]
-    public void SaveChanges_behavior_on_DbConcurrencyException(AutoTransactionBehavior transactionBehavior)
+    public void SaveChanges_behavior_on_DbUpdateConcurrencyException(AutoTransactionBehavior transactionBehavior)
     {
         var collection =
             tempDatabase.CreateTemporaryCollection<TextEntity>("SaveChanges_DbConcurrencyException" + transactionBehavior);
@@ -164,7 +165,7 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
     [Theory]
     [InlineData(AutoTransactionBehavior.WhenNeeded)]
     [InlineData(AutoTransactionBehavior.Never)]
-    public async Task SaveChangesAsync_behavior_on_DbConcurrencyException(AutoTransactionBehavior transactionBehavior)
+    public async Task SaveChangesAsync_behavior_on_DbUpdateConcurrencyException(AutoTransactionBehavior transactionBehavior)
     {
         var collection =
             tempDatabase.CreateTemporaryCollection<TextEntity>("SaveChangesAsync_DbConcurrencyException" + transactionBehavior);
@@ -197,4 +198,191 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
             Assert.Equal(transactionBehavior == AutoTransactionBehavior.Never ? 1 : 0, db.Entities.Count());
         }
     }
+
+    class NamedEntity
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int RowVersion { get; set; }
+    }
+
+    class Customer : NamedEntity
+    {
+        public string SalesRegion { get; set; }
+    }
+
+    class Supplier : NamedEntity
+    {
+        public string Address { get; set; }
+    }
+
+    class Employee : NamedEntity
+    {
+        public string JobTitle { get; set; }
+    }
+
+    class MultiEntityDbContext(IMongoDatabase database) : DbContext
+    {
+        public DbSet<Customer> Customers { get; set; }
+        public DbSet<Supplier> Suppliers { get; set; }
+        public DbSet<Employee> Employees { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>().ToCollection("customers");
+            modelBuilder.Entity<Supplier>().ToCollection("suppliers");
+            modelBuilder.Entity<Employee>().ToCollection("employees");
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseMongoDB(database.Client, database.DatabaseNamespace.DatabaseName);
+        }
+    }
+
+    class ConcurrentMultiEntityDbContext(IMongoDatabase database) : MultiEntityDbContext(database)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Customer>().Property(p => p.RowVersion).IsRowVersion();
+            modelBuilder.Entity<Employee>().Property(p => p.RowVersion).IsRowVersion();
+            modelBuilder.Entity<Supplier>().Property(p => p.RowVersion).IsRowVersion();
+        }
+    }
+
+    [Fact]
+    public void SaveChanges_multi_collection_rolls_back_on_driver_exception()
+    {
+        using var tempDatabaseFixture = new TemporaryDatabaseFixture();
+        var e1 = new Employee {Id = "E1", Name = "Roy Williams", JobTitle = "Office Manager"};
+
+        {
+            using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            db.Add(new Supplier {Id = "S1", Name = "Friendly Corp.", Address = "123 Main St."});
+            db.Add(e1);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            db.Add(new Employee {Id = "E2", Name = "Jay Smith", JobTitle = "Procurement Manager"});
+            db.Add(new Customer {Id = "C1", Name = "A Friend", SalesRegion = "EMEA"});
+            db.Add(new Supplier {Id = "S2", Name = "Friendly Services", Address = "345 Main St."});
+            db.Add(new Supplier {Id = "S1", Name = "Friendly Industries", Address = "234 Main St."});
+            db.RemoveRange(e1);
+            Assert.Throws<MongoBulkWriteException<BsonDocument>>(() => db.SaveChanges());
+        }
+
+        {
+            using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            Assert.Empty(db.Customers);
+            Assert.Equal(1, db.Employees.Count());
+            Assert.Equal(1, db.Suppliers.Count());
+        }
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_multi_collection_rolls_back_on_driver_exception()
+    {
+        await using var tempDatabaseFixture = new TemporaryDatabaseFixture();
+        var e1 = new Employee {Id = "E1", Name = "Roy Williams", JobTitle = "Office Manager"};
+
+        {
+            await using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            await db.AddAsync(new Supplier {Id = "S1", Name = "Friendly Corp.", Address = "123 Main St."});
+            await db.AddAsync(e1);
+            await db.SaveChangesAsync();
+        }
+
+        {
+            await using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            await db.AddAsync(new Employee {Id = "E2", Name = "Jay Smith", JobTitle = "Procurement Manager"});
+            await db.AddAsync(new Customer {Id = "C1", Name = "A Friend", SalesRegion = "EMEA"});
+            await db.AddAsync(new Supplier {Id = "S2", Name = "Friendly Services", Address = "345 Main St."});
+            await db.AddAsync(new Supplier {Id = "S1", Name = "Friendly Industries", Address = "234 Main St."});
+            db.RemoveRange(e1);
+            await Assert.ThrowsAsync<MongoBulkWriteException<BsonDocument>>(() => db.SaveChangesAsync());
+        }
+
+        {
+            await using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            Assert.Empty(db.Customers);
+            Assert.Equal(1, db.Employees.Count());
+            Assert.Equal(1, db.Suppliers.Count());
+        }
+    }
+
+    [Fact]
+    public void SaveChanges_multi_collection_rolls_back_on_DbUpdateConcurrencyException()
+    {
+        using var tempDatabaseFixture = new TemporaryDatabaseFixture();
+        var e1 = new Employee {Id = "E1", Name = "Roy Williams", JobTitle = "Office Manager"};
+        var s1 = new Supplier {Id = "S1", Name = "Friendly Corp.", Address = "123 Main St."};
+
+        {
+            using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            db.AddRange(s1, e1);
+            db.SaveChanges();
+        }
+
+        {
+            using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            db.Suppliers.Single(s => s.Id == "S1").Address = "100 Main St.";
+            db.Employees.Single(e => e.Id == "E1").JobTitle = "Senior Office Manager";
+            db.SaveChanges();
+        }
+
+        {
+            using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            db.Customers.Add(new Customer { Id = "C1", Name = "A Friend", SalesRegion = "EMEA" });
+            db.RemoveRange(s1);
+            e1.Name = "Roy Williams Jr.";
+            Assert.Throws<DbUpdateConcurrencyException>(() => db.SaveChanges());
+        }
+
+        {
+            using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            Assert.Empty(db.Customers);
+            Assert.Single(db.Employees, e => e is {Id: "E1", Name: "Roy Williams", JobTitle: "Senior Office Manager", RowVersion: 2});
+            Assert.Single(db.Suppliers, e => e is {Id: "S1", Name: "Friendly Corp.", Address: "100 Main St.", RowVersion: 2});
+        }
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_multi_collection_rolls_back_on_DbUpdateConcurrencyException()
+    {
+        await using var tempDatabaseFixture = new TemporaryDatabaseFixture();
+        var e1 = new Employee {Id = "E1", Name = "Roy Williams", JobTitle = "Office Manager"};
+        var s1 = new Supplier {Id = "S1", Name = "Friendly Corp.", Address = "123 Main St."};
+
+        {
+            await using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            await db.AddRangeAsync(s1, e1);
+            await db.SaveChangesAsync();
+        }
+
+        {
+            await using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            (await db.Suppliers.SingleAsync(s => s.Id == "S1")).Address = "100 Main St.";
+            (await db.Employees.SingleAsync(e => e.Id == "E1")).JobTitle = "Senior Office Manager";
+            await db.SaveChangesAsync();
+        }
+
+        {
+            await using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            await db.Customers.AddAsync(new Customer { Id = "C1", Name = "A Friend", SalesRegion = "EMEA" });
+            db.RemoveRange(s1);
+            e1.Name = "Roy Williams Jr.";
+            await Assert.ThrowsAsync<DbUpdateConcurrencyException>(() => db.SaveChangesAsync());
+        }
+
+        {
+            await using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            Assert.Empty(db.Customers);
+            Assert.Single(db.Employees, e => e is {Id: "E1", Name: "Roy Williams", JobTitle: "Senior Office Manager", RowVersion: 2});
+            Assert.Single(db.Suppliers, e => e is {Id: "S1", Name: "Friendly Corp.", Address: "100 Main St.", RowVersion: 2});
+        }
+    }
 }
+

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SaveChangesTransactionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Update/SaveChangesTransactionTests.cs
@@ -14,6 +14,7 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
@@ -236,7 +237,9 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseMongoDB(database.Client, database.DatabaseNamespace.DatabaseName);
+            optionsBuilder
+                .UseMongoDB(database.Client, database.DatabaseNamespace.DatabaseName)
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
         }
     }
 
@@ -259,6 +262,7 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
 
         {
             using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            db.Database.EnsureCreated();
             db.Add(new Supplier {Id = "S1", Name = "Friendly Corp.", Address = "123 Main St."});
             db.Add(e1);
             db.SaveChanges();
@@ -290,6 +294,7 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
 
         {
             await using var db = new MultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            await db.Database.EnsureCreatedAsync();
             await db.AddAsync(new Supplier {Id = "S1", Name = "Friendly Corp.", Address = "123 Main St."});
             await db.AddAsync(e1);
             await db.SaveChangesAsync();
@@ -322,6 +327,7 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
 
         {
             using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            db.Database.EnsureCreated();
             db.AddRange(s1, e1);
             db.SaveChanges();
         }
@@ -358,6 +364,7 @@ public class SaveChangesTransactionTests(TemporaryDatabaseFixture tempDatabase)
 
         {
             await using var db = new ConcurrentMultiEntityDbContext(tempDatabaseFixture.MongoDatabase);
+            await db.Database.EnsureCreatedAsync();
             await db.AddRangeAsync(s1, e1);
             await db.SaveChangesAsync();
         }


### PR DESCRIPTION
Just an extra couple of tests to ensure auto transactions roll back all collections affected not just one.