### PR TITLE
Fixes to docs and order of convention registration

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConvention.cs
@@ -24,7 +24,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace MongoDB.EntityFrameworkCore.Metadata.Conventions.BsonAttributes;
 
 /// <summary>
-/// A convention that configures the element name for entity properties based on an applied <see cref="BsonElementAttribute" /> for
+/// A convention that configures the element name for entity properties based on an applied <see cref="BsonDateTimeOptionsAttribute" /> for
 /// familiarity with the Mongo C# Driver.
 /// </summary>
 public sealed class BsonDateTimeOptionsAttributeConvention : PropertyAttributeConventionBase<BsonDateTimeOptionsAttribute>

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoConventionSetBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoConventionSetBuilder.cs
@@ -57,6 +57,7 @@ public class MongoConventionSetBuilder : ProviderConventionSetBuilder
         conventionSet.Add(new BsonElementAttributeConvention(Dependencies));
         conventionSet.Add(new BsonIdPropertyAttributeConvention(Dependencies));
         conventionSet.Add(new BsonIgnoreAttributeConvention(Dependencies));
+        conventionSet.Add(new BsonRepresentationAttributeConvention(Dependencies));
         conventionSet.Add(new BsonRequiredPropertyAttributeConvention(Dependencies));
 
         // Unsupported attributes on properties that should throw not supported
@@ -67,7 +68,6 @@ public class MongoConventionSetBuilder : ProviderConventionSetBuilder
         conventionSet.Add(new BsonGuidRepresentationAttributeConvention(Dependencies));
         conventionSet.Add(new BsonIgnoreIfDefaultAttributePropertyAttributeConvention(Dependencies));
         conventionSet.Add(new BsonIgnoreIfNullAttributePropertyAttributeConvention(Dependencies));
-        conventionSet.Add(new BsonRepresentationAttributeConvention(Dependencies));
         conventionSet.Add(new BsonSerializationOptionsAttributeConvention(Dependencies));
         conventionSet.Add(new BsonSerializerPropertyConvention(Dependencies));
         conventionSet.Add(new BsonBsonTimeSpanOptionsPropertyAttributeConvention(Dependencies));

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/PrimitiveCollectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/PrimitiveCollectionTests.cs
@@ -1,4 +1,19 @@
-﻿using MongoDB.Bson;
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
 


### PR DESCRIPTION
Spotted these during the default work but don't want to pollute that PR with unrelated fixes.