### PR TITLE
EF-258: API consistency checks and related fixes

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoDbContextOptionsExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoDbContextOptionsExtensions.cs
@@ -243,6 +243,20 @@ public static class MongoDbContextOptionsExtensions
     }
 
     /// <summary>
+    /// Configures the context to connect to a MongoDB database using the <see cref="DbContextOptionsBuilder{TContext}"/>.
+    /// </summary>
+    /// <param name="optionsBuilder">The builder being used to configure the context.</param>
+    /// <param name="extension">The <see cref="MongoOptionsExtension"/> to configure.</param>
+    /// <param name="optionsAction">An optional action to allow additional MongoDB-specific configuration.</param>
+    /// <returns>The options builder so that further configuration can be chained.</returns>
+    public static DbContextOptionsBuilder<TContext> UseMongoDB<TContext>(
+        this DbContextOptionsBuilder<TContext> optionsBuilder,
+        MongoOptionsExtension extension,
+        Action<MongoDbContextOptionsBuilder>? optionsAction = null)
+        where TContext : DbContext
+        => (DbContextOptionsBuilder<TContext>)UseMongoDB((DbContextOptionsBuilder)optionsBuilder, extension, optionsAction);
+
+    /// <summary>
     /// Configures the context to connect to a MongoDB database using the <see cref="DbContextOptionsBuilder"/>.
     /// </summary>
     /// <param name="optionsBuilder">The builder being used to configure the context.</param>

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeBuilderExtensions.cs
@@ -79,27 +79,6 @@ public static class MongoEntityTypeBuilderExtensions
     }
 
     /// <summary>
-    /// Sets the name of the collection to which the entity type is mapped.
-    /// </summary>
-    /// <param name="entityType">The entity type to set the collection name for.</param>
-    /// <param name="name">The name to set.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>The configured collection name.</returns>
-    public static string? SetCollectionName(
-        this IConventionEntityType entityType,
-        string? name,
-        bool fromDataAnnotation = false)
-    {
-        if (name is {Length: 0})
-            throw new ArgumentException(ArgumentNameCannotBeEmptyExceptionMessage);
-
-        return (string?)entityType.SetAnnotation(
-            MongoAnnotationNames.CollectionName,
-            name,
-            fromDataAnnotation)?.Value;
-    }
-
-    /// <summary>
     ///  Returns whether the collection name can be set for this entity type using the specified configuration source.
     /// </summary>
     /// <param name="entityTypeBuilder">The builder for the entity type being configured.</param>
@@ -189,6 +168,4 @@ public static class MongoEntityTypeBuilderExtensions
 
         return entityTypeBuilder.CanSetAnnotation(MongoAnnotationNames.ElementName, name, fromDataAnnotation);
     }
-
-
 }

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
@@ -40,6 +40,27 @@ public static class MongoEntityTypeExtensions
     }
 
     /// <summary>
+    /// Sets the name of the collection to which the entity type is mapped.
+    /// </summary>
+    /// <param name="entityType">The entity type to set the collection name for.</param>
+    /// <param name="name">The name to set.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns>The configured collection name.</returns>
+    public static string? SetCollectionName(
+        this IConventionEntityType entityType,
+        string? name,
+        bool fromDataAnnotation = false)
+    {
+        if (name is {Length: 0})
+            throw new ArgumentException("The string argument 'name' cannot be empty.");
+
+        return (string?)entityType.SetAnnotation(
+            MongoAnnotationNames.CollectionName,
+            name,
+            fromDataAnnotation)?.Value;
+    }
+
+    /// <summary>
     /// Returns the name of the collection to which the entity type is mapped
     /// or <see langword="null" /> if not mapped to a collection.
     /// </summary>
@@ -50,6 +71,15 @@ public static class MongoEntityTypeExtensions
             ? entityType.GetRootType().GetCollectionName()
             : (string?)entityType[MongoAnnotationNames.CollectionName]
               ?? GetDefaultCollectionName(entityType);
