### PR TITLE
EF-288: Explicitly reference driver types from driver assembly

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/ChangeTracking/NullableEqualityComparer.cs
+++ b/src/MongoDB.EntityFrameworkCore/ChangeTracking/NullableEqualityComparer.cs
@@ -3,8 +3,6 @@
 
 // Originally from EFCore.Cosmos NullableEqualityComparer.cs
 
-using System.Collections.Generic;
-
 namespace MongoDB.EntityFrameworkCore.ChangeTracking;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/ChangeTracking/NullableStringDictionaryComparer.cs
+++ b/src/MongoDB.EntityFrameworkCore/ChangeTracking/NullableStringDictionaryComparer.cs
@@ -3,8 +3,6 @@
 
 // Originally from EFCore.Cosmos NullableStringDictionaryComparer.cs
 
-using System;
-using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace MongoDB.EntityFrameworkCore.ChangeTracking;

--- a/src/MongoDB.EntityFrameworkCore/ChangeTracking/StringDictionaryComparer.cs
+++ b/src/MongoDB.EntityFrameworkCore/ChangeTracking/StringDictionaryComparer.cs
@@ -3,8 +3,6 @@
 
 // Originally from EFCore.Cosmos StringDictionaryComparer.cs
 
-using System;
-using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace MongoDB.EntityFrameworkCore.ChangeTracking;

--- a/src/MongoDB.EntityFrameworkCore/Check.cs
+++ b/src/MongoDB.EntityFrameworkCore/Check.cs
@@ -13,12 +13,8 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Internal;
-using MongoDB.Driver.Linq;
 
 namespace MongoDB.EntityFrameworkCore;
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoBulkWriteEventData.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoEventId.cs
@@ -15,8 +15,6 @@
 
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerExtensions.cs
@@ -13,15 +13,8 @@
  * limitations under the License.
  */
 
-using System;
 using System.Globalization;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;
-using MongoDB.Bson;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Query;
 using MongoDB.EntityFrameworkCore.Storage;
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerTransactionExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerTransactionExtensions.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggerUpdateExtensions.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
-using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoLoggingDefinitions.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
-
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoQueryEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoQueryEventData.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionEndEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionEndEventData.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionErrorEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionErrorEventData.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionEventData.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionStartingEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/MongoTransactionStartingEventData.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/NonCapturingLazyInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/NonCapturingLazyInitializer.cs
@@ -3,7 +3,6 @@
 
 // Originally from EFCore NonCapturingLazyInitializer.cs
 
-using System;
 using System.Threading;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/PropertyAndIndexNameEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/PropertyAndIndexNameEventData.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 

--- a/src/MongoDB.EntityFrameworkCore/Diagnostics/TimeSpanEventData.cs
+++ b/src/MongoDB.EntityFrameworkCore/Diagnostics/TimeSpanEventData.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace MongoDB.EntityFrameworkCore.Diagnostics;
 

--- a/src/MongoDB.EntityFrameworkCore/EnumerableMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/EnumerableMethods.cs
@@ -3,10 +3,7 @@
 
 // Originally EF Core EnumerableMethods.cs
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace MongoDB.EntityFrameworkCore;

--- a/src/MongoDB.EntityFrameworkCore/ExpressionExtensionMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/ExpressionExtensionMethods.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using System.Reflection;
 
 namespace MongoDB.EntityFrameworkCore;

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoDatabaseFacadeExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoDatabaseFacadeExtensions.cs
@@ -13,13 +13,10 @@
  * limitations under the License.
  */
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Metadata;
 using MongoDB.EntityFrameworkCore.Storage;
 

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoDbContextOptionsExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoDbContextOptionsExtensions.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Infrastructure;
 

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeBuilderExtensions.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using MongoDB.EntityFrameworkCore.Metadata;
 

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoEntityTypeExtensions.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.EntityFrameworkCore.Metadata;
 
 namespace MongoDB.EntityFrameworkCore.Extensions;

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexBuilderExtensions.cs
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-using System;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Metadata;
+using VectorSimilarity = MongoDB.Driver.VectorSimilarity;
 
 namespace MongoDB.EntityFrameworkCore.Extensions;
 
@@ -69,7 +68,7 @@ public static class MongoIndexBuilderExtensions
     /// Configures the index as an Atlas Vector Search index with the given similarity function and dimensions.
     /// </summary>
     /// <param name="indexBuilder">The builder for the index being configured.</param>
