### PR TITLE
Update Evergreen CI test to add MONGODB_VERSION

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -416,6 +416,8 @@ tasks:
     commands:
       - func: bootstrap-mongo-orchestration
       - func: run-tests
+        vars:
+          MONGODB_VERSION: ${VERSION}
 
   - name: pack-packages
     commands:


### PR DESCRIPTION
This is required to make some of the tests MongoDB version-specific such as those in #197 