### PR TITLE
EF-207: Add support for Entity Framework alternate keys

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -247,10 +247,10 @@ public class MongoClientWrapper : IMongoClientWrapper
         var partsIndex = 0;
         foreach (var property in key.Properties)
         {
-            parts[partsIndex++] = property.GetElementName();
+            parts[partsIndex++] = property.GetElementName() + "_1";
         }
 
-        return string.Join('_', path.Concat(parts)) + "_unique";
+        return string.Join('_', path.Concat(parts));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
- Adds support for [EF Alternate Keys](https://jira.mongodb.org/browse/EF-207) backed with MongoDB unique indexes
- Also fixes a [rogue exception](https://jira.mongodb.org/browse/EF-206) when EF temporarily adds multiple keys during model construciton