### PR TITLE
EF-76: Flow EF metadata down through CreateGetValueExpression (#240)

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -39,11 +39,10 @@ namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisitor
 {
     private readonly MongoQueryExpression _queryExpression;
-    private readonly IEntityType _rootEntityType;
-    private readonly ParameterExpression DocParameter;
+    private readonly ParameterExpression _docParameter;
     private readonly bool _trackQueryResults;
     private readonly Dictionary<ParameterExpression, Expression> _materializationContextBindings = new();
-    private readonly Dictionary<Expression, ParameterExpression> ProjectionBindings = new();
+    private readonly Dictionary<Expression, ParameterExpression> _projectionBindings = new();
     private readonly Dictionary<Expression, (IEntityType EntityType, Expression BsonDocExpression)> _ownerMappings = new();
     private readonly Dictionary<Expression, Expression> _ordinalParameterBindings = new();
     private List<IncludeExpression> _pendingIncludes = [];
@@ -51,7 +50,6 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     /// <summary>
     /// Create a <see cref="MongoProjectionBindingRemovingExpressionVisitor"/>.
     /// </summary>
-    /// <param name="rootEntityType">The <see cref="IEntityType"/> this projection relates to.</param>
     /// <param name="queryExpression">The <see cref="MongoQueryExpression"/> this visitor should use.</param>
     /// <param name="docParameter">The parameter that will hold the <see cref="BsonDocument"/> input parameter to the shaper.</param>
     /// <param name="trackQueryResults">
@@ -59,14 +57,12 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     /// <see langword="false"/> if they are not.
     /// </param>
     public MongoProjectionBindingRemovingExpressionVisitor(
-        IEntityType rootEntityType,
         MongoQueryExpression queryExpression,
         ParameterExpression docParameter,
         bool trackQueryResults)
     {
         _queryExpression = queryExpression;
-        _rootEntityType = rootEntityType;
-        DocParameter = docParameter;
+        _docParameter = docParameter;
         _trackQueryResults = trackQueryResults;
     }
 
@@ -78,11 +74,16 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 {
                     var projection = GetProjection(projectionBindingExpression);
 
-                    return CreateGetValueExpression(
-                        DocParameter,
-                        projection.Alias,
-                        !projectionBindingExpression.Type.IsNullableType(),
-                        projectionBindingExpression.Type);
+                    var memberExpression = (MemberExpression)projection.Expression;
+                    while (memberExpression.Expression is MemberExpression nestedMemberExpression)
+                    {
+                        memberExpression = nestedMemberExpression;
+                    }
+
+                    var typeBase = ((StructuralTypeShaperExpression)memberExpression.Expression!).StructuralType;
+                    var propertyBase = typeBase.FindMember(memberExpression.Member.Name);
+
+                    return CreateGetValueExpression(_docParameter, projection.Alias, propertyBase);
                 }
 
             case CollectionShaperExpression collectionShaperExpression:
@@ -101,12 +102,12 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                             throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
                     }
 
-                    var bsonArray = ProjectionBindings[objectArrayProjection];
+                    var bsonArray = _projectionBindings[objectArrayProjection];
                     var jObjectParameter = Expression.Parameter(typeof(BsonDocument), bsonArray.Name + "Object");
                     var ordinalParameter = Expression.Parameter(typeof(int), bsonArray.Name + "Ordinal");
 
                     var accessExpression = objectArrayProjection.InnerProjection.ParentAccessExpression;
-                    ProjectionBindings[accessExpression] = jObjectParameter;
+                    _projectionBindings[accessExpression] = jObjectParameter;
                     _ownerMappings[accessExpression] =
                         (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
                     _ordinalParameterBindings[accessExpression] = Expression.Add(
@@ -183,15 +184,16 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
             {
                 if (parameterExpression.Type == typeof(BsonDocument) || parameterExpression.Type == typeof(BsonArray))
                 {
-                    string? fieldName = null;
-                    var fieldRequired = true;
+                    // "alias" will be different from the property/navigation name when mapped to a different name in the document.
+                    string? alias = null;
+                    IPropertyBase? propertyBase = null;
 
                     var projectionExpression = ((UnaryExpression)binaryExpression.Right).Operand;
                     if (projectionExpression is ProjectionBindingExpression projectionBindingExpression)
                     {
                         var projection = GetProjection(projectionBindingExpression);
                         projectionExpression = projection.Expression;
-                        fieldName = projection.Alias;
+                        alias = projection.Alias;
                     }
                     else if (projectionExpression is UnaryExpression convertExpression &&
                              convertExpression.NodeType == ExpressionType.Convert)
@@ -203,15 +205,16 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     if (projectionExpression is ObjectArrayProjectionExpression objectArrayProjectionExpression)
                     {
                         innerAccessExpression = objectArrayProjectionExpression.AccessExpression;
-                        ProjectionBindings[objectArrayProjectionExpression] = parameterExpression;
-                        fieldName ??= objectArrayProjectionExpression.Name;
+                        _projectionBindings[objectArrayProjectionExpression] = parameterExpression;
+                        alias ??= objectArrayProjectionExpression.Name;
+                        propertyBase = objectArrayProjectionExpression.Navigation;
                     }
                     else
                     {
                         var entityProjectionExpression = (EntityProjectionExpression)projectionExpression;
                         var accessExpression = entityProjectionExpression.ParentAccessExpression;
-                        ProjectionBindings[accessExpression] = parameterExpression;
-                        fieldName ??= entityProjectionExpression.Name;
+                        _projectionBindings[accessExpression] = parameterExpression;
+                        alias ??= entityProjectionExpression.Name;
 
                         switch (accessExpression)
                         {
@@ -219,10 +222,10 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                                 innerAccessExpression = innerObjectAccessExpression.AccessExpression;
                                 _ownerMappings[accessExpression] =
                                     (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
-                                fieldRequired = innerObjectAccessExpression.Required;
+                                propertyBase = innerObjectAccessExpression.Navigation;
                                 break;
                             case RootReferenceExpression:
-                                innerAccessExpression = DocParameter;
+                                innerAccessExpression = _docParameter;
                                 break;
                             default:
                                 throw new InvalidOperationException(
@@ -230,8 +233,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                         }
                     }
 
-                    var valueExpression =
-                        CreateGetValueExpression(innerAccessExpression, fieldName, fieldRequired, parameterExpression.Type);
+                    var valueExpression = CreateGetValueExpression(innerAccessExpression, alias, propertyBase);
 
                     return Expression.MakeBinary(ExpressionType.Assign, binaryExpression.Left, valueExpression);
                 }
@@ -290,8 +292,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
             if (methodCallExpression.Arguments[0] is ProjectionBindingExpression projectionBindingExpression)
             {
                 var projection = GetProjection(projectionBindingExpression);
-                innerExpression =
-                    CreateGetValueExpression(DocParameter, projection.Alias, projection.Required, typeof(BsonDocument));
+                innerExpression = CreateGetValueExpression(_docParameter, projection.Alias, property);
             }
             else
             {
@@ -331,7 +332,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     }
 
     private Expression CreateGetValueExpression(
-        Expression docExpression,
+        Expression documentExpression,
         IProperty property,
         Type type)
     {
@@ -343,7 +344,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 var ownership = entityType.FindOwnership();
                 if (ownership?.IsUnique == false && property.IsOwnedTypeOrdinalKey())
                 {
-                    var readExpression = _ordinalParameterBindings[docExpression];
+                    var readExpression = _ordinalParameterBindings[documentExpression];
                     if (readExpression.Type != type)
                     {
                         readExpression = Expression.Convert(readExpression, type);
@@ -356,16 +357,16 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 if (principalProperty != null)
                 {
                     Expression? ownerBsonDocExpression = null;
-                    if (_ownerMappings.TryGetValue(docExpression,
+                    if (_ownerMappings.TryGetValue(documentExpression,
                             out var ownerInfo))
                     {
                         ownerBsonDocExpression = ownerInfo.BsonDocExpression;
                     }
-                    else if (docExpression is RootReferenceExpression rootReferenceExpression)
+                    else if (documentExpression is RootReferenceExpression rootReferenceExpression)
                     {
                         ownerBsonDocExpression = rootReferenceExpression;
                     }
-                    else if (docExpression is ObjectAccessExpression objectAccessExpression)
+                    else if (documentExpression is ObjectAccessExpression objectAccessExpression)
                     {
                         ownerBsonDocExpression = objectAccessExpression.AccessExpression;
                     }
@@ -381,8 +382,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         }
 
         return Expression.Convert(
-            CreateGetValueExpression(docExpression, property.Name, !type.IsNullableType(), type, property.DeclaringType,
-                property.GetTypeMapping()),
+            CreateGetValueExpression(documentExpression, null, property),
             type);
     }
 
@@ -391,52 +391,43 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     /// </summary>
     /// <param name="projectionBindingExpression">The <see cref="ProjectionBindingExpression"/> to look-up.</param>
     /// <returns>The registered <see cref="ProjectionExpression"/> this <paramref name="projectionBindingExpression"/> relates to.</returns>
-    protected ProjectionExpression GetProjection(ProjectionBindingExpression projectionBindingExpression)
+    private ProjectionExpression GetProjection(ProjectionBindingExpression projectionBindingExpression)
         => _queryExpression.Projection[GetProjectionIndex(projectionBindingExpression)];
 
     /// <summary>
     /// Create a new compilable <see cref="Expression"/> the shaper can use to obtain the value from the <see cref="BsonDocument"/>.
     /// </summary>
-    /// <param name="docExpression">The <see cref="Expression"/> used to access the <see cref="BsonDocument"/>.</param>
-    /// <param name="propertyName">The name of the property.</param>
-    /// <param name="required"><see langword="true"/> if the field is required, <see langword="false"/> if it is optional.</param>
-    /// <param name="type">The <see cref="Type"/> of the value as it is within the document.</param>
-    /// <param name="declaredType">The optional <see cref="ITypeBase"/> this element comes from.</param>
-    /// <param name="typeMapping">Any associated <see cref="CoreTypeMapping"/> to be used in mapping the value.</param>
+    /// <param name="documentExpression">The <see cref="Expression"/> used to access the <see cref="BsonDocument"/>.</param>
+    /// <param name="alias">The name of the property.</param>
+    /// <param name="propertyBase">The <see cref="INavigation"/> or <see cref="IProperty"/> associated with the value.</param>
     /// <returns>A compilable <see cref="Expression"/> to obtain the desired value as the correct type.</returns>
-    protected Expression CreateGetValueExpression(
-        Expression docExpression,
-        string? propertyName,
-        bool required,
-        Type type,
-        ITypeBase? declaredType = null,
-        CoreTypeMapping? typeMapping = null)
+    private Expression CreateGetValueExpression(
+        Expression documentExpression,
+        string? alias,
+        IPropertyBase? propertyBase)
     {
-        var entityType = declaredType ?? docExpression switch
+        if (propertyBase is null && alias is null)
         {
-            RootReferenceExpression rootReferenceExpression => rootReferenceExpression.EntityType,
-            ObjectAccessExpression docAccessExpression => docAccessExpression.Navigation.TargetEntityType,
-            _ => _rootEntityType
-        };
+            return documentExpression;
+        }
 
-        var innerExpression = docExpression;
-        if (ProjectionBindings.TryGetValue(docExpression, out var innerVariable))
+        var innerExpression = documentExpression;
+        if (_projectionBindings.TryGetValue(documentExpression, out var innerVariable))
         {
             innerExpression = innerVariable;
         }
         else
         {
-            innerExpression = docExpression switch
+            innerExpression = documentExpression switch
             {
-                RootReferenceExpression => CreateGetValueExpression(DocParameter, null, required, typeof(BsonDocument)),
-                ObjectAccessExpression docAccessExpression => CreateGetValueExpression(docAccessExpression.AccessExpression,
-                    docAccessExpression.Name, required, typeof(BsonDocument)),
+                // TODO: handle more nesting; not currently used.
+                //RootReferenceExpression => CreateGetValueExpression(DocParameter, null, required, typeof(BsonDocument), propertyBase: propertyBase, declaredType: propertyBase!.DeclaringType),
+                //ObjectAccessExpression docAccessExpression => CreateGetValueExpression(docAccessExpression.AccessExpression, docAccessExpression.Name, required, typeof(BsonDocument), propertyBase: propertyBase, declaredType: propertyBase!.DeclaringType),
                 _ => innerExpression
             };
         }
 
-        var elementType = typeMapping?.ClrType ?? type;
-        return BsonBinding.CreateGetValueExpression(innerExpression, propertyName, required, elementType, entityType);
+        return BsonBinding.CreateGetValueExpression(innerExpression, alias, propertyBase);
     }
 
     private BlockExpression AddIncludes(BlockExpression shaperBlock)

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -90,8 +90,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         var shaperBody = shapedQueryExpression.ShaperExpression;
         shaperBody = new BsonDocumentInjectingExpressionVisitor().Visit(shaperBody);
         shaperBody = InjectEntityMaterializers(shaperBody);
-        shaperBody = new MongoProjectionBindingRemovingExpressionVisitor(
-                rootEntityType, mongoQueryExpression, bsonDocParameter, trackQueryResults)
+        shaperBody = new MongoProjectionBindingRemovingExpressionVisitor(mongoQueryExpression, bsonDocParameter, trackQueryResults)
             .Visit(shaperBody);
 
         var shaperLambda = Expression.Lambda(

--- a/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
@@ -282,7 +282,7 @@ public sealed class BsonSerializerFactory
         return CreateGenericSerializer(typeof(EnumerableInterfaceImplementerSerializer<,>), [type, itemType], childSerializer);
     }
 
-    internal static BsonSerializationInfo GetPropertySerializationInfo(IReadOnlyProperty property)
+    internal static BsonSerializationInfo GetPropertySerializationInfo(string? alias, IReadOnlyProperty property)
     {
         var serializer = CreateTypeSerializer(property);
 
@@ -298,12 +298,12 @@ public sealed class BsonSerializerFactory
         if (binaryVectorType != null)
         {
             return new BsonSerializationInfo(
-                property.GetElementName(),
+                alias ?? property.GetElementName(),
                 CreateBinaryVectorSerializer(type, binaryVectorType.Value),
                 serializer.ValueType);
         }
 
-        return new BsonSerializationInfo(property.GetElementName(), serializer, serializer.ValueType);
+        return new BsonSerializationInfo(alias ?? property.GetElementName(), serializer, serializer.ValueType);
     }
 
     private static IBsonSerializer CreateBinaryVectorSerializer(Type type, BinaryVectorDataType binaryVectorDataType)

--- a/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
@@ -98,7 +98,7 @@ internal class EntitySerializer<TValue> :
         var property = _entityType.FindProperty(memberName);
         if (property != null)
         {
-            serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+            serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(null, property);
             return true;
         }
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -203,7 +203,7 @@ internal class MongoUpdate(IUpdateEntry entry, WriteModel<BsonDocument> model)
 
     private static void WriteProperty(IBsonWriter writer, object? value, IProperty property)
     {
-        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(null, property);
         writer.WriteName(serializationInfo.ElementPath?.Last() ?? serializationInfo.ElementName);
         var root = BsonSerializationContext.CreateRoot(writer);
         serializationInfo.Serializer.Serialize(root, value);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -2384,43 +2384,46 @@ Orders.{ "$match" : { "$and" : [{ "OrderDate" : { "$ne" : null } }, { "$expr" : 
 
     public override async Task Select_expression_long_to_string(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_long_to_string(async))).Message);
+        await base.Select_expression_long_to_string(async);
 
         AssertMql(
+            """
+            Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "ShipName" : { "$toString" : { "$toLong" : "$_id" } }, "_id" : 0 } }
+            """
 );
     }
 
     public override async Task Select_expression_int_to_string(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_int_to_string(async))).Message);
+        await base.Select_expression_int_to_string(async);
 
         AssertMql(
-);
+            """
+            Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "ShipName" : { "$toString" : "$_id" }, "_id" : 0 } }
+            """
+        );
     }
 
     public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool async)
     {
         // Fails: Client eval in final projection EF-250
         Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.ToString_with_formatter_is_evaluated_on_the_client(async))).Message);
+            "Expression not supported: o.OrderID.ToString(\"X\")",
+            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.ToString_with_formatter_is_evaluated_on_the_client(async))).Message);
 
         AssertMql(
-);
+            """
+            Orders.
+            """
+        );
     }
 
     public override async Task Select_expression_other_to_string(bool async)
     {
         // Fails: Client eval in final projection EF-250
         Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_other_to_string(async))).Message);
