### PR TITLE
EF-265: Make provider conventions public

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/DateTimeKindConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/DateTimeKindConvention.cs
@@ -23,7 +23,7 @@ namespace MongoDB.EntityFrameworkCore.Metadata.Conventions;
 /// <summary>
 /// A convention that set <see cref="DateTimeKind"/> for <see cref="DateTime"/> properties.
 /// </summary>
-public class DateTimeKindConvention : IPropertyAddedConvention
+public sealed class DateTimeKindConvention : IPropertyAddedConvention
 {
     /// <summary>
     /// Creates a <see cref="DateTimeKindConvention"/>.
@@ -34,10 +34,7 @@ public class DateTimeKindConvention : IPropertyAddedConvention
         DateTimeKind = dateTimeKind;
     }
 
-    /// <summary>
-    /// <see cref="DateTimeKind"/> to use.
-    /// </summary>
-    protected DateTimeKind DateTimeKind { get; }
+    private DateTimeKind DateTimeKind { get; }
 
     /// <summary>
     /// For every property of <see cref="DateTime"/> type that is added to the model set the configured <see cref="DateTimeKind"/>.

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoValueGenerationConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoValueGenerationConvention.cs
@@ -28,7 +28,7 @@ namespace MongoDB.EntityFrameworkCore.Metadata.Conventions;
 /// A convention that configures store value generation for <see cref="ObjectId"/> and <see cref="Guid"/> keys
 /// as well as the synthesized keys used internally by EF to index owned collection navigations.
 /// </summary>
-internal class MongoValueGenerationConvention : ValueGenerationConvention, IEntityTypeAnnotationChangedConvention
+public class MongoValueGenerationConvention : ValueGenerationConvention, IEntityTypeAnnotationChangedConvention
 {
     /// <summary>
     /// Creates a <see cref="MongoValueGenerationConvention" />.


### PR DESCRIPTION
Also sealed DateTimeKindConvention to align with other conventions like this.