### PR TITLE
EF-173: Support HasIndex by creating them during CreateDatabase

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
@@ -30,6 +30,21 @@ public static class MongoIndexBuilderExtensions
     /// </summary>
     /// <param name="indexBuilder">The builder for the index being configured.</param>
     /// <param name="options">The <see cref="CreateIndexOptions"/> for this index.</param>
+    /// <returns>A builder to further configure the index.</returns>
+    public static IndexBuilder HasCreateIndexOptions(
+        this IndexBuilder indexBuilder,
+        CreateIndexOptions? options)
+    {
+        indexBuilder.Metadata.SetCreateIndexOptions(options);
+
+        return indexBuilder;
+    }
+
+    /// <summary>
+    /// Configures the <see cref="CreateIndexOptions"/> for the index.
+    /// </summary>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="options">The <see cref="CreateIndexOptions"/> for this index.</param>
     /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>
     /// The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
@@ -39,29 +54,26 @@ public static class MongoIndexBuilderExtensions
         CreateIndexOptions<BsonDocument>? options,
         bool fromDataAnnotation = false)
     {
-        if (indexBuilder.CanSetCreateIndexOptions(options, fromDataAnnotation))
+        if (!indexBuilder.CanSetCreateIndexOptions(options, fromDataAnnotation))
         {
-            indexBuilder.Metadata.SetCreateIndexOptions(options, fromDataAnnotation);
-            return indexBuilder;
+            return null;
         }
+
+        indexBuilder.Metadata.SetCreateIndexOptions(options, fromDataAnnotation);
         return indexBuilder;
     }
 
     /// <summary>
     /// Configures the <see cref="CreateIndexOptions"/> for the index.
     /// </summary>
+    /// <typeparam name="TEntity">The entity type being configured.</typeparam>
     /// <param name="indexBuilder">The builder for the index being configured.</param>
     /// <param name="options">The <see cref="CreateIndexOptions"/> for this index.</param>