+
+    /// <summary>
+    /// Gets the <see cref="ConfigurationSource" /> for the name of the collection to which the entity type is mapped.
+    /// </summary>
+    /// <param name="entityType">The entity type to find configuration source for.</param>
+    /// <returns>The <see cref="ConfigurationSource" /> for the name of the collection to which the entity type is mapped</returns>
+    public static ConfigurationSource? GetCollectionNameConfigurationSource(this IConventionEntityType entityType)
+        => entityType.FindAnnotation(MongoAnnotationNames.CollectionName)
+            ?.GetConfigurationSource();
 
     /// <summary>
     /// Returns the default collection name that would be used for this entity type.

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
@@ -14,7 +14,6 @@
  */
 
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Metadata;
 
@@ -37,29 +36,6 @@ public static class MongoIndexBuilderExtensions
     {
         indexBuilder.Metadata.SetCreateIndexOptions(options);
 
-        return indexBuilder;
-    }
-
-    /// <summary>
-    /// Configures the <see cref="CreateIndexOptions"/> for the index.
-    /// </summary>
-    /// <param name="indexBuilder">The builder for the index being configured.</param>
-    /// <param name="options">The <see cref="CreateIndexOptions"/> for this index.</param>
-    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
-    /// <returns>
-    /// The same builder instance if the configuration was applied, <see langword="null" /> otherwise.
-    /// </returns>
-    public static IConventionIndexBuilder? HasCreateIndexOptions(
-        this IConventionIndexBuilder indexBuilder,
-        CreateIndexOptions<BsonDocument>? options,
-        bool fromDataAnnotation = false)
-    {
-        if (!indexBuilder.CanSetCreateIndexOptions(options, fromDataAnnotation))
-        {
-            return null;
-        }
-
-        indexBuilder.Metadata.SetCreateIndexOptions(options, fromDataAnnotation);
         return indexBuilder;
     }
 

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
@@ -183,6 +183,17 @@ public static class MongoPropertyBuilderExtensions
     /// <param name="propertyBuilder">The builder for the property being configured.</param>
     /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> to use for the property.</param>
     /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    public static PropertyBuilder<TProperty> HasDateTimeKind<TProperty>(
+        this PropertyBuilder<TProperty> propertyBuilder,
+        DateTimeKind dateTimeKind)
+        => (PropertyBuilder<TProperty>)HasDateTimeKind((PropertyBuilder)propertyBuilder, dateTimeKind);
+
+    /// <summary>
+    /// Configures the <see cref="DateTimeKind"/> for the property.
+    /// </summary>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> to use for the property.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
     public static IConventionPropertyBuilder HasDateTimeKind(
         this IConventionPropertyBuilder propertyBuilder,
         DateTimeKind dateTimeKind)
@@ -190,4 +201,17 @@ public static class MongoPropertyBuilderExtensions
         propertyBuilder.Metadata.SetDateTimeKind(dateTimeKind);
         return propertyBuilder;
     }
+
+    /// <summary>
+    /// Returns a value indicating whether the given <see cref="DateTimeKind"/> can be set.
+    /// </summary>
+    /// <param name="propertyBuilder">The builder for the property being configured.</param>
+    /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> to use for the property.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
+    /// <returns><see langword="true" /> if the <see cref="DateTimeKind"/> can be set, <see langword="false"/> if not.</returns>
+    public static bool CanSetDateTimeKind(
+        this IConventionPropertyBuilder propertyBuilder,
+        DateTimeKind dateTimeKind,
+        bool fromDataAnnotation = false)
+        => propertyBuilder.CanSetAnnotation(MongoAnnotationNames.DateTimeKind, dateTimeKind, fromDataAnnotation);
 }

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
@@ -90,7 +90,8 @@ public static class MongoPropertyExtensions
     /// or <see langword="null" /> to unset the value and use the default.</param>
     /// <param name="allowOverflow">Whether to allow overflow or not.</param>
     /// <param name="allowTruncation">Whether to allow truncation or not.</param>