-    /// <param name="similarity">The <see cref="VectorSimilarity"/> to use to search for top K-nearest neighbors.</param>
+    /// <param name="similarity">The <see cref="Driver.VectorSimilarity"/> to use to search for top K-nearest neighbors.</param>
     /// <param name="dimensions">Number of vector dimensions, between 1 and 8192.</param>
     /// <returns>A builder to further configure the vector index options.</returns>
     public static VectorIndexBuilder IsVectorIndex(

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoIndexExtensions.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Metadata;
 
 namespace MongoDB.EntityFrameworkCore.Extensions;

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoModelExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoModelExtensions.cs
@@ -13,11 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore.Metadata;
-
 namespace MongoDB.EntityFrameworkCore.Extensions;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoNavigationExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoNavigationExtensions.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.EntityFrameworkCore.Metadata;
 
 namespace MongoDB.EntityFrameworkCore.Extensions;

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertiesConfigurationBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertiesConfigurationBuilderExtensions.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Metadata;
 
 // ReSharper disable once CheckNamespace

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyBuilderExtensions.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Metadata;
 
 // ReSharper disable once CheckNamespace

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoPropertyExtensions.cs
@@ -13,11 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Metadata;

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoQueryableExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoQueryableExtensions.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.Metadata;
 

--- a/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/MongoServiceCollectionExtensions.cs
@@ -13,16 +13,12 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Infrastructure;
 using MongoDB.EntityFrameworkCore.Metadata.Conventions;

--- a/src/MongoDB.EntityFrameworkCore/Extensions/QueryableEncryptionBuilderExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Extensions/QueryableEncryptionBuilderExtensions.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/GlobalUsings.cs
+++ b/src/MongoDB.EntityFrameworkCore/GlobalUsings.cs
@@ -1,0 +1,12 @@
+extern alias Driver;
+
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Linq.Expressions;
+global using Microsoft.EntityFrameworkCore;
+global using Microsoft.EntityFrameworkCore.Diagnostics;
+global using Microsoft.EntityFrameworkCore.Metadata;
+global using MongoDB.Bson;
+global using Driver::MongoDB.Driver;
+global using Driver::MongoDB.Driver.Linq;

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/IMongoDbContextOptionsBuilderInfrastructure.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/IMongoDbContextOptionsBuilderInfrastructure.cs
@@ -13,8 +13,6 @@
 * limitations under the License.
 */
 
-using Microsoft.EntityFrameworkCore;
-
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/IQueryableEncryptionSchemaProvider.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/IQueryableEncryptionSchemaProvider.cs
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using MongoDB.Bson;
-
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoClientSettingsHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoClientSettingsHelper.cs
@@ -13,13 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
-using MongoDB.Bson;
-using MongoDB.Driver;
-
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
 internal static class MongoClientSettingsHelper

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoDbContextOptionsBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoDbContextOptionsBuilder.cs
@@ -13,8 +13,6 @@
 * limitations under the License.
 */
 
-using Microsoft.EntityFrameworkCore;
-
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelRuntimeInitializer.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
@@ -13,15 +13,8 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.EntityFrameworkCore.Diagnostics;

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
@@ -13,13 +13,10 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore;
 
 // ReSharper disable once CheckNamespace (extensions should be in the EF namespace for discovery)

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionEqualityBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionEqualityBuilder.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace MongoDB.EntityFrameworkCore.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionRangeBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionRangeBuilder.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionSchemaGenerator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionSchemaGenerator.cs
@@ -13,12 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.EntityFrameworkCore.Extensions;

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionSchemaProvider.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/QueryableEncryptionSchemaProvider.cs
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
-
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
 /// <inheritdoc />

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Attributes/CollectionAttribute.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Attributes/CollectionAttribute.cs
@@ -13,8 +13,6 @@
 * limitations under the License.
 */
 
-using System;
-
 // ReSharper disable once CheckNamespace
 namespace MongoDB.EntityFrameworkCore;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/BsonRepresentationConfiguration.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/BsonRepresentationConfiguration.cs
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using MongoDB.Bson;
-
 namespace MongoDB.EntityFrameworkCore.Metadata;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BinaryVectorAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BinaryVectorAttributeConvention.cs
@@ -14,11 +14,9 @@
  */
 
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Metadata.Conventions.BsonAttributes;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonDateTimeOptionsAttributeConvention.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonElementAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonElementAttributeConvention.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System.Linq;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonIdAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonIdAttributeConvention.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonIgnoreAttributeConvention.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonRepresentationAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/BsonAttributes/BsonRepresentationAttributeConvention.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CamelCaseElementNameConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CamelCaseElementNameConvention.cs
@@ -14,7 +14,6 @@
  */
 
 using System.Globalization;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CollectionNameFromDbSetConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/CollectionNameFromDbSetConvention.cs
@@ -13,9 +13,6 @@
 * limitations under the License.
 */
 
-using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/ColumnAttributeConvention.cs
@@ -14,9 +14,7 @@
  */
 
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/DateTimeKindConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/DateTimeKindConvention.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/IndexNamingConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/IndexNamingConvention.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System.Linq;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoConventionSetBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoConventionSetBuilder.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoRelationshipDiscoveryConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoRelationshipDiscoveryConvention.cs
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoValueGenerationConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/MongoValueGenerationConvention.cs
@@ -13,13 +13,9 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.Metadata.Conventions;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/NotSupportedPropertyAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/NotSupportedPropertyAttributeConvention.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Infrastructure;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/TableAttributeConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/TableAttributeConvention.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/InternalIndexExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/InternalIndexExtensions.cs
@@ -13,13 +13,8 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
+using VectorSimilarity = MongoDB.Driver.VectorSimilarity;
 
 namespace MongoDB.EntityFrameworkCore.Metadata;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/InternalKeyExtensions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/InternalKeyExtensions.cs
@@ -13,12 +13,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.Metadata;

--- a/src/MongoDB.EntityFrameworkCore/Metadata/MongoDatabaseCreationOptions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/MongoDatabaseCreationOptions.cs
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-
-using MongoDB.Driver;
-
 namespace MongoDB.EntityFrameworkCore.Metadata;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Metadata/VectorIndexBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/VectorIndexBuilder.cs
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
+using VectorQuantization = MongoDB.Driver.VectorQuantization;
 
 namespace MongoDB.EntityFrameworkCore.Metadata;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/VectorIndexBuilder`.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/VectorIndexBuilder`.cs
@@ -13,12 +13,8 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Driver;
+using VectorQuantization = MongoDB.Driver.VectorQuantization;
 
 namespace MongoDB.EntityFrameworkCore.Metadata;
 

--- a/src/MongoDB.EntityFrameworkCore/Metadata/VectorIndexOptions.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/VectorIndexOptions.cs
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using MongoDB.Driver;
+using VectorQuantization = MongoDB.Driver.VectorQuantization;
+using VectorSimilarity = MongoDB.Driver.VectorSimilarity;
 
 namespace MongoDB.EntityFrameworkCore.Metadata;
 
@@ -23,7 +23,7 @@ namespace MongoDB.EntityFrameworkCore.Metadata;
 /// See <see href="https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type">How to Index Fields for Vector Search</see>
 /// for more information.
 /// </summary>
-/// <param name="Similarity">The <see cref="VectorSimilarity"/> to use to search for top K-nearest neighbors.</param>
+/// <param name="Similarity">The <see cref="Driver.VectorSimilarity"/> to use to search for top K-nearest neighbors.</param>
 /// <param name="Dimensions">Number of vector dimensions that Atlas Vector Search enforces at index-time and query-time.</param>
 /// <param name="Quantization">Type of automatic vector quantization for your vectors.</param>
 /// <param name="HnswMaxEdges">Maximum number of edges (or connections) that a node can have in the Hierarchical Navigable Small Worlds graph.</param>

--- a/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
+++ b/src/MongoDB.EntityFrameworkCore/MongoDB.EntityFrameworkCore.csproj
@@ -40,7 +40,7 @@
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.UnitTests" />
     <InternalsVisibleTo Include="MongoDB.EntityFrameworkCore.SpecificationTests" />
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
-    <PackageReference Include="MongoDB.Driver" Version="$(CSharpDriverVersion)" />
+    <PackageReference Include="MongoDB.Driver" Version="$(CSharpDriverVersion)" Aliases="Driver"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'Debug' ">

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/CollectionShaperExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/CollectionShaperExpression.cs
@@ -3,10 +3,6 @@
 
 // Originally from EFCore.Cosmos CollectionShaperExpression.
 
-using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/EntityProjectionExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/EntityProjectionExpression.cs
@@ -3,12 +3,7 @@
 
 // Derived from EFCore.Cosmos EntityProjectionExpression.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/EntityTypedExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/EntityTypedExpression.cs
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Metadata;
-
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoCollectionExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoCollectionExpression.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.cs
@@ -13,11 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/ObjectAccessExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/ObjectAccessExpression.cs
@@ -3,9 +3,6 @@
 
 // Derived from EFCore.Cosmos ObjectAccessExpression.
 
-using System;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using MongoDB.EntityFrameworkCore.Extensions;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/ObjectArrayProjectionExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/ObjectArrayProjectionExpression.cs
@@ -3,10 +3,6 @@
 
 // Originally from EFCore.Cosmos ObjectArrayProjectionExpression.cs
 
-using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using MongoDB.EntityFrameworkCore.Extensions;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/ProjectionExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/ProjectionExpression.cs
@@ -3,9 +3,6 @@
 
 // Derived from EFCore.Cosmos ProjectionExpression.
 
-using System;
-using System.Linq.Expressions;
-
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/RootReferenceExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/RootReferenceExpression.cs
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Metadata;
-
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;
 
 /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
@@ -14,10 +14,7 @@
  */
 
 using System.Collections.ObjectModel;
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 
 namespace MongoDB.EntityFrameworkCore.Query;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
@@ -13,12 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPostprocessor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPostprocessor.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPreprocessor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryTranslationPreprocessor.cs
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-using System.Linq;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using MongoDB.EntityFrameworkCore.Query.Visitors;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
@@ -13,13 +13,9 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/BsonDocumentInjectingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/BsonDocumentInjectingExpressionVisitor.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/EntityFrameworkDetourExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/EntityFrameworkDetourExpressionVisitor.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/FinalPredicateHoistingVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/FinalPredicateHoistingVisitor.cs
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-using System.Linq;
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -13,24 +13,14 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
-using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Metadata;
-using MongoDB.EntityFrameworkCore.Query.Expressions;
 using MongoDB.EntityFrameworkCore.Serializers;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -15,14 +15,8 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using MongoDB.EntityFrameworkCore.Extensions;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -13,19 +13,11 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 using MongoDB.EntityFrameworkCore.Storage;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -13,12 +13,9 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using System.Linq.Expressions;
+extern alias Driver;
+
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
@@ -53,7 +50,7 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         return base.Visit(expression);
     }
 