+            "cannot be called with instance of type",
+            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_other_to_string(async))).Message);
 
         AssertMql(
 );
@@ -2507,7 +2510,7 @@ Orders.{ "$match" : { "$and" : [{ "OrderDate" : { "$ne" : null } }, { "$expr" : 
     {
         // Fails: Projections issue EF-76
         Assert.Contains(
-            "Rewriting child expression",
+            "No coercion operator is defined",
             (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_date_add_milliseconds_large_number_divided(async))).Message);
 
         AssertMql(

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Storage/BsonBindingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Storage/BsonBindingTests.cs
@@ -64,7 +64,7 @@ public class BsonBindingTests
         var property = entity.GetProperty(nameof(TestEntity.IntProperty));
         var document = BsonDocument.Parse("{ IntProperty: 12 }");
 
-        var value = BsonBinding.GetPropertyValue<int>(document, property);
+        var value = BsonBinding.GetPropertyValue<int>(document, null, property);
 
         Assert.Equal(12, value);
     }
@@ -81,7 +81,7 @@ public class BsonBindingTests
         var property = entity.GetProperty(nameof(TestEntity.IntProperty));
         var document = BsonDocument.Parse("{ property: 12 }");
 
-        var ex = Assert.Throws<InvalidOperationException>(() => BsonBinding.GetPropertyValue<int>(document, property));
+        var ex = Assert.Throws<InvalidOperationException>(() => BsonBinding.GetPropertyValue<int>(document, null, property));
         Assert.Contains("IntProperty", ex.Message);
     }
 
@@ -97,7 +97,7 @@ public class BsonBindingTests
         var property = entity.GetProperty(nameof(TestEntity.NullableProperty));
 
         var document = BsonDocument.Parse("{ somevalue: 12 }");
-        var value = BsonBinding.GetPropertyValue<int?>(document, property);
+        var value = BsonBinding.GetPropertyValue<int?>(document, null, property);
 
         Assert.Null(value);
     }


### PR DESCRIPTION
* EF-76: Flow EF metadata down through CreateGetValueExpression

That is, the IProperty or INavigation associated with the access. Types, requiredness, type-mappings, etc. are then obtained from the property.

An alias is passed in if the name in the BSON document is different from the mapped element name for the property.

* Updates based on co-pilot review.