### PR TITLE
EF-80: Add support for type discriminators

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
@@ -46,13 +46,10 @@ public static class MongoEntityTypeExtensions
     /// <param name="entityType">The entity type to get the collection name for.</param>
     /// <returns>The name of the collection to which the entity type is mapped.</returns>
     public static string GetCollectionName(this IReadOnlyEntityType entityType)
-    {
-        var nameAnnotation = entityType.FindAnnotation(MongoAnnotationNames.CollectionName);
-        if (nameAnnotation?.Value != null)
-            return (string)nameAnnotation.Value;
-
-        return GetDefaultCollectionName(entityType);
-    }
+        => entityType.BaseType != null
+            ? entityType.GetRootType().GetCollectionName()
+            : (string?)entityType[MongoAnnotationNames.CollectionName]
+              ?? GetDefaultCollectionName(entityType);
 
     /// <summary>
     /// Returns the default collection name that would be used for this entity type.
@@ -69,8 +66,8 @@ public static class MongoEntityTypeExtensions
     /// <returns><see langword="true"/> if the entity is a root, <see langword="false"/> if it is owned.</returns>
     public static bool IsDocumentRoot(this IReadOnlyEntityType entityType)
         => entityType.BaseType?.IsDocumentRoot()
-           ?? (entityType.FindOwnership() == null
-               || entityType[MongoAnnotationNames.CollectionName] != null);
+           ?? entityType.FindOwnership() == null
+           || entityType[MongoAnnotationNames.CollectionName] != null;
 
     /// <summary>
     /// Get the name of the parent element to which the entity type is mapped.

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
@@ -35,8 +35,10 @@ namespace MongoDB.EntityFrameworkCore.Infrastructure;
 public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies dependencies)
     : ModelRuntimeInitializer(dependencies)
 {
+#if !MONGO_DRIVER_3
     private static readonly Dictionary<Type, IDiscriminatorConvention>? DiscriminatorConventionDictionary =
         typeof(BsonSerializer).GetField("__discriminatorConventions", BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null) as Dictionary<Type, IDiscriminatorConvention>;
+#endif
 
     /// <summary>
     /// Validates and initializes the given model with runtime dependencies.
@@ -56,8 +58,8 @@ public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies de
 
 #if !MONGO_DRIVER_3
         ConfigureDriverConventions();
-#endif
         SetupTypeDiscriminators(model);
+#endif
 
         return model;
     }
@@ -69,7 +71,6 @@ public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies de
         Bson.BsonDefaults.GuidRepresentationMode = Bson.GuidRepresentationMode.V3;
 #pragma warning restore CS0618 // Type or member is obsolete
     }
-#endif
 
     private static void SetupTypeDiscriminators(IModel model)
     {
@@ -103,4 +104,5 @@ public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies de
             }
         }
     }
+#endif
 }

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
@@ -13,18 +13,10 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Conventions;
-using MongoDB.EntityFrameworkCore.Extensions;
-using MongoDB.EntityFrameworkCore.Serializers;
 
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
@@ -35,11 +27,6 @@ namespace MongoDB.EntityFrameworkCore.Infrastructure;
 public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies dependencies)
     : ModelRuntimeInitializer(dependencies)
 {
-#if !MONGO_DRIVER_3
-    private static readonly Dictionary<Type, IDiscriminatorConvention>? DiscriminatorConventionDictionary =
-        typeof(BsonSerializer).GetField("__discriminatorConventions", BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null) as Dictionary<Type, IDiscriminatorConvention>;
-#endif
-
     /// <summary>
     /// Validates and initializes the given model with runtime dependencies.
     /// </summary>
@@ -55,54 +42,7 @@ public class MongoModelRuntimeInitializer(ModelRuntimeInitializerDependencies de
         IDiagnosticsLogger<DbLoggerCategory.Model.Validation>? validationLogger = null)
     {
         model = base.Initialize(model, designTime, validationLogger);
-
-#if !MONGO_DRIVER_3
-        ConfigureDriverConventions();
-        SetupTypeDiscriminators(model);
-#endif
-
         return model;
     }
 
-#if !MONGO_DRIVER_3
-    private static void ConfigureDriverConventions()
-    {
-#pragma warning disable CS0618 // Type or member is obsolete
-        Bson.BsonDefaults.GuidRepresentationMode = Bson.GuidRepresentationMode.V3;
-#pragma warning restore CS0618 // Type or member is obsolete
-    }
-
-    private static void SetupTypeDiscriminators(IModel model)
-    {
-        // In The C# 3.0 Driver we'll stop using reflection and decorate EntitySerializer with a property
-        // capable of specifying the IDiscriminatorConvention (CSHARP-5259) but we can do this for now.
-
-        if (DiscriminatorConventionDictionary == null)
-        {
-            throw new InvalidOperationException("Unable to access MongoDB C# Driver discriminator conventions.");
-        }
-
-        var discriminatorProperties = new HashSet<IReadOnlyProperty>();
-        foreach (var entityType in model.GetEntityTypes().Where(e => e.IsDocumentRoot()))
-        {
-            var discriminatorProperty = entityType.FindDiscriminatorProperty();
-            if (discriminatorProperty != null)
-            {
-                discriminatorProperties.Add(discriminatorProperty);
-            }
-        }
-
-        foreach (var discriminatorProperty in discriminatorProperties)
-        {
-            var entityType = (IReadOnlyEntityType)discriminatorProperty.DeclaringType;
-            var newDiscriminator = new MongoEFDiscriminator(entityType);
-            if (!DiscriminatorConventionDictionary.TryAdd(entityType.ClrType, newDiscriminator)) {
-                var existingDiscriminator = DiscriminatorConventionDictionary[entityType.ClrType];
-                if (existingDiscriminator.ElementName != newDiscriminator.ElementName) {
-                    throw new NotSupportedException($"Multiple discriminator element names for entity type '{entityType.ClrType.ShortDisplayName()}' are not supported.");
-                }
-            }
-        }
-    }
-#endif
 }