-    private static readonly Type[] AllowedQueryableExtensions = [ typeof(Queryable), typeof(MongoQueryableExtensions), typeof(Driver.Linq.MongoQueryable) ];
+    private static readonly Type[] AllowedQueryableExtensions = [ typeof(Queryable), typeof(MongoQueryableExtensions), typeof(Driver::MongoDB.Driver.Linq.MongoQueryable) ];
 
     /// <summary>
     /// Visit the <see cref="MethodCallExpression"/> to capture the cardinality and final expression

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -13,17 +13,9 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
-using MongoDB.Driver;
-using MongoDB.Driver.Linq;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 using MongoDB.EntityFrameworkCore.Query.Visitors.Dependencies;

--- a/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/BsonSerializerFactory.cs
@@ -13,17 +13,11 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Options;
 using MongoDB.Bson.Serialization.Serializers;

--- a/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/EntitySerializer.cs
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.EntityFrameworkCore.Extensions;

--- a/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
@@ -13,12 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization.Conventions;
 

--- a/src/MongoDB.EntityFrameworkCore/Serializers/ValueConverterSerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/ValueConverterSerializer.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -13,13 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Serializers;

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonTypeHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonTypeHelper.cs
@@ -13,10 +13,6 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Serializers;
 
 namespace MongoDB.EntityFrameworkCore.Storage;