-    public static void SetBsonRepresentation(
+    /// <returns>Returns the <see cref="BsonRepresentationConfiguration"/> the property is stored as.</returns>
+    public static BsonRepresentationConfiguration? SetBsonRepresentation(
         this IMutableProperty property,
         BsonType? bsonType,
         bool? allowOverflow,
@@ -99,11 +100,12 @@ public static class MongoPropertyExtensions
         if (bsonType == null)
         {
             property.RemoveAnnotation(MongoAnnotationNames.BsonRepresentation);
-            return;
+            return null;
         }
 
         var representation = new BsonRepresentationConfiguration(bsonType.Value, allowOverflow, allowTruncation);
         property.SetAnnotation(MongoAnnotationNames.BsonRepresentation, representation.ToDictionary());
+        return representation;
     }
 
     /// <summary>
@@ -177,8 +179,9 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the DateTimeKind for.</param>
     /// <param name="dateTimeKind">The <see cref="DateTimeKind"/> that should be used.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <exception cref="InvalidOperationException"></exception>
-    public static void SetDateTimeKind(this IConventionProperty property, DateTimeKind dateTimeKind)
+    public static DateTimeKind SetDateTimeKind(this IConventionProperty property, DateTimeKind dateTimeKind, bool fromDataAnnotation = false)
     {
         if (property.ClrType != typeof(DateTime) && property.ClrType != typeof(DateTime?))
         {
@@ -186,7 +189,9 @@ public static class MongoPropertyExtensions
                 property.DeclaringType.Name} entity.");
         }
 
-        property.SetAnnotation(MongoAnnotationNames.DateTimeKind, dateTimeKind);
+        property.SetAnnotation(MongoAnnotationNames.DateTimeKind, dateTimeKind, fromDataAnnotation);
+
+        return dateTimeKind;
     }
 
     /// <summary>
@@ -196,7 +201,7 @@ public static class MongoPropertyExtensions
     /// <returns>
     /// The <see cref="ConfigurationSource" /> the <see cref="DateTimeKind"/> was specified by for this property.
     /// </returns>
-    public static ConfigurationSource? GetDateKindConfigurationSource(this IConventionProperty property)
+    public static ConfigurationSource? GetDateTimeKindConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(MongoAnnotationNames.DateTimeKind)?.GetConfigurationSource();
 
 
@@ -223,11 +228,13 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the BsonType for.</param>
     /// <param name="dataKeyId">The encryption data key id to set, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The <see cref="Guid"/> encryption data key id for the property if set, or <see langref="null"/> if no value is set.</returns>
     public static Guid? SetEncryptionDataKeyId(
         this IConventionProperty property,
-        Guid? dataKeyId)
-        => (Guid?)property.SetOrRemoveAnnotation(MongoAnnotationNames.EncryptionDataKeyId, Check.NotEmpty(dataKeyId))?.Value;
+        Guid? dataKeyId,
+        bool fromDataAnnotation = false)
+        => (Guid?)property.SetOrRemoveAnnotation(MongoAnnotationNames.EncryptionDataKeyId, Check.NotEmpty(dataKeyId), fromDataAnnotation)?.Value;
 
     /// <summary>
     /// Gets the <see cref="ConfigurationSource" /> of the encryption data key id when targeting MongoDB.
@@ -264,12 +271,14 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the Queryable Encryption type for.</param>
     /// <param name="queryableEncryptionType">The <see cref="QueryableEncryptionType"/> specifying the type of Queryable Encryption to use, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The <see cref="QueryableEncryptionType"/>, or <see langword="null"/> if not set.</returns>
     public static QueryableEncryptionType? SetQueryableEncryptionType(
         this IConventionProperty property,
-        QueryableEncryptionType? queryableEncryptionType)
+        QueryableEncryptionType? queryableEncryptionType,
+        bool fromDataAnnotation = false)
         => (QueryableEncryptionType?)property
