### PR TITLE
EF-171: Allow type discriminators without mapped property

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
@@ -73,7 +73,6 @@ public class MongoModelValidator : ModelValidator
         ValidateNoUnsupportedAttributesOrAnnotations(model);
         ValidateElementNames(model);
         ValidateNoUnsupportedShadowProperties(model);
-        ValidateElementNames(model);
         ValidateNoMutableKeys(model, logger);
         ValidatePrimaryKeys(model);
     }

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -199,7 +199,7 @@ public class MongoUpdate(string collectionName, WriteModel<BsonDocument> model)
     internal static void WriteNonKeyProperties(IBsonWriter writer, IUpdateEntry entry, Func<IProperty, bool>? propertyFilter = null)
     {
         var properties = entry.EntityType.GetProperties()
-            .Where(p => !p.IsShadowProperty() && !p.IsPrimaryKey() && p.GetElementName() != "")
+            .Where(p => !p.IsPrimaryKey() && p.GetElementName() != "")
             .Where(p => propertyFilter == null || propertyFilter(p))
             .ToArray();
 


### PR DESCRIPTION
Enables type discriminators to be used without a mapped property by relaxing some of the shadow property validation and ensuring type discriminator shadow properties are always serialized.