--- a/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
+++ b/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
@@ -4,7 +4,7 @@
     <Description>Official MongoDB supported provider for Entity Framework Core 8. See https://www.mongodb.com/docs/entity-framework/ for more details.</Description>
     <IsPackable>true</IsPackable>
     <PackageId>MongoDB.EntityFrameworkCore</PackageId>
-    <Configurations>Debug;Release;Debug 3.0 Driver</Configurations>
+    <Configurations>Debug;Release;</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
@@ -16,22 +16,10 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DocumentationFile>bin\Debug\MongoDB.EntityFrameworkCore.xml</DocumentationFile>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug 3.0 Driver' ">
-    <DocumentationFile>bin\Debug\MongoDB.EntityFrameworkCore.xml</DocumentationFile>
-    <DefineConstants>MONGO_DRIVER_3</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(Configuration)' == 'Debug 3.0 Driver' ">
-    <PackageReference Include="MongoDB.Driver" Version="2.28.0-55-gf54ba02046" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(Configuration)' != 'Debug 3.0 Driver' ">
-    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.UnitTests" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0-55-gf54ba02046" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
   </ItemGroup>

--- a/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
+++ b/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Debug 3.0 Driver' ">
-    <PackageReference Include="MongoDB.Driver" Version="2.28.0-41-g27d46610e4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0-55-gf54ba02046" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' != 'Debug 3.0 Driver' ">

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -70,9 +70,6 @@ internal sealed class MongoEFToLinqTranslatingExpressionVisitor : ExpressionVisi
         BsonDocumentSerializer resultSerializer)
     {
         var asMethodInfo = AsMethodInfo.MakeGenericMethod(query.Type.GenericTypeArguments[0], typeof(BsonDocument));
-#if !MONGO_DRIVER_3
-        query = Expression.Convert(query, typeof(IMongoQueryable<>).MakeGenericType(query.Type.GenericTypeArguments[0]));
-#endif
         var serializerExpression = Expression.Constant(resultSerializer, resultSerializer.GetType());
 
         return Expression.Call(

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionBindingRemovingExpressionVisitor.cs
@@ -344,7 +344,7 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
         }
 
         return Expression.Convert(
-            CreateGetValueExpression(docExpression, property.Name, !type.IsNullableType(), type, property.GetTypeMapping()),
+            CreateGetValueExpression(docExpression, property.Name, !type.IsNullableType(), type, property.DeclaringType, property.GetTypeMapping()),
             type);
     }
 
@@ -359,16 +359,18 @@ internal abstract class ProjectionBindingRemovingExpressionVisitor : ExpressionV
     /// Create a new compilable <see cref="Expression"/> the shaper can use to obtain the value from the <see cref="BsonDocument"/>.
     /// </summary>
     /// <param name="docExpression">The <see cref="Expression"/> used to access the <see cref="BsonDocument"/>.</param>
-    /// <param name="fieldName">The name of the field within the document.</param>
-    /// <param name="fieldRequired"><see langword="true"/> if the field is required, <see langword="false"/> if it is optional.</param>
+    /// <param name="propertyName">The name of the property.</param>
+    /// <param name="required"><see langword="true"/> if the field is required, <see langword="false"/> if it is optional.</param>
     /// <param name="type">The <see cref="Type"/> of the value as it is within the document.</param>
