### PR TITLE
Optimize ToTitleCase Method for performance & allocation

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/NamingHelperMethods.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+using System.Buffers;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -72,29 +73,59 @@ public static partial class NamingHelperMethods
     /// <returns>The cleaned title-cased string.</returns>
     /// <remarks>Word boundaries are considered spaces, non-alphanumeric, a transition from
     /// lower to upper, and a transition from number to non-number.</remarks>
-    public static string ToTitleCase(
-        this string input,
-        CultureInfo culture)
+    public static string ToTitleCase(this string input, CultureInfo culture)
     {
         if (string.IsNullOrEmpty(input)) return input;
 
-        var words = WordSplitRegex().Split(input);
+        Span<char> initialBuffer = stackalloc char[512];
 
-        var result = new char[input.Length];
-        var outIndex = 0;
+        if (input.Length > initialBuffer.Length) return ToTitleCaseLarge(input, culture);
 
-        for (var inIndex = 0; inIndex < words.Length; inIndex++)
+        var written = ToTitleCaseInternal(input.AsSpan(), initialBuffer, culture);
+        return new string(initialBuffer[..written]);
+    }
+
+    private static string ToTitleCaseLarge(string input, CultureInfo culture)
+    {
+        var rentedArray = ArrayPool<char>.Shared.Rent(input.Length);
+        try
         {
-            var w = words[inIndex];
-            if (w.Length == 0) continue;
+            var written = ToTitleCaseInternal(input.AsSpan(), rentedArray, culture);
+            return new string(rentedArray, 0, written);
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(rentedArray);
+        }
+    }
 
-            result[outIndex] = char.ToUpper(w[0], culture);
-            w.ToLower(culture).CopyTo(1, result, outIndex + 1, w.Length - 1);
+    private static int ToTitleCaseInternal(ReadOnlySpan<char> input, Span<char> output, CultureInfo culture)
+    {
+        var outIndex = 0;
+        var lastIndex = 0;
 
-            outIndex += w.Length;
+        foreach (var match in WordSplitRegex.EnumerateMatches(input))
+        {
+            var wordLength = match.Index - lastIndex;
+            if (wordLength > 0)
+                ProcessWord(input.Slice(lastIndex, wordLength), output[outIndex..], culture,
+                    ref outIndex);
+
+            lastIndex = match.Index + match.Length;
         }
 
-        return new string(result, 0, outIndex);
+        if (lastIndex < input.Length)
+            ProcessWord(input[lastIndex..], output[outIndex..], culture, ref outIndex);
+
+        return outIndex;
+    }
+
+    private static void ProcessWord(ReadOnlySpan<char> word, Span<char> output, CultureInfo culture,
+        ref int outIndex)
+    {
+        output[0] = char.ToUpper(word[0], culture);
+        for (var i = 1; i < word.Length; i++) output[i] = char.ToLower(word[i], culture);
+        outIndex += word.Length;
     }
 
     // Find word boundaries.


### PR DESCRIPTION
Hi,

This pull request introduces optimizations to the `ToTitleCase` method in the `NamingHelperMethods` class to improve performance and reduce memory allocations.

Testing:
-  Passed your unit tests

Key Enhancements:

1. Performance Optimization:
   - Small inputs: 25.4 times faster (4,252.0 ns → 167.3 ns)
   - Medium inputs: 7.3 times faster (105,182.6 ns → 14,419.9 ns)
   - Large inputs: 5.4 times faster (10,983,153.6 ns → 2,048,688.3 ns)
   - Very large inputs: 6.3 times faster (128,103,886.7 ns → 20,264,420.3 ns)

2. Memory Allocation Optimization:
   - Small inputs: 196 times less memory used (9,416 B → 48 B)
   - Medium inputs: 23 times less memory used (45,840 B → 1,992 B)
   - Large inputs: 20 times less memory used (3,926,474 B → 196,977 B)
   - Very large inputs: 18.8 times less memory used (37,083,832 B → 1,968,249 B)

3. Garbage Collection Efficiency:
   - Significant reduction in Gen0, Gen1, and Gen2 collections across all input sizes


![performance_test](https://github.com/user-attachments/assets/bbda7354-2fac-400a-b690-a63fe78d5248)