-    /// <returns>
-    /// The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
-    /// </returns>
+    /// <returns>A builder to further configure the index.</returns>
     public static IndexBuilder<TEntity> HasCreateIndexOptions<TEntity>(
         this IndexBuilder<TEntity> indexBuilder,
-        CreateIndexOptions? options)
-    {
-        indexBuilder.Metadata.SetCreateIndexOptions(options);
-        return indexBuilder;
-    }
+        CreateIndexOptions options)
+        => (IndexBuilder<TEntity>)HasCreateIndexOptions((IndexBuilder)indexBuilder, options);
 
     /// <summary>
     /// Returns a value indicating whether the given <see cref="CreateIndexOptions"/> can be set for the index.

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
@@ -1,0 +1,78 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// MongoDB specific extension methods for <see cref="IndexBuilder" />.
+/// </summary>
+public static class MongoIndexBuilderExtensions
+{
+    /// <summary>
+    /// Configures the <see cref="CreateIndexOptions"/> for the index.
+    /// </summary>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="options">The <see cref="CreateIndexOptions"/> for this index.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>
+    /// The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
+    /// </returns>
+    public static IConventionIndexBuilder? HasCreateIndexOptions(
+        this IConventionIndexBuilder indexBuilder,
+        CreateIndexOptions<BsonDocument>? options,
+        bool fromDataAnnotation = false)
+    {
+        if (indexBuilder.CanSetCreateIndexOptions(options, fromDataAnnotation))
+        {
+            indexBuilder.Metadata.SetCreateIndexOptions(options, fromDataAnnotation);
+            return indexBuilder;
+        }
+        return indexBuilder;
+    }
+
+    /// <summary>
+    /// Configures the <see cref="CreateIndexOptions"/> for the index.
+    /// </summary>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="options">The <see cref="CreateIndexOptions"/> for this index.</param>
+    /// <returns>
+    /// The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
+    /// </returns>
+    public static IndexBuilder<TEntity> HasCreateIndexOptions<TEntity>(
+        this IndexBuilder<TEntity> indexBuilder,
+        CreateIndexOptions? options)
+    {
+        indexBuilder.Metadata.SetCreateIndexOptions(options);
+        return indexBuilder;
+    }
+
+    /// <summary>
+    /// Returns a value indicating whether the given <see cref="CreateIndexOptions"/> can be set for the index.
+    /// </summary>
+    /// <param name="indexBuilder">The builder for the index being configured.</param>
+    /// <param name="options">The <see cref="CreateIndexOptions"/> for the index.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the given name can be set for the index.</returns>
+    public static bool CanSetCreateIndexOptions(
+        this IConventionIndexBuilder indexBuilder,
+        CreateIndexOptions? options,
+        bool fromDataAnnotation = false)
+        => indexBuilder.CanSetAnnotation(MongoAnnotationNames.CreateIndexOptions, options, fromDataAnnotation);
+}

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexExtensions.cs
@@ -1,0 +1,67 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Index extension methods for MongoDB database metadata.
+/// </summary>
+public static class MongoIndexExtensions
+{
+    /// <summary>
+    /// Sets the  <see cref="CreateIndexOptions"/> for the index.
+    /// </summary>
+    /// <param name="index">The <see cref="IConventionIndex"/> to set the options for.</param>
+    /// <param name="createIndexOptions">The <see cref="CreateIndexOptions"/> containing the options for creating this index.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured value.</returns>
+    public static CreateIndexOptions? SetCreateIndexOptions(
+        this IConventionIndex index,
+        CreateIndexOptions? createIndexOptions,
+        bool fromDataAnnotation = false)
+        => (CreateIndexOptions?)index
+            .SetOrRemoveAnnotation(MongoAnnotationNames.CreateIndexOptions, createIndexOptions, fromDataAnnotation)?.Value;
+
+    /// <summary>
+    /// Sets the  <see cref="CreateIndexOptions"/> for the index.
+    /// </summary>
+    /// <param name="index">The <see cref="IMutableIndex"/> to set the options for.</param>
+    /// <param name="createIndexOptions">The <see cref="CreateIndexOptions"/> containing the options for creating this index.</param>
+    public static void SetCreateIndexOptions(this IMutableIndex index, CreateIndexOptions? createIndexOptions)
+        => index.SetOrRemoveAnnotation(MongoAnnotationNames.CreateIndexOptions, createIndexOptions);
+
+    /// <summary>
+    /// Gets the <see cref="ConfigurationSource" /> for the create index options of the index.
+    /// </summary>
+    /// <param name="index">The <see cref="IConventionIndex"/> to get the options for.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the name of the index in the database.</returns>
+    public static ConfigurationSource? GetCreateIndexOptionsConfigurationSource(this IConventionIndex index)
+        => index.FindAnnotation(MongoAnnotationNames.CreateIndexOptions)?.GetConfigurationSource();
+
+    /// <summary>
+    /// Gets the <see cref="CreateIndexOptions"/> options for the index if one is set.
+    /// </summary>
+    /// <param name="index">The <see cref="IConventionIndex"/> to set the options for.</param>
+    /// <returns>The <see cref="CreateIndexModel{TDocument}"/> with the configured index options, or <see langword="null" /> if one is not set.</returns>
+    public static CreateIndexOptions? GetCreateIndexOptions(this IConventionIndex index)
+        => (CreateIndexOptions?)index.FindAnnotation(MongoAnnotationNames.CreateIndexOptions)?.Value;
+
+    internal static CreateIndexOptions? GetCreateIndexOptions(this IIndex index)
+        => (CreateIndexOptions?)index.FindAnnotation(MongoAnnotationNames.CreateIndexOptions)?.Value;
+}

--- a/src/MongoDB.EntityFrameworkCore/Metadata/MongoAnnotationNames.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/MongoAnnotationNames.cs
@@ -37,17 +37,22 @@ public static class MongoAnnotationNames
     public const string ElementName = Prefix + nameof(ElementName);
 
     /// <summary>
-    /// The key for DateTimeKind annotations.
+    /// The key for <see cref="DateTimeKind"/> annotations.
     /// </summary>
     public const string DateTimeKind = Prefix + nameof(DateTimeKind);
 
     /// <summary>
-    /// The key for NotSupportedAttribute annotations.
+    /// The key for marking annotations as not supported.
     /// </summary>
     public const string NotSupportedAttributes = Prefix + nameof(NotSupportedAttributes);
 
     /// <summary>
-    /// The key for Bson Representation annotations.
+    /// The key for Bson representation annotations.
     /// </summary>
     public const string BsonRepresentation = Prefix + nameof(BsonRepresentation);
+
+    /// <summary>
+    /// The key for create index options annotations.
+    /// </summary>
+    public const string CreateIndexOptions = Prefix + nameof(CreateIndexOptions);
 }

