### PR TITLE
EF-199: Allow navigation collections to be tested for nullability

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPreprocessor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPreprocessor.cs
@@ -29,6 +29,7 @@ public class MongoQueryTranslationPreprocessor(
     public override Expression Process(Expression query)
     {
         query = FinalPredicateHoistingVisitor.Hoist(query);
+        query = new EntityFrameworkDetourExpressionVisitor(queryCompilationContext).Visit(query);
         return base.Process(query);
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/EntityFrameworkDetourExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/EntityFrameworkDetourExpressionVisitor.cs
@@ -1,0 +1,68 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace MongoDB.EntityFrameworkCore.Query.Visitors;
+
+/// <summary>
+/// Adjust any expressions that EF might interfere with in undesirable ways in order to stop it.
+/// </summary>
+internal class EntityFrameworkDetourExpressionVisitor(QueryCompilationContext queryCompilationContext)
+    : ExpressionVisitor
+{
+    protected override Expression VisitBinary(BinaryExpression b)
+    {
+        return b switch
+        {
+            {NodeType: not (ExpressionType.Equal or ExpressionType.NotEqual)}
+                => base.VisitBinary(b),
+
+            // Prevent EF changing (e.childCollection == null) to (e == null)
+            {Right: ConstantExpression {Value: null}, Left: MemberExpression leftMember} when
+                GetNavigationCollectionResultType(leftMember) is { } leftType
+                => CreateCastedNullComparison(leftMember, leftType, b.NodeType),
+
+            // Prevent EF changing (null != e.childCollection) to (null == e)
+            {Right: MemberExpression rightMember, Left: ConstantExpression {Value: null}} when
+                GetNavigationCollectionResultType(rightMember) is { } rightType
+                => CreateCastedNullComparison(rightMember, rightType, b.NodeType),
+
+            _ => base.VisitBinary(b)
+        };
+    }
+
+    private Type? GetNavigationCollectionResultType(MemberExpression memberExpression)
+    {
+        var clrType = memberExpression.Member.ReflectedType;
+        if (clrType == null) return null;
+
+        var entityType = queryCompilationContext.Model.FindEntityType(clrType);
+        var navigation = entityType?.FindNavigation(memberExpression.Member);
+        if (navigation == null || navigation.IsCollection == false) return null;
+
+        return navigation.PropertyInfo?.PropertyType ?? navigation.FieldInfo?.FieldType;
+    }
+
+    private static BinaryExpression CreateCastedNullComparison(MemberExpression memberExpression, Type toType,
+        ExpressionType nodeType)
+    {
+        return nodeType == ExpressionType.Equal
+            ? Expression.Equal(Expression.Convert(memberExpression, toType), Expression.Constant(null))
+            : Expression.NotEqual(Expression.Convert(memberExpression, toType), Expression.Constant(null));
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -16,7 +16,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using MongoDB.Bson;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
@@ -139,11 +138,11 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     [Fact]
     public void OwnedEntity_missing_document_element_does_not_throw()
     {
-        database.CreateCollection<Person>("personNoLocation").WriteTestDocs([
+        database.CreateCollection<Person>().WriteTestDocs([
             new Person {name = "Bill"}
         ]);
 
-        var collection = database.MongoDatabase.GetCollection<PersonWithOptionalLocation>("personNoLocation");
+        var collection = database.GetCollection<PersonWithOptionalLocation>();
         using var db = SingleEntityDbContext.Create(collection);
 
         var person = db.Entities.First();
@@ -526,8 +525,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     {
         var expectedLocation = new Location {latitude = 1.01m, longitude = 1.02m};
         var collection = database.CreateCollection<PersonWithIEnumerableLocations>();
-        collection.WriteTestDocs(new PersonWithIEnumerableLocations[]
-        {
+        collection.WriteTestDocs([
             new()
             {
                 _id = ObjectId.GenerateNewId(),
@@ -540,7 +538,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
                 name = "IEnumerableRound2",
                 locations = new List<Location> {new() {latitude = 1.03m, longitude = 1.04m}}
             }
-        });
+        ]);
 
         var actual = SingleEntityDbContext.Create(collection).Entities.ToList();
 
@@ -1169,12 +1167,5 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
                 ]
             }
         ]
-    };
-
-    private static readonly FirstLevel FirstLevel1NullChildren = new()
-    {
-        _id = Guid.NewGuid(),
-        day = DayOfWeek.Monday,
-        reference = new() {day = DayOfWeek.Friday, name = "This is the first level name"},
     };
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/EF-199

The (temporary) solution here until EF allows us to opt-out of this behavior is to wrap the property access in a cast which is sufficient enough to break the pattern matching in EF Core's NavigationExpandingExpressionVisitor.