-            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionType, Check.IsDefinedOrNull(queryableEncryptionType))
+            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionType, Check.IsDefinedOrNull(queryableEncryptionType), fromDataAnnotation)
             ?.Value;
 
     /// <summary>
@@ -306,12 +315,14 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the maximum value for.</param>
     /// <param name="maxValue">The maximum value for the Queryable Encryption range property, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The maximum value for the Queryable Encryption range property, or <see langword="null"/> if not set.</returns>
     public static object? SetQueryableEncryptionRangeMax(
         this IConventionProperty property,
-        object? maxValue)
+        object? maxValue,
+        bool fromDataAnnotation = false)
         => (QueryableEncryptionType?)property
-            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionRangeMax, maxValue)?.Value;
+            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionRangeMax, maxValue, fromDataAnnotation)?.Value;
 
     /// <summary>
     /// Gets the <see cref="ConfigurationSource" /> of the maximum value of a Queryable Encryption range property when targeting MongoDB.
@@ -347,12 +358,14 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the minimum value for.</param>
     /// <param name="minValue">The minimum value for the Queryable Encryption range property, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The minimum value for the Queryable Encryption range property, or <see langword="null"/> if not set.</returns>
     public static object? SetQueryableEncryptionRangeMin(
         this IConventionProperty property,
-        object? minValue)
+        object? minValue,
+        bool fromDataAnnotation = false)
         => (QueryableEncryptionType?)property
-            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionRangeMin, minValue)?.Value;
+            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionRangeMin, minValue, fromDataAnnotation)?.Value;
 
     /// <summary>
     /// Gets the <see cref="ConfigurationSource" /> of the minimum value of a Queryable Encryption range property when targeting MongoDB.
@@ -389,12 +402,14 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the sparsity value for.</param>
     /// <param name="sparsity">The sparsity value for the Queryable Encryption range property, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The sparsity value for the Queryable Encryption range property, or <see langword="null"/> if not set.</returns>
     public static int? SetQueryableEncryptionSparsity(
         this IConventionProperty property,
-        int? sparsity)
+        int? sparsity,
+        bool fromDataAnnotation = false)
         => (int?)property
-            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionSparsity, sparsity)?.Value;
+            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionSparsity, sparsity, fromDataAnnotation)?.Value;
 
     /// <summary>
     /// Gets the <see cref="ConfigurationSource" /> of the sparsity of a Queryable Encryption range property when targeting MongoDB.
@@ -430,12 +445,14 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the precision value for.</param>
     /// <param name="precision">The precision value for the Queryable Encryption range property, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The precision value for the Queryable Encryption range property, or <see langword="null"/> if not set.</returns>
     public static int? SetQueryableEncryptionPrecision(
         this IConventionProperty property,
-        int? precision)
+        int? precision,
+        bool fromDataAnnotation = false)
         => (int?)property
-            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionPrecision, precision)?.Value;
+            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionPrecision, precision, fromDataAnnotation)?.Value;
 
     /// <summary>
     /// Gets the <see cref="ConfigurationSource" /> of the precision value of a Queryable Encryption range property when targeting MongoDB.
@@ -471,12 +488,14 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the trim factor for.</param>
     /// <param name="trimFactor">The trim factor for the Queryable Encryption range property, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The trim factor for the Queryable Encryption range property, or <see langword="null"/> if not set.</returns>
     public static int? SetQueryableEncryptionTrimFactor(
         this IConventionProperty property,
-        int? trimFactor)
+        int? trimFactor,
+        bool fromDataAnnotation = false)
         => (int?)property