+    /// <param name="declaredType">The optional <see cref="ITypeBase"/> this element comes from.</param>
     /// <param name="typeMapping">Any associated <see cref="CoreTypeMapping"/> to be used in mapping the value.</param>
     /// <returns>A compilable <see cref="Expression"/> to obtain the desired value as the correct type.</returns>
     protected abstract Expression CreateGetValueExpression(
         Expression docExpression,
-        string fieldName,
-        bool fieldRequired,
+        string propertyName,
+        bool required,
         Type type,
+        ITypeBase declaredType = null,
         CoreTypeMapping typeMapping = null);
 
     private BlockExpression AddIncludes(BlockExpression shaperBlock)

--- a/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
@@ -28,10 +28,10 @@ namespace MongoDB.EntityFrameworkCore.Serializers;
 /// and the MongoDB LINQ provider's <see cref="IBsonDocumentSerializer"/> interface.
 /// </summary>
 /// <typeparam name="TValue">The underlying CLR type being handled by this serializer.</typeparam>
-internal class EntitySerializer<TValue> : IBsonSerializer<TValue>, IBsonDocumentSerializer
-#if MONGO_DRIVER_3
-    , IHasDiscriminatorConvention
-#endif
+internal class EntitySerializer<TValue> :
+    IBsonSerializer<TValue>,
+    IBsonDocumentSerializer,
+    IHasDiscriminatorConvention
 {
     private readonly Func<IReadOnlyProperty, bool> _isStored = p => !p.IsShadowProperty() && p.GetElementName() != "";
     private readonly IReadOnlyEntityType _entityType;

--- a/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
@@ -1,0 +1,45 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace MongoDB.EntityFrameworkCore.Serializers;
+
+/// <summary>
+/// Provides a bridge between EF Core and the MongoDB C# driver for handling discriminator values.
+/// </summary>
+/// <param name="entityType">The <see cref="IReadOnlyEntityType"/> entity that forms part of the hierarchy.</param>
+internal class MongoEFDiscriminator(IReadOnlyEntityType entityType)
+    : IDiscriminatorConvention
+{
+    public Type GetActualType(IBsonReader bsonReader, Type nominalType)
+        => throw new NotImplementedException();
+
+    public BsonValue GetDiscriminator(Type nominalType, Type actualType)
+    {
+        var childEntityType = entityType.Model.FindEntityType(actualType)
+            ?? throw new InvalidOperationException($"Entity type '{actualType.ShortDisplayName()}' not found in model.");
+        return BsonValue.Create(childEntityType.GetDiscriminatorValue());
+    }
+
+    public string ElementName { get; } = entityType.FindDiscriminatorProperty()?.GetElementName() ?? "_t";
+}

--- a/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
@@ -29,11 +29,7 @@ namespace MongoDB.EntityFrameworkCore.Serializers;
 /// </summary>
 /// <param name="entityType">The <see cref="IReadOnlyEntityType"/> entity that forms part of the hierarchy.</param>
 internal class MongoEFDiscriminator(IReadOnlyEntityType entityType) :
-#if MONGO_DRIVER_3
     IScalarDiscriminatorConvention
-#else
-    IDiscriminatorConvention
-#endif
 {
     private readonly IReadOnlyModel _model = entityType.Model;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
@@ -22,33 +22,261 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Mapping;
 public class DiscriminatorTests(TemporaryDatabaseFixture database)
     : IClassFixture<TemporaryDatabaseFixture>
 {
-    class Vehicle
+    [Fact]
+    public void Sets_type_discriminator_property_and_type_for_read_and_write()
     {
-        public ObjectId _id { get; set; }
-        public string VehicleType { get; set; }
+        var collection = database.CreateCollection<BaseEntity>();
+        SetupTestData(SingleEntityDbContext.Create(collection, ConfigureModel));
+
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+        var entities = db.Entities.ToList();
+        Assert.Single(entities, e => e.EntityType == "Client" && e.GetType() == typeof(Customer));
+        Assert.Single(entities, e => e.EntityType == "Order" && e.GetType() == typeof(Order));
+        Assert.Single(entities, e => e.EntityType == "Supplier" && e.GetType() == typeof(Supplier));
+        Assert.Single(entities, e => e.EntityType == "Contact" && e.GetType() == typeof(Contact));
+        Assert.Single(entities, e => e.EntityType == "BaseEntity" && e.GetType() == typeof(BaseEntity));
     }
 
-    class VehicleDbContext(Action<ModelBuilder> modelConfigurator) : DbContext
+    [Fact]
+    public void Can_configure_type_discriminator_with_name_and_int()
     {
-        public DbSet<Vehicle> Vehicles { get; set; }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        var collection = database.CreateCollection<GuidKeyedEntity>();
+        var configuration = (ModelBuilder mb) =>
         {
-            base.OnModelCreating(modelBuilder);
-            modelConfigurator(modelBuilder);
+            mb.Entity<GuidKeyedEntity>(e =>
+            {
+                e.HasDiscriminator(g => g.SubType)
+                    .HasValue<KeyedCustomer>(1)
+                    .HasValue<KeyedOrder>(2);
+                e.Property(f => f.SubType).HasElementName("_subtype");
+            });
+        };
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, configuration);
+            db.Add(new KeyedCustomer {Name = "Customer 1"});
+            db.Add(new KeyedOrder {OrderReference = "Order 1"});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, configuration);
+            var customer = db.Entities.First(e => e is KeyedCustomer);
+            Assert.Equal("Customer 1", Assert.IsType<KeyedCustomer>(customer).Name);
         }
     }
 
     [Fact]
