### PR TITLE
Change testing/matrix

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -491,6 +491,10 @@ axes:
         display_name: "rapid"
         variables:
           VERSION: "rapid"
+      - id: "8.0"
+        display_name: "8.0"
+        variables:
+          VERSION: "8.0"
       - id: "7.0"
         display_name: "7.0"
         variables:

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Encryption/EncryptionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Encryption/EncryptionTests.cs
@@ -83,8 +83,7 @@ public class EncryptionTests(TemporaryDatabaseFixture database)
         Assert.Contains("not all keys requested were satisfied", ex.Message);
     }
 
-    private bool isBuggyMongocryptd =>
-        Environment.GetEnvironmentVariable("OS") == "Windows_NT" &&
+    private static bool IsBuggyMongocryptd =>
         Environment.GetEnvironmentVariable("MONGODB_VERSION") == "latest";
 
     [Theory]
@@ -92,7 +91,7 @@ public class EncryptionTests(TemporaryDatabaseFixture database)
     public void Encrypted_data_can_round_trip(CryptProvider cryptProvider, EncryptionMode encryptionMode)
     {
         // Remove me once mongocryptd is fixed for Windows on latest
-        if (cryptProvider == CryptProvider.Mongocryptd && isBuggyMongocryptd) return;
+        if (cryptProvider == CryptProvider.Mongocryptd && IsBuggyMongocryptd) return;
 
         var collection = _database.CreateCollection<Patient>(values: [cryptProvider, encryptionMode]);
         var encryptedCollection =

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Encryption/EncryptionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Encryption/EncryptionTests.cs
@@ -83,10 +83,17 @@ public class EncryptionTests(TemporaryDatabaseFixture database)
         Assert.Contains("not all keys requested were satisfied", ex.Message);
     }
 
+    private bool isBuggyMongocryptd =>
+        Environment.GetEnvironmentVariable("OS") == "Windows_NT" &&
+        Environment.GetEnvironmentVariable("MONGODB_VERSION") == "latest";
+
     [Theory]
     [MemberData(nameof(CryptProviderAndEncryptionModeData))]
     public void Encrypted_data_can_round_trip(CryptProvider cryptProvider, EncryptionMode encryptionMode)
     {
+        // Remove me once mongocryptd is fixed for Windows on latest
+        if (cryptProvider == CryptProvider.Mongocryptd && isBuggyMongocryptd) return;
+
         var collection = _database.CreateCollection<Patient>(values: [cryptProvider, encryptionMode]);
         var encryptedCollection =
             SetupEncryptedTestData(cryptProvider, collection.CollectionNamespace.CollectionName, encryptionMode);


### PR DESCRIPTION
- Adds MongoDB v8 as a named axis
- Skips the tests that break on latest/win due to upstream bug