--- a/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
@@ -31,11 +31,11 @@ namespace MongoDB.EntityFrameworkCore.Storage;
 public interface IMongoClientWrapper
 {
     /// <summary>
-    /// Get an <see cref="IMongoCollection{T}"/> for the given <paramref name="collectionName"/>;
+    /// Get an <see cref="IMongoCollection{T}"/> for the given <paramref name="collectionName"/>.
     /// </summary>
     /// <param name="collectionName">The name of the collection to get a collection for.</param>
     /// <typeparam name="T">The type of data that will be returned by the collection.</typeparam>
-    /// <returns>The <see cref="IMongoCollection{T}"/> </returns>
+    /// <returns>The <see cref="IMongoCollection{T}"/>.</returns>
     public IMongoCollection<T> GetCollection<T>(string collectionName);
 
     /// <summary>
@@ -52,21 +52,21 @@ public interface IMongoClientWrapper
     /// Create a new database with the name specified in the connection options.
     /// </summary>
     /// <remarks>If the database already exists only new collections will be created.</remarks>
-    /// <param name="model">The <see cref="IModel"/> that informs how the database should be created.</param>
+    /// <param name="model">The <see cref="IDesignTimeModel"/> that informs how the database should be created.</param>
     /// <returns><see langword="true" /> if the database was created from scratch, <see langword="false" /> if it already existed.</returns>
-    public bool CreateDatabase(IModel model);
+    public bool CreateDatabase(IDesignTimeModel model);
 
     /// <summary>
     /// Create a new database with the name specified in the connection options asynchronously.
     /// </summary>
     /// <remarks>If the database already exists only new collections will be created.</remarks>
-    /// <param name="model">The <see cref="IModel"/> that informs how the database should be created.</param>
+    /// <param name="model">The <see cref="IDesignTimeModel"/> that informs how the database should be created.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel this asynchronous request.</param>
     /// <returns>
     /// A <see cref="Task"/> that, when resolved, will be
     /// <see langword="true" /> if the database was created from scratch, <see langword="false" /> if it already existed.
     /// </returns>
-    public Task<bool> CreateDatabaseAsync(IModel model, CancellationToken cancellationToken = default);
+    public Task<bool> CreateDatabaseAsync(IDesignTimeModel model, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete the database specified in the connection options.

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseCreator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseCreator.cs
@@ -16,6 +16,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
@@ -36,16 +37,16 @@ public class MongoDatabaseCreator(
         => clientWrapper.DeleteDatabase();
 
     /// <inheritdoc/>
-    public Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = new())
+    public Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default)
         => clientWrapper.DeleteDatabaseAsync(cancellationToken);
 
     /// <inheritdoc/>
     public bool EnsureCreated()
-        => clientWrapper.CreateDatabase(currentDbContext.Context.Model);
+        => clientWrapper.CreateDatabase(currentDbContext.Context.GetService<IDesignTimeModel>());
 
     /// <inheritdoc/>
-    public Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = new())
-        => clientWrapper.CreateDatabaseAsync(currentDbContext.Context.Model, cancellationToken);
+    public Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default)
+        => clientWrapper.CreateDatabaseAsync(currentDbContext.Context.GetService<IDesignTimeModel>(), cancellationToken);
 
     /// <inheritdoc/>
     public bool CanConnect()

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoClientWrapperTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoClientWrapperTests.cs
@@ -135,7 +135,9 @@ public class MongoClientWrapperTests
             ? await client.CreateDatabaseAsync(context.GetService<IDesignTimeModel>())
             : client.CreateDatabase(context.GetService<IDesignTimeModel>());
 
-        Assert.Equal(2, GetIndexes(database.MongoDatabase, "Addresses").Count);
+        var indexes = GetIndexes(database.MongoDatabase, "Addresses");
+        Assert.Equal(2, indexes.Count);
+        Assert.Single(indexes, i => i["key"].AsBsonDocument.Names.Single() == "PostCode");
     }
 
     [Theory]


### PR DESCRIPTION
## Usage

```csharp
mb.Entity<Address>().HasIndex(a => new { a.Country, a.PostCode }, "country_zip");
mb.Entity<Company>().HasIndex(c => c.OrderRef).IsUnique();
mb.Entity<Orders>().HasIndex(o => o.OrderDate).IsDescending();
mb.Entity<Documents>()
  .HasIndex(d => d.DocRef)
    .HasCreateIndexOptions(new CreateIndexOptions { Sparse = true });
```

## Features

- Single property, multi-property and string named property specification
- Explicit name and generated name indexes
- Descending and mixed ordering
- Unique indexes
- Sparse & custom options through HasCreateIndexOptions
- MQL-based partialFilter support through CreateIndexOptions<BsonDocument>

## Known limitations

### Indexes once created are not automatically modified or deleted 

This is not a migration system. Developers will need to write manual code that uses the MongoDB C# Driver if they need to delete or modify existing indexes. 

### Unnamed indexes use generated names based on properties

As per the server the client generates a name based on the properties and sort order of those properties. This means changing either of these elements causes a new index to be created UNLESS a name has been specified. It is recommended to name indexes explicitly using `HasName`.

### Partial filters must be specified as MQL

LINQ queries can not be used to declare the partial indexes but MQL can be.