### PR TITLE
EF-212: Allow exception suppression when entity type property has ColumnAttribute

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -44,7 +45,8 @@ public static class MongoEventId
         TransactionRolledBack,
         TransactionError,
         RecommendedMinMaxRangeMissing,
-        EncryptedNullablePropertyEncountered
+        EncryptedNullablePropertyEncountered,
+        ColumnAttributeWithTypeUsed
     }
 
     private static EventId MakeDatabaseCommandId(Id id)
@@ -172,4 +174,16 @@ public static class MongoEventId
     ///     <para>This event uses the <see cref="PropertyEventData" /> payload when used with a <see cref="DiagnosticSource" />.</para>
     /// </remarks>
     public static readonly EventId EncryptedNullablePropertyEncountered = MakeValidationId(Id.EncryptedNullablePropertyEncountered);
+
+    private static EventId MakeModelId(Id id)
+        => new((int)id, DbLoggerCategory.Model.Name + "." + id);
+
+    /// <summary>
+    /// A <see cref="ColumnAttribute"/> with a type name was found on the property of a type mapped to MongoDB.
+    /// </summary>
+    /// <remarks>
+    ///     <para>This event is in the <see cref="DbLoggerCategory.Model" /> category.</para>
+    ///     <para>This event uses the <see cref="PropertyEventData" /> payload when used with a <see cref="DiagnosticSource" />.</para>
+    /// </remarks>
+    public static readonly EventId ColumnAttributeWithTypeUsed = MakeModelId(Id.ColumnAttributeWithTypeUsed);
 }

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
@@ -40,4 +40,6 @@ internal class MongoLoggingDefinitions : LoggingDefinitions
 
     public EventDefinitionBase? LogRecommendedMinMaxRangeMissing;
     public EventDefinitionBase? LogEncryptedNullablePropertyEncountered;
+
+    public EventDefinitionBase? LogColumnAttributeWithTypeUsed;
 }

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
@@ -21,6 +20,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
+using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.Metadata.Conventions;
@@ -63,11 +63,7 @@ public class ColumnAttributeConvention :
 
         if (!string.IsNullOrWhiteSpace(attribute.TypeName))
         {
-            var meta = propertyBuilder.Metadata;
-            throw new NotSupportedException($"Property '{meta.DeclaringType.ShortName()}.{meta.PropertyInfo?.Name}' specifies a "
-                                            + $"{nameof(ColumnAttribute)}.{nameof(ColumnAttribute.TypeName)
-                                            } which is not supported by "
-                                            + $"MongoDB. Consider using EF ValueConverters to handle the conversion instead.");
+            Dependencies.Logger.ColumnAttributeWithTypeUsed(propertyBuilder.Metadata); // Will throw by default
         }
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
@@ -15,6 +15,7 @@
 
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
@@ -194,6 +195,10 @@ public class ColumnAttributeConventionTests(TemporaryDatabaseFixture database)
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder
                 .UseMongoDB("mongodb://localhost:27017", nameof(TypeNameSpecifyingEntity))
-                .ConfigureWarnings(x => x.Ignore(MongoEventId.ColumnAttributeWithTypeUsed));
+                .ConfigureWarnings(x =>
+                {
+                    x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning);
+                    x.Ignore(MongoEventId.ColumnAttributeWithTypeUsed);
+                });
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/ColumnAttributeConventionTests.cs
@@ -14,8 +14,10 @@
  */
 
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Diagnostics;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Metadata.Conventions;
 
@@ -163,9 +165,35 @@ public class ColumnAttributeConventionTests(TemporaryDatabaseFixture database)
 
         using var db = SingleEntityDbContext.Create(collection);
 
-        var ex = Assert.Throws<NotSupportedException>(() => db.Entities.FirstOrDefault());
-        Assert.Contains(nameof(ColumnAttribute.TypeName), ex.Message);
-        Assert.Contains(nameof(TypeNameSpecifyingEntity), ex.Message);
-        Assert.Contains(nameof(TypeNameSpecifyingEntity.TypeNameNotPermitted), ex.Message);
+        var ex = Assert.Throws<InvalidOperationException>(() => db.Model);
+
+        Assert.Equal(
+            "An error was generated for warning 'Microsoft.EntityFrameworkCore.Model.ColumnAttributeWithTypeUsed': " +
+            "Property 'TypeNameSpecifyingEntity.TypeNameNotPermitted' specifies a 'ColumnAttribute.TypeName' which is not supported by MongoDB. " +
+            "Use MongoDB-specific attributes or the model building API to configure your model for MongoDB. " +
+            "The 'TypeName' will be ignored if this event is suppressed. " +
+            "This exception can be suppressed or logged by passing event ID 'MongoEventId.ColumnAttributeWithTypeUsed' to the 'ConfigureWarnings' method in 'DbContext.OnConfiguring' or 'AddDbContext'.",
+            ex.Message);
+    }
+
+    [Fact]
+    public void ColumnAttribute_warning_can_be_suppressed()
+    {
+        using var db = new NoThrowDbContext();
+
+        var model = db.Model;
+        Assert.NotNull(model
+            .FindEntityType(typeof(TypeNameSpecifyingEntity))!
+            .FindProperty(nameof(TypeNameSpecifyingEntity.TypeNameNotPermitted)));
+    }
+
+    private class NoThrowDbContext : DbContext
+    {
+        public DbSet<TypeNameSpecifyingEntity> Entities { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", nameof(TypeNameSpecifyingEntity))
+                .ConfigureWarnings(x => x.Ignore(MongoEventId.ColumnAttributeWithTypeUsed));
     }
 }


### PR DESCRIPTION
Currently, the provider throws when a ColumnAttribute is encountered. This can be helpful for people who think it will be used, when it isn't. However, there are cases where already existing entity types must be used, and in these cases the column attributes can be ignored. We can allow this by making this message into an exception by default, but changeable to a log or ignore, using EF's infrastructure.