-            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionTrimFactor, trimFactor)?.Value;
+            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionTrimFactor, trimFactor, fromDataAnnotation)?.Value;
 
     /// <summary>
     /// Gets the <see cref="ConfigurationSource" /> of the trim factor of a Queryable Encryption range property when targeting MongoDB.
@@ -512,12 +531,14 @@ public static class MongoPropertyExtensions
     /// </summary>
     /// <param name="property">The <see cref="IConventionProperty"/> to set the contention for.</param>
     /// <param name="contention">The contention for the Queryable Encryption property, or <see langword="null" /> to unset the value.</param>
+    /// <param name="fromDataAnnotation">Indicates whether the configuration was specified using a data annotation.</param>
     /// <returns>The contention for the Queryable Encryption property, or <see langword="null"/> if not set.</returns>
     public static int? SetQueryableEncryptionContention(
         this IConventionProperty property,
-        int? contention)
+        int? contention,
+        bool fromDataAnnotation = false)
         => (int?)property
-            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionContention, contention)?.Value;
+            .SetOrRemoveAnnotation(MongoAnnotationNames.QueryableEncryptionContention, contention, fromDataAnnotation)?.Value;
 
     /// <summary>
     /// Gets the <see cref="ConfigurationSource" /> of the contention of a Queryable Encryption property when targeting MongoDB.
@@ -528,7 +549,6 @@ public static class MongoPropertyExtensions
     /// </returns>
     public static ConfigurationSource? GetQueryableEncryptionContentionConfigurationSource(this IConventionProperty property)
         => property.FindAnnotation(MongoAnnotationNames.QueryableEncryptionContention)?.GetConfigurationSource();
-
 
     private static string GetDefaultElementName(IReadOnlyProperty property) =>
         property switch

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoApiConsistencyTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoApiConsistencyTest.cs
@@ -1,0 +1,117 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+using MongoDB.EntityFrameworkCore.Storage;
+
+namespace MongoDB.EntityFrameworkCore.SpecificationTests;
+
+public class MongoApiConsistencyTest(MongoApiConsistencyTest.MongoApiConsistencyFixture fixture)
+    : ApiConsistencyTestBase<MongoApiConsistencyTest.MongoApiConsistencyFixture>(fixture)
+{
+    protected override void AddServices(ServiceCollection serviceCollection)
+        => serviceCollection.AddEntityFrameworkMongoDB();
+
+    public override void Public_inheritable_apis_should_be_virtual()
+    {
+        // Ignored for now.
+    }
+
+    protected override Assembly TargetAssembly
+        => typeof(MongoDatabaseWrapper).Assembly;
+
+    public class MongoApiConsistencyFixture : ApiConsistencyFixtureBase
+    {
+        public override HashSet<Type> FluentApiTypes { get; } =
+        [
+            typeof(MongoDbContextOptionsBuilder),
+            typeof(MongoDbContextOptionsExtensions),
+            typeof(MongoEntityTypeBuilderExtensions),
+            typeof(MongoIndexBuilderExtensions),
+            typeof(MongoPropertyBuilderExtensions),
+            typeof(MongoServiceCollectionExtensions)
+        ];
+
+public override
+            Dictionary<Type,
+                (Type? ReadonlyExtensions,
+                Type? MutableExtensions,
+                Type? ConventionExtensions,
+                Type? ConventionBuilderExtensions,
+                Type? RuntimeExtensions)> MetadataExtensionTypes { get; }
+            = new()
+            {
+                {
+                    typeof(IReadOnlyModel), (
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                    )
+                },
+                {
+                    typeof(IReadOnlyEntityType), (
+                        typeof(MongoEntityTypeExtensions),
+                        typeof(MongoEntityTypeExtensions),
+                        typeof(MongoEntityTypeExtensions),
+                        typeof(MongoEntityTypeBuilderExtensions),
+                        null
+                    )
+                },
+                {
+                    typeof(IReadOnlyKey), (
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                    )
+                },
+                {
+                    typeof(IReadOnlyProperty), (
+                        typeof(MongoPropertyExtensions),
+                        null, // typeof(MongoPropertyExtensions), TODO: Should be able to override base here: see https://github.com/dotnet/efcore/issues/36521
+                        null, // typeof(MongoPropertyExtensions), TODO: Should be able to override base here: see https://github.com/dotnet/efcore/issues/36521
+                        typeof(MongoPropertyBuilderExtensions),
+                        null
+                    )
+                },
+                {
+                    typeof(IReadOnlyIndex), (
+                        typeof(MongoIndexExtensions),
+                        typeof(MongoIndexExtensions),
+                        typeof(MongoIndexExtensions),
+                        typeof(MongoIndexBuilderExtensions),
+                        null
+                    )
+                },
+                {
+                    typeof(IReadOnlyElementType), (
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                    )
+                }
+            };
+    }
+}


