### PR TITLE
EF-163: Set V3 Guid mode at initialization

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
@@ -118,6 +118,7 @@ public static class MongoServiceCollectionExtensions
             .TryAdd<IQueryTranslationPostprocessorFactory, MongoQueryTranslationPostprocessorFactory>()
             .TryAdd<IQueryableMethodTranslatingExpressionVisitorFactory, MongoQueryableMethodTranslatingExpressionVisitorFactory>()
             .TryAdd<IShapedQueryCompilingExpressionVisitorFactory, MongoShapedQueryCompilingExpressionVisitorFactory>()
+            .TryAdd<IModelRuntimeInitializer, MongoModelRuntimeInitializer>()
             .TryAddProviderSpecificServices(
                 b => b
                     .TryAddScoped<IMongoClientWrapper, MongoClientWrapper>()

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
@@ -1,0 +1,66 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace MongoDB.EntityFrameworkCore.Infrastructure;
+
+/// <summary>
+/// Initializes a <see cref="IModel" /> with the runtime dependencies.
+/// </summary>
+/// <param name="dependencies"></param>
+public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies dependencies)
+    : ModelRuntimeInitializer(dependencies)
+{
+    private static readonly Dictionary<Type, IDiscriminatorConvention>? DiscriminatorConventionDictionary =
+        typeof(BsonSerializer).GetField("__discriminatorConventions", BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null) as Dictionary<Type, IDiscriminatorConvention>;
+
+    /// <summary>
+    /// Validates and initializes the given model with runtime dependencies.
+    /// </summary>
+    /// <remarks>
+    /// Specifically, this method initializes the MongoDB C# Driver with the necessary
+    /// configuration to support the model and MongoDB EF Core provider.
+    /// </remarks>
+    /// <param name="model">The model to initialize.</param>
+    /// <param name="designTime">Whether the model should contain design-time configuration.</param>
+    /// <param name="validationLogger">The validation logger.</param>
+    /// <returns>The initialized model.</returns>
+    public override IModel Initialize(IModel model, bool designTime = true,
+        IDiagnosticsLogger<DbLoggerCategory.Model.Validation>? validationLogger = null)
+    {
+        model = base.Initialize(model, designTime, validationLogger);
+
+        ConfigureDriverConventions();
+
+        return model;
+    }
+
+    private static void ConfigureDriverConventions()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3;
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
@@ -13,16 +13,11 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Conventions;
 
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
@@ -33,9 +28,6 @@ namespace MongoDB.EntityFrameworkCore.Infrastructure;
 public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies dependencies)
     : ModelRuntimeInitializer(dependencies)
 {
-    private static readonly Dictionary<Type, IDiscriminatorConvention>? DiscriminatorConventionDictionary =
-        typeof(BsonSerializer).GetField("__discriminatorConventions", BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null) as Dictionary<Type, IDiscriminatorConvention>;
-
     /// <summary>
     /// Validates and initializes the given model with runtime dependencies.
     /// </summary>

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
@@ -21,7 +21,6 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Query;
 
@@ -60,13 +59,6 @@ public class MongoQueryCompilationContext : QueryCompilationContext
     /// <inheritdoc />
     public override Func<QueryContext, TResult> CreateQueryExecutor<TResult>(Expression originalQuery)
     {
-#pragma warning disable CS0618 // Type or member is obsolete
-        if (BsonDefaults.GuidRepresentationMode != GuidRepresentationMode.V3)
-        {
-            BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3;
-        }
-#pragma warning restore CS0618 // Type or member is obsolete
-
         var query = Dependencies.QueryTranslationPreprocessorFactory.Create(this).Process(originalQuery);
         query = Dependencies.QueryableMethodTranslatingExpressionVisitorFactory.Create(this).Visit(query);
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TemporaryDatabaseFixture.cs
@@ -31,9 +31,6 @@ public class TemporaryDatabaseFixture : IDisposable, IAsyncDisposable
     {
         Client = TestServer.GetClient();
         MongoDatabase = Client.GetDatabase($"{TestDatabasePrefix}{TimeStamp}-{Interlocked.Increment(ref Count)}");
-#pragma warning disable CS0618 // Type or member is obsolete
-        BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3; // We sometimes insert with C# Driver before firing up EF Provider
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     public IMongoDatabase MongoDatabase { get; }


### PR DESCRIPTION
Previously the V3 Guid mode was set when a query was run. This means if data was inserted before any queries it used the V2 non-standard mode resulting in exception messages.

This moves the configuration of the BsonDefaults static to DbContext initialization.