### PR TITLE
Fix test that was broken on latest C# Driver branch

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -588,11 +588,11 @@ public class ValueConverterTests(TemporaryDatabaseFixture database)
     }
 
     private static readonly Action<ModelBuilder> DecimalToMongoString = mb =>
-        mb.Entity<AmountIsString>()
-            .Property(e => e.amount).HasConversion(v => decimal.Parse(v), v => v.ToString());
+        mb.Entity<AmountIsDecimal>()
+            .Property(e => e.amount).HasConversion(v => v.ToString(), v => decimal.Parse(v));
 
     private static readonly Action<ModelBuilder> DefaultDecimalToMongoString = mb =>
-        mb.Entity<AmountIsString>()
+        mb.Entity<AmountIsDecimal>()
             .Property(e => e.amount).HasConversion<string>();
 
     [Theory]


### PR DESCRIPTION
Latest changes to C# Driver store Decimals as Decimal128.

This exposed a miconfigured test that was supposed to store Decimals as Strings explicitly but was in fact doing it implicitly due to the default value converter configuring the wrong entity.