### PR DESCRIPTION
- -- Non-generic fluent returns that aren't hidden --
  - PropertyBuilder MongoPropertyBuilderExtensions.HasDateTimeKind(PropertyBuilder, DateTimeKind)
    - AV: Added
  - DbContextOptionsBuilder MongoDbContextOptionsExtensions.UseMongoDB(DbContextOptionsBuilder, MongoOptionsExtension, Action`1)
    - AV: Added
- -- Errors: --
  - MongoPropertyBuilderExtensions expected to have a CanSetDateTimeKind or CanHaveDateTimeKind method
    - Added
  - MongoIndexBuilderExtensions.CanSetCreateIndexOptions(IConventionIndexBuilder, CreateIndexOptions, Boolean) expected to have the first parameter of type CreateIndexOptions<BsonDocument>
    - Removed the generic overload--minor binary break, but not a source break.
- -- Errors: --
  - MongoPropertyExtensions.SetBsonRepresentation(IConventionProperty, Nullable`1, Nullable`1, Nullable`1, Boolean) expected to have an IConvention or BsonType? return type
    - Should be skipped
  - MongoPropertyExtensions.SetDateTimeKind(IConventionProperty, DateTimeKind) expected to have an IConvention or DateTimeKind return type
    - Added
  - MongoPropertyExtensions.SetEncryptionDataKeyId(IConventionProperty, Nullable`1) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
  - MongoPropertyExtensions.SetQueryableEncryptionType(IConventionProperty, Nullable`1) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
  - MongoPropertyExtensions.SetQueryableEncryptionRangeMax(IConventionProperty, Object) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
  - MongoPropertyExtensions.SetQueryableEncryptionRangeMin(IConventionProperty, Object) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
  - MongoPropertyExtensions.SetQueryableEncryptionSparsity(IConventionProperty, Nullable`1) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
  - MongoPropertyExtensions.SetQueryableEncryptionPrecision(IConventionProperty, Nullable`1) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
  - MongoPropertyExtensions.SetQueryableEncryptionTrimFactor(IConventionProperty, Nullable`1) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
  - MongoPropertyExtensions.SetQueryableEncryptionContention(IConventionProperty, Nullable`1) expected to have a 'bool fromDataAnnotation = false' parameter
    - Added
- -- Errors: --
  - MongoPropertyExtensions expected to have a GetDateTimeKindConfigurationSource() method
    - Renamed GetDateKindConfigurationSource to GetDateTimeKindConfigurationSource
- -- Mismatches: --
  - No IConvention equivalent of MongoEntityTypeExtensions.SetCollectionName(IMutableEntityType, String)
    - Moved from builder extensions to core metadata extensions - minor binary break; no source break (unless extension method called explicitly)
- -- Errors: --
  - MongoEntityTypeExtensions expected to have a GetCollectionNameConfigurationSource() method
    - Added
- -- Errors: -- MongoPropertyExtensions.SetBsonRepresentation(IMutableProperty, Nullable`1, Nullable`1, Nullable`1) expected to have a void return type
    - Should be skipped