### PR TITLE
Add project config to allow 2.28 or 3.0 driver

### DIFF
--- a/MongoDB.EFCoreProvider.sln
+++ b/MongoDB.EFCoreProvider.sln
@@ -23,20 +23,27 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug 3.0 Driver|Any CPU = Debug 3.0 Driver|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F50A0110-A930-4876-BBD4-78B039C12D9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F50A0110-A930-4876-BBD4-78B039C12D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F50A0110-A930-4876-BBD4-78B039C12D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F50A0110-A930-4876-BBD4-78B039C12D9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F50A0110-A930-4876-BBD4-78B039C12D9E}.Debug 3.0 Driver|Any CPU.ActiveCfg = Debug 3.0 Driver|Any CPU
+		{F50A0110-A930-4876-BBD4-78B039C12D9E}.Debug 3.0 Driver|Any CPU.Build.0 = Debug 3.0 Driver|Any CPU
 		{9337C5E2-A5DB-4608-9274-5C679B92ED9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9337C5E2-A5DB-4608-9274-5C679B92ED9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9337C5E2-A5DB-4608-9274-5C679B92ED9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9337C5E2-A5DB-4608-9274-5C679B92ED9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9337C5E2-A5DB-4608-9274-5C679B92ED9E}.Debug 3.0 Driver|Any CPU.ActiveCfg = Debug 3.0 Driver|Any CPU
+		{9337C5E2-A5DB-4608-9274-5C679B92ED9E}.Debug 3.0 Driver|Any CPU.Build.0 = Debug 3.0 Driver|Any CPU
 		{CDBD7CC4-0F4D-4B03-859E-71FE5A3DE363}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CDBD7CC4-0F4D-4B03-859E-71FE5A3DE363}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDBD7CC4-0F4D-4B03-859E-71FE5A3DE363}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDBD7CC4-0F4D-4B03-859E-71FE5A3DE363}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDBD7CC4-0F4D-4B03-859E-71FE5A3DE363}.Debug 3.0 Driver|Any CPU.ActiveCfg = Debug 3.0 Driver|Any CPU
+		{CDBD7CC4-0F4D-4B03-859E-71FE5A3DE363}.Debug 3.0 Driver|Any CPU.Build.0 = Debug 3.0 Driver|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="myget.org" value="https://www.myget.org/F/mongodb/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
@@ -17,7 +17,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
@@ -44,15 +43,19 @@ public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies de
     {
         model = base.Initialize(model, designTime, validationLogger);
 
+#if !MONGO_DRIVER_3
         ConfigureDriverConventions();
+#endif
 
         return model;
     }
 
+#if !MONGO_DRIVER_3
     private static void ConfigureDriverConventions()
     {
 #pragma warning disable CS0618 // Type or member is obsolete
-        BsonDefaults.GuidRepresentationMode = GuidRepresentationMode.V3;
+        Bson.BsonDefaults.GuidRepresentationMode = Bson.GuidRepresentationMode.V3;
 #pragma warning restore CS0618 // Type or member is obsolete
     }
+#endif
 }

--- a/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
+++ b/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
@@ -4,6 +4,8 @@
     <Description>Official MongoDB supported provider for Entity Framework Core 8. See https://www.mongodb.com/docs/entity-framework/ for more details.</Description>
     <IsPackable>true</IsPackable>
     <PackageId>MongoDB.EntityFrameworkCore</PackageId>
+    <Configurations>Debug;Release;Debug 3.0 Driver</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,10 +17,22 @@
     <DocumentationFile>bin\Debug\MongoDB.EntityFrameworkCore.xml</DocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug 3.0 Driver' ">
+    <DocumentationFile>bin\Debug\MongoDB.EntityFrameworkCore.xml</DocumentationFile>
+    <DefineConstants>MONGO_DRIVER_3</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug 3.0 Driver' ">
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0-41-g27d46610e4" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' != 'Debug 3.0 Driver' ">
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.UnitTests" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
-    <PackageReference Remove="Microsoft.SourceLink.GitHub"/>
+    <PackageReference Remove="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
 </Project>

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -70,13 +70,15 @@ internal sealed class MongoEFToLinqTranslatingExpressionVisitor : ExpressionVisi
         BsonDocumentSerializer resultSerializer)
     {
         var asMethodInfo = AsMethodInfo.MakeGenericMethod(query.Type.GenericTypeArguments[0], typeof(BsonDocument));
-        var cast = Expression.Convert(query, typeof(IMongoQueryable<>).MakeGenericType(query.Type.GenericTypeArguments[0]));
+#if !MONGO_DRIVER_3
+        query = Expression.Convert(query, typeof(IMongoQueryable<>).MakeGenericType(query.Type.GenericTypeArguments[0]));
+#endif
         var serializerExpression = Expression.Constant(resultSerializer, resultSerializer.GetType());
 
         return Expression.Call(
             null,
             asMethodInfo,
-            cast,
+            query,
             serializerExpression
         );
     }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -134,7 +134,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         var translatedQuery = queryTranslator.Visit(queryExpression.CapturedExpression)!;
 
         var executableQuery =
-            new MongoExecutableQuery(translatedQuery, resultCardinality, source.Provider, collection.CollectionNamespace);
+            new MongoExecutableQuery(translatedQuery, resultCardinality, (IMongoQueryProvider)source.Provider, collection.CollectionNamespace);
 
         return new QueryingEnumerable<TResult, TResult>(
             mongoQueryContext,
@@ -164,7 +164,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         var translatedQuery = queryTranslator.Translate(queryExpression.CapturedExpression, resultCardinality);
 
         var executableQuery =
-            new MongoExecutableQuery(translatedQuery, resultCardinality, source.Provider, collection.CollectionNamespace);
+            new MongoExecutableQuery(translatedQuery, resultCardinality, (IMongoQueryProvider)source.Provider, collection.CollectionNamespace);
 
         return new QueryingEnumerable<BsonDocument, TResult>(
             mongoQueryContext,

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -70,7 +70,7 @@ public class MongoClientWrapper : IMongoClientWrapper
         if (executableQuery.Cardinality != ResultCardinality.Enumerable)
             return ExecuteScalar<T>(executableQuery);
 
-        var queryable = (IMongoQueryable<T>)executableQuery.Provider.CreateQuery<T>(executableQuery.Query);
+        var queryable = executableQuery.Provider.CreateQuery<T>(executableQuery.Query);
         log = () => _commandLogger.ExecutedMqlQuery(executableQuery);
         return queryable;
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/MongoDB.EntityFrameworkCore.FunctionalTests.csproj
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/MongoDB.EntityFrameworkCore.FunctionalTests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Configurations>Debug;Release;Debug 3.0;Debug 3.0 Driver</Configurations>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6"/>
   </ItemGroup>

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/MongoDB.EntityFrameworkCore.UnitTests.csproj
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/MongoDB.EntityFrameworkCore.UnitTests.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Configurations>Debug;Release;Debug 3.0;Debug 3.0 Driver</Configurations>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="8.0.6"/>


### PR DESCRIPTION
Give us a project configuration "Debug 3.0 Driver" which allows using the MongoDB C# Driver 3.0 pre-release.

This will help us continue developing and provide an easy migration when we switch to the 3.0 driver after it is released.