### PR TITLE
EF-195: Support setting BSON representation on PropertiesConfigurationBuilder

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertiesConfigurationBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertiesConfigurationBuilderExtensions.cs
@@ -1,0 +1,64 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Metadata;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// MongoDB-specific extension methods for <see cref="PropertiesConfigurationBuilder" />.
+/// </summary>
+public static class MongoPropertiesConfigurationBuilderExtensions
+{
+    /// <summary>
+    /// Configures the BSON representation that the properties are stored as when targeting MongoDB.
+    /// </summary>
+    /// <param name="propertiesConfigurationBuilder">The builder for the properties being configured.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store these properties as.</param>
+    /// <param name="allowOverflow">Whether to allow overflow or not.</param>
+    /// <param name="allowTruncation">Whether to allow truncation or not.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static PropertiesConfigurationBuilder HaveBsonRepresentation(
+        this PropertiesConfigurationBuilder propertiesConfigurationBuilder,
+        BsonType bsonType,
+        bool? allowOverflow = null,
+        bool? allowTruncation = null)
+    {
+        var representation = new BsonRepresentationConfiguration(bsonType, allowOverflow, allowTruncation);
+        propertiesConfigurationBuilder.HaveAnnotation(MongoAnnotationNames.BsonRepresentation, representation.ToDictionary());
+
+        return propertiesConfigurationBuilder;
+    }
+
+    /// <summary>
+    /// Configures the BSON representation that the properties are stored as when targeting MongoDB.
+    /// </summary>
+    /// <typeparam name="TProperty">The type of the properties being configured.</typeparam>
+    /// <param name="propertiesConfigurationBuilder">The builder for the properties being configured.</param>
+    /// <param name="bsonType">The <see cref="BsonType"/> to store these properties as.</param>
+    /// <param name="allowOverflow">Whether to allow overflow or not.</param>
+    /// <param name="allowTruncation">Whether to allow truncation or not.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static PropertiesConfigurationBuilder<TProperty> HaveBsonRepresentation<TProperty>(
+        this PropertiesConfigurationBuilder<TProperty> propertiesConfigurationBuilder,
+        BsonType bsonType,
+        bool? allowOverflow = null,
+        bool? allowTruncation = null)
+        => (PropertiesConfigurationBuilder<TProperty>)HaveBsonRepresentation((PropertiesConfigurationBuilder)propertiesConfigurationBuilder, bsonType, allowOverflow, allowTruncation);
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoPropertiesConfigurationBuilderExtensionsTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoPropertiesConfigurationBuilderExtensionsTests.cs
@@ -35,6 +35,7 @@ public class MongoPropertiesConfigurationBuilderExtensionsTests
 
         var representation = property.GetBsonRepresentation();
         Assert.NotNull(representation);
+        Assert.Equal(bsonType, representation.BsonType);
     }
 
     [Theory]

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoPropertiesConfigurationBuilderExtensionsTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Extensions/MongoPropertiesConfigurationBuilderExtensionsTests.cs
@@ -1,0 +1,87 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Extensions;
+
+public class MongoPropertiesConfigurationBuilderExtensionsTests
+{
+    [Theory]
+    [InlineData(BsonType.String)]
+    [InlineData(BsonType.Double)]
+    [InlineData(BsonType.Decimal128)]
+    [InlineData(BsonType.Int64)]
+    public void HaveBsonRepresentation_can_set_type_on_property(BsonType bsonType)
+    {
+        using var db = new TestDbContext(bsonType);
+
+        var property = db.GetProperty((TestEntity t) => t.DateTimeOffsetProperty);
+        Assert.NotNull(property);
+
+        var representation = property.GetBsonRepresentation();
+        Assert.NotNull(representation);
+    }
+
+    [Theory]
+    [InlineData(BsonType.String, false, true)]
+    [InlineData(BsonType.Double, false, false)]
+    [InlineData(BsonType.Decimal128, null, false)]
+    [InlineData(BsonType.Int64, true, true)]
+    public void HaveBsonRepresentation_can_set_type_overflow_and_truncation_on_property(BsonType bsonType, bool? allowOverflow, bool? allowTruncation)
+    {
+        using var db = new TestDbContext(bsonType, allowOverflow, allowTruncation);
+
+        var property = db.GetProperty((TestEntity t) => t.DateTimeOffsetProperty);
+        Assert.NotNull(property);
+
+        var representation = property.GetBsonRepresentation();
+        Assert.NotNull(representation);
+        Assert.Equal(bsonType, representation.BsonType);
+        Assert.Equal(allowOverflow, representation.AllowOverflow);
+        Assert.Equal(allowTruncation, representation.AllowTruncation);
+    }
+
+
+    private class TestEntity
+    {
+        public int Id { get; set; }
+
+        public DateTimeOffset DateTimeOffsetProperty { get; set; }
+
+        public DateTimeOffset? NullableDateTimeOffsetProperty { get; set; }
+
+        public string StringProperty { get; set; }
+    }
+
+    private class TestDbContext(BsonType bsonType, bool? allowOverflow = null, bool? allowTruncation = null) : DbContext
+    {
+        public DbSet<TestEntity> Tests { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", $"UnitTests{Guid.NewGuid()}")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            base.ConfigureConventions(configurationBuilder);
+
+            configurationBuilder.Properties<DateTimeOffset>().HaveBsonRepresentation(bsonType, allowOverflow, allowTruncation);
+        }
+    }
+}


### PR DESCRIPTION
> Not sure whether this fits the category of allowed contributions. If there are adjustments required, I can make them.

This allows configuration of properties of a certain type to have one particular representation in the whole context as compared to having this done from one property to another.

Example:

```cs
private class Customer
{
    public int Id { get; set; }
    public DateTimeOffset CreatedAt { get; set; }
    public DateTimeOffset UpdatedAt { get; set; }
    public DateTimeOffset? ArchivedAt { get; set; }
}

private class OrdersDbContext : DbContext
{
    public DbSet<Customer> Customers { get; set; }

    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
        => optionsBuilder.UseMongoDB("mongodb://localhost:27017", "mydB");

    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
    {
        base.ConfigureConventions(configurationBuilder);

        configurationBuilder.Properties<DateTimeOffset>().HaveBsonRepresentation(BsonType.DateTime);
    }
}
```