-    public void Discriminators_throw_not_supported_if_configured()
+    public void Returns_correct_values_when_property_name_shared_between_entities()
     {
-        var collection = database.CreateCollection<Vehicle>();
+        var collection = database.CreateCollection<BaseEntity>();
+        SetupTestData(SingleEntityDbContext.Create(collection, ConfigureModel));
+
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+        var entities = db.Entities.Where(e => e is Supplier || e is Contact).ToList();
+
+        Assert.Single(entities, e => e is Supplier {Name: "Supplier 1"});
+        Assert.Single(entities, e => e is Contact {Name: "Contact 1"});
+        Assert.Equal(2, entities.Count);
+    }
+
+    [Fact]
+    public void Returns_correct_values_when_navigation_shared_between_entities()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+        var expectedProducts = new List<string> {"Product 3", "Product 4", "Product 5"};
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+            db.Add(new Customer {Name = "Customer 1", ShippingAddress = "123 Main St"});
+            db.Add(new Supplier {Name = "Supplier 1", Products = ["Product 1", "Product 2"]});
+            db.Add(new Order {OrderReference = "Order 1"});
+            db.Add(new OrderWithProducts {OrderReference = "Order 2", Products = expectedProducts});
+            db.Add(new BaseEntity());
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+            var entities = db.Entities.Where(e => e is Order || e is OrderWithProducts).ToList();
+
+            Assert.Single(entities, e => e is Order {OrderReference: "Order 1"});
+            var order = Assert.IsType<OrderWithProducts>(Assert.Single(entities,
+                e => e is OrderWithProducts {OrderReference: "Order 2"}));
+            Assert.Equal(expectedProducts, order.Products);
+            Assert.Equal(2, entities.Count);
+        }
+    }
+
+    [Fact]
+    public void Returns_correct_entity_where_is_type_query()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+        SetupTestData(SingleEntityDbContext.Create(collection, ConfigureModel));
+
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+        var entities = db.Entities.Where(e => e is Supplier).ToList();
+        Assert.Single(entities, e => e is Supplier {Name: "Supplier 1"});
+
+        var firstOrder = db.Entities.First(e => e is Order);
+        Assert.Equal("Order 1", Assert.IsType<Order>(firstOrder).OrderReference);
+    }
+
+    [Fact]
+    public void Returns_correct_entity_with_OfType_query()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+        SetupTestData(SingleEntityDbContext.Create(collection, ConfigureModel));
+
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+        var entities = db.Entities.OfType<Customer>().ToList();
+        Assert.Single(entities, e => e.Name == "Customer 1");
+    }
+
+    [Fact]
+    public void Returns_correct_entity_where_GetType_query()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+        SetupTestData(SingleEntityDbContext.Create(collection, ConfigureModel));
+
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+        var entities = db.Entities.Where(e => e.GetType() == typeof(Order)).ToList();
+        Assert.Single(entities, e => e is Order {OrderReference: "Order 1"});
+    }
+
+    [Fact]
+    public void Returns_correct_entities_with_mixed_query()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+        SetupTestData(SingleEntityDbContext.Create(collection, ConfigureModel));
+
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+        var entities = db.Entities.OfType<BaseEntity>().Where(e => e is Customer || e.GetType() == typeof(Order)).ToList();
+        Assert.Equal(2, entities.Count);
+        Assert.Single(entities, e => e is Customer {Name: "Customer 1"});
+        Assert.Single(entities, e => e is Order {OrderReference: "Order 1"});
+    }
+
+    [Fact]
+    public void TablePerType_throws_NotSupportedException()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+
         using var db = SingleEntityDbContext.Create(collection, mb =>
         {
-            mb.Entity<Vehicle>().HasDiscriminator(v => v.VehicleType);
+            ConfigureModel(mb);
+            mb.Entity<BaseEntity>().UseTptMappingStrategy();
         });
 
