### PR TITLE
Noticed a typo in the BsonTimeSpanOptionsAttributeConvention.cs

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonTimeSpanOptionsAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonTimeSpanOptionsAttributeConvention.cs
@@ -23,5 +23,5 @@ namespace MongoDB.EntityFrameworkCore.Metadata.Conventions.BsonAttributes;
 /// to ensure the model will throw as the attribute is not supported in the EF provider.
 /// </summary>
 /// <param name="dependencies">The <see cref="ProviderConventionSetBuilderDependencies"/> conventions depend upon.</param>
-public sealed class BsonBsonTimeSpanOptionsPropertyAttributeConvention(ProviderConventionSetBuilderDependencies dependencies)
+public sealed class BsonTimeSpanOptionsPropertyAttributeConvention(ProviderConventionSetBuilderDependencies dependencies)
     : NotSupportedPropertyAttributeConvention<BsonTimeSpanOptionsAttribute>(dependencies);

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoConventionSetBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoConventionSetBuilder.cs
@@ -70,7 +70,7 @@ public class MongoConventionSetBuilder : ProviderConventionSetBuilder
         conventionSet.Add(new BsonIgnoreIfNullAttributePropertyAttributeConvention(Dependencies));
         conventionSet.Add(new BsonSerializationOptionsAttributeConvention(Dependencies));
         conventionSet.Add(new BsonSerializerPropertyConvention(Dependencies));
-        conventionSet.Add(new BsonBsonTimeSpanOptionsPropertyAttributeConvention(Dependencies));
+        conventionSet.Add(new BsonTimeSpanOptionsPropertyAttributeConvention(Dependencies));
 
         // Replace default conventions with MongoDB-specific ones
         conventionSet.Replace<KeyDiscoveryConvention>(new PrimaryKeyDiscoveryConvention(Dependencies));


### PR DESCRIPTION
Small silly typo crept in at some point in the past.

Technically this is a breaking change as it's public but I'd be surprised if anyone used it. Should still mention it in the 8.2 release notes/breaking changes though just to be sure.