### PR TITLE
EF-76: Partial support for Tuple.Create

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoProjectionBindingExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoProjectionBindingExpression.cs
@@ -79,6 +79,9 @@ public sealed class MongoProjectionBindingExpression : Expression, IPrintableExp
     /// <inheritdoc />
     public override Type Type { get; }
 
+    /// <summary>
+    ///     The type of the final projection result.
+    /// </summary>
     public Type ProjectionType { get; }
 
     /// <inheritdoc />

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoProjectionMember.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoProjectionMember.cs
@@ -111,6 +111,6 @@ public sealed class MongoProjectionMember
     /// <inheritdoc />
     public override string ToString()
         => _memberChain.Any()
-            ? string.Join(".", _memberChain.Select(mi => mi))
+            ? string.Join(".", _memberChain)
             : "EmptyMongoProjectionMember";
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -28,6 +28,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Serializers;
 using MongoDB.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;
@@ -82,8 +83,13 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
 
                     var typeBase = ((StructuralTypeShaperExpression)memberExpression.Expression!).StructuralType;
                     var propertyBase = typeBase.FindMember(memberExpression.Member.Name);
+                    var serializationInfo = BsonSerializerFactory.GetTypeSerializationInfo(memberExpression.Type);
 
-                    return CreateGetValueExpression(_docParameter, projection.Alias, propertyBase);
+                    return projectionBindingExpression.ProjectionMember == null
+                        ? BsonBinding.CreateGetNextValueByOrdinal(
+                            _docParameter, projectionBindingExpression.Index!.Value, projectionBindingExpression.ProjectionType, serializationInfo)
+                        : CreateGetValueExpression(
+                            _docParameter, projection.Alias, propertyBase);
                 }
 
             case CollectionShaperExpression collectionShaperExpression:
@@ -184,8 +190,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
             {
                 if (parameterExpression.Type == typeof(BsonDocument) || parameterExpression.Type == typeof(BsonArray))
                 {
-                    // "alias" will be different from the property/navigation name when mapped to a different name in the document.
-                    string? alias = null;
+                    string? docKeyName = null;
                     IPropertyBase? propertyBase = null;
 
                     var projectionExpression = ((UnaryExpression)binaryExpression.Right).Operand;
@@ -193,7 +198,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     {
                         var projection = GetProjection(projectionBindingExpression);
                         projectionExpression = projection.Expression;
-                        alias = projection.Alias;
+                        docKeyName = projection.Alias;
                     }
                     else if (projectionExpression is UnaryExpression convertExpression &&
                              convertExpression.NodeType == ExpressionType.Convert)
@@ -206,7 +211,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     {
                         innerAccessExpression = objectArrayProjectionExpression.AccessExpression;
                         _projectionBindings[objectArrayProjectionExpression] = parameterExpression;
-                        alias ??= objectArrayProjectionExpression.Name;
+                        docKeyName ??= objectArrayProjectionExpression.Name;
                         propertyBase = objectArrayProjectionExpression.Navigation;
                     }
                     else
@@ -214,7 +219,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                         var entityProjectionExpression = (EntityProjectionExpression)projectionExpression;
                         var accessExpression = entityProjectionExpression.ParentAccessExpression;
                         _projectionBindings[accessExpression] = parameterExpression;
-                        alias ??= entityProjectionExpression.Name;
+                        docKeyName ??= entityProjectionExpression.Name;
 
                         switch (accessExpression)
                         {
@@ -233,7 +238,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                         }
                     }
 
-                    var valueExpression = CreateGetValueExpression(innerAccessExpression, alias, propertyBase);
+                    var valueExpression = CreateGetValueExpression(innerAccessExpression, docKeyName, propertyBase);
 
                     return Expression.MakeBinary(ExpressionType.Assign, binaryExpression.Left, valueExpression);
                 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -71,17 +71,25 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         // TODO: Handle select expressions and non-EF shapers more comprehensively
         if (projectedEntityType == null)
         {
-            // We are relying on raw/scalar values coming back from LINQ V3 provider for now - no shaper required
-            return Expression.Call(null,
-                TranslateAndExecuteUnshapedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType,
-                    shapedQueryExpression.ShaperExpression.Type),
-                QueryCompilationContext.QueryContextParameter,
-                Expression.Constant(rootEntityType),
-                Expression.Constant(_bsonSerializerFactory),
-                Expression.Constant(mongoQueryExpression),
-                Expression.Constant(_contextType),
-                Expression.Constant(_threadSafetyChecksEnabled),
-                Expression.Constant(shapedQueryExpression.ResultCardinality));
+            // Allow Select(e => Tuple.Create(e.A, e.B, e.C, ...)) through
+            if (!(mongoQueryExpression.CapturedExpression is MethodCallExpression { Method.IsGenericMethod: true } selectCall
+                  && selectCall.Method.GetGenericMethodDefinition() == QueryableMethods.Select
+                  && selectCall.Arguments[1].UnwrapLambdaFromQuote().Body
+                      is MethodCallExpression { Method.Name: "Create" } tupleCreateCall
+                  && tupleCreateCall.Method.DeclaringType == typeof(Tuple)))
+            {
+                // We are relying on raw/scalar values coming back from LINQ V3 provider for now - no shaper required
+                return Expression.Call(null,
+                    TranslateAndExecuteUnshapedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType,
+                        shapedQueryExpression.ShaperExpression.Type),
+                    QueryCompilationContext.QueryContextParameter,
+                    Expression.Constant(rootEntityType),
+                    Expression.Constant(_bsonSerializerFactory),
+                    Expression.Constant(mongoQueryExpression),
+                    Expression.Constant(_contextType),
+                    Expression.Constant(_threadSafetyChecksEnabled),
+                    Expression.Constant(shapedQueryExpression.ResultCardinality));
+            }
         }
 
         var bsonDocParameter = Expression.Parameter(typeof(BsonDocument), "bsonDoc");

--- a/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
@@ -306,6 +306,12 @@ public sealed class BsonSerializerFactory
         return new BsonSerializationInfo(alias ?? property.GetElementName(), serializer, serializer.ValueType);
     }
 
+    internal static BsonSerializationInfo GetTypeSerializationInfo(Type type)
+    {
+        var serializer = CreateTypeSerializer(type);
+        return new BsonSerializationInfo(null, serializer, serializer.ValueType);
+    }
+
     private static IBsonSerializer CreateBinaryVectorSerializer(Type type, BinaryVectorDataType binaryVectorDataType)
     {
         if (type.IsArray)


### PR DESCRIPTION
This doesn't yet handle cases where the values passed to Tuple.Create are not property accesses.