-        var ex = Assert.Throws<NotSupportedException>(() => db.Entities.FirstOrDefault());
-        Assert.Contains(nameof(Vehicle), ex.Message);
+        Assert.Throws<NotSupportedException>(() => SetupTestData(db));
+    }
+
+    [Fact]
+    public void TablePerConcrete_throws_NotSupportedException()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+
+        using var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            ConfigureModel(mb);
+            mb.Entity<BaseEntity>().UseTpcMappingStrategy();
+        });
+
+        Assert.Throws<NotSupportedException>(() => SetupTestData(db));
+    }
+
+    [Fact]
+    public void Multiple_discriminators_for_same_type_throws()
+    {
+        var collection = database.CreateCollection<BaseEntity>();
+
+        var configA = (ModelBuilder mb) =>
+        {
+            ConfigureModel(mb);
+            mb.Entity<BaseEntity>().Property(p => p.EntityType).HasElementName("_A");
+        };
+
+        var configB = (ModelBuilder mb) =>
+        {
+            ConfigureModel(mb);
+            mb.Entity<BaseEntity>().Property(p => p.EntityType).HasElementName("_B");
+        };
+
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            SetupTestData(SingleEntityDbContext.Create(collection, configA));
+            SetupTestData(SingleEntityDbContext.Create(collection, configB));
+        });
+    }
+
+    private static void ConfigureModel(ModelBuilder mb)
+    {
+        mb.Entity<BaseEntity>()
+            .HasDiscriminator(e => e.EntityType)
+            .HasValue<Customer>("Client")
+            .HasValue<Supplier>("Supplier")
+            .HasValue<Order>("Order")
+            .HasValue<OrderWithProducts>("OrderEx")
+            .HasValue<Contact>("Contact");
+    }
+
+    private static void SetupTestData(DbContext db)
+    {
+        db.Add(new Customer {Name = "Customer 1", ShippingAddress = "123 Main St"});
+        db.Add(new Supplier {Name = "Supplier 1", Products = ["Product 1", "Product 2"]});
+        db.Add(new Order {OrderReference = "Order 1"});
+        db.Add(new Contact {Name = "Contact 1"});
+        db.Add(new BaseEntity());
+        db.SaveChanges();
+        db.Dispose();
+    }
+
+    class BaseEntity
+    {
+        public ObjectId _id { get; set; }
+        public string EntityType { get; set; }
+    }
+
+    class Customer : BaseEntity
+    {
+        public string Name { get; set; }
+        public string ShippingAddress { get; set; }
+    }
+
+    class Supplier : BaseEntity
+    {
+        public string Name { get; set; }
+        public List<string> Products { get; set; }
+    }
+
+    class Order : BaseEntity
+    {
+        public string OrderReference { get; set; }
+    }
+
+    class OrderWithProducts : Order
+    {
+        public List<string> Products { get; set; }
+    }
+
+    class Contact : BaseEntity
+    {
+        public string Name { get; set; }
+    }
+
+    abstract class GuidKeyedEntity
+    {
+        public Guid Id { get; set; }
+        public int SubType { get; set; }
+    }
+
+    class KeyedCustomer : GuidKeyedEntity
+    {
+        public string Name { get; set; }
+    }
+
+    class KeyedOrder : GuidKeyedEntity
+    {
+        public string OrderReference { get; set; }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
@@ -123,7 +123,6 @@ public class DiscriminatorTests(TemporaryDatabaseFixture database)
         Assert.Single(entities, e => e is Order {OrderReference: "Order 1"});
     }
 
-#if MONGO_DRIVER_3
     [Fact]
     public void Returns_correct_values_when_navigation_shared_between_entities()
     {
@@ -176,7 +175,6 @@ public class DiscriminatorTests(TemporaryDatabaseFixture database)
         Assert.Single(entities, e => e is SubCustomer {Name: "SubCustomer 1"});
         Assert.Single(entities, e => e is Order {OrderReference: "Order 1"});
     }
-#endif
 
     [Fact]
     public void TablePerType_throws_NotSupportedException()


### PR DESCRIPTION
This adds support for type discriminators and also sets the requirement for the C# Driver 3.0 currently under development.

This was necessary as earlier versions of the C# Driver did not support storing a single type discriminator value on the document (scalar discriminators) while still offering the expected support for OfType and "is type" filters.