--- a/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/IMongoClientWrapper.cs
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Query;
 
 namespace MongoDB.EntityFrameworkCore.Storage;

--- a/src/MongoDB.EntityFrameworkCore/Storage/IMongoDatabaseCreator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/IMongoDatabaseCreator.cs
@@ -13,10 +13,8 @@
  * limitations under the License.
  */
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using MongoDB.EntityFrameworkCore.Metadata;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/IMongoTransactionManager.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/IMongoTransactionManager.cs
@@ -13,11 +13,9 @@
  * limitations under the License.
  */
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Storage;
-using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -13,15 +13,10 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Infrastructure;
 using MongoDB.EntityFrameworkCore.Query;

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseCreator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseCreator.cs
@@ -13,20 +13,12 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
-using MongoDB.Bson;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Metadata;

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoDatabaseWrapper.cs
@@ -13,20 +13,13 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
-using MongoDB.Bson;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoTransaction.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoTransaction.cs
@@ -13,15 +13,10 @@
  * limitations under the License.
  */
 
-using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Storage;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 
 namespace MongoDB.EntityFrameworkCore.Storage;

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoTransactionEnlistmentManager.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoTransactionEnlistmentManager.cs
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-using System;
 using System.Transactions;
 using Microsoft.EntityFrameworkCore.Storage;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoTransactionManager.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoTransactionManager.cs
@@ -13,14 +13,10 @@
  * limitations under the License.
  */
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
-using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMapping.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMapping.cs
@@ -13,14 +13,11 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Json;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMappingSource.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoTypeMappingSource.cs
@@ -13,13 +13,10 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.ChangeTracking;
 
 namespace MongoDB.EntityFrameworkCore.Storage;

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -13,18 +13,11 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Update;
-using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Serializers;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdateBatch.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdateBatch.cs
@@ -13,9 +13,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
-using System.Linq;
-using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.Storage;

--- a/src/MongoDB.EntityFrameworkCore/Storage/RowVersion.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/RowVersion.cs
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq;
 using System.Numerics;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Update;
 
 namespace MongoDB.EntityFrameworkCore.Storage;

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/Decimal128DecimalConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/Decimal128DecimalConverter.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/Decimal128ToDecimalConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/Decimal128ToDecimalConverter.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/DecimalToDecimal128Converter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/DecimalToDecimal128Converter.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/MongoValueConverterSelector.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/MongoValueConverterSelector.cs
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/ObjectIdToStringConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/ObjectIdToStringConverter.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringObjectIdConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringObjectIdConverter.cs
@@ -13,10 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringToObjectIdConverter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/ValueConversion/StringToObjectIdConverter.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/MongoDB.EntityFrameworkCore/TypeExtensionMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/TypeExtensionMethods.cs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 
 // ReSharper disable once CheckNamespace

--- a/src/MongoDB.EntityFrameworkCore/ValueGeneration/MongoValueGeneratorSelector.cs
+++ b/src/MongoDB.EntityFrameworkCore/ValueGeneration/MongoValueGeneratorSelector.cs
@@ -13,11 +13,7 @@
  * limitations under the License.
  */
 
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.ValueGeneration;
 

--- a/src/MongoDB.EntityFrameworkCore/ValueGeneration/ObjectIdValueGenerator.cs
+++ b/src/MongoDB.EntityFrameworkCore/ValueGeneration/ObjectIdValueGenerator.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.ValueGeneration;
 

--- a/src/MongoDB.EntityFrameworkCore/ValueGeneration/StringObjectIdValueGenerator.cs
+++ b/src/MongoDB.EntityFrameworkCore/ValueGeneration/StringObjectIdValueGenerator.cs
@@ -15,7 +15,6 @@
 
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
-using MongoDB.Bson;
 
 namespace MongoDB.EntityFrameworkCore.ValueGeneration;
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/MongoDB.EntityFrameworkCore.FunctionalTests.csproj
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/MongoDB.EntityFrameworkCore.FunctionalTests.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release;Debug EF9;Release EF9</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>EF8</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;EF8</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>EF8</DefineConstants>
+    <DefineConstants>TRACE;RELEASE;EF8</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug EF9' ">
     <DefineConstants>TRACE;DEBUG;EF9</DefineConstants>
@@ -15,7 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release EF9' ">
     <DefineConstants>TRACE;RELEASE;EF9</DefineConstants>
   </PropertyGroup>
-
   <Import Project="..\..\Versions.props" />
 
   <ItemGroup>

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoDB.EntityFrameworkCore.SpecificationTests.csproj
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoDB.EntityFrameworkCore.SpecificationTests.csproj
@@ -5,10 +5,10 @@
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>EF8</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;EF8</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>EF8</DefineConstants>
+    <DefineConstants>TRACE;RELEASE;EF8</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug EF9' ">
     <DefineConstants>TRACE;DEBUG;EF9</DefineConstants>

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/MongoDB.EntityFrameworkCore.UnitTests.csproj
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/MongoDB.EntityFrameworkCore.UnitTests.csproj
@@ -1,9 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <Configurations>Debug;Release;Debug EF9;Release EF9</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>TRACE;DEBUG;EF8</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DefineConstants>TRACE;RELEASE;EF8</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug EF9' ">
+    <DefineConstants>TRACE;DEBUG;EF9</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release EF9' ">
+    <DefineConstants>TRACE;RELEASE;EF9</DefineConstants>
+  </PropertyGroup>
   <Import Project="..\..\Versions.props" />
 
   <ItemGroup>


### PR DESCRIPTION
This is a temporary change until a new driver version is released. Since we do not sim ship, we should not introduce driver types like this going forward--it's not safe with our process.