### PR TITLE
EF-293: Fix entity states for owned entity collections

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -193,6 +193,22 @@ functions:
           BUILD_CONFIGURATION="Debug EF10" \
             ./evergreen/run-tests.sh
 
+  run-tests-macos:
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: mongo-efcore-provider
+        script: |
+          ${PREPARE_SHELL}
+          DRIVER_VERSION=${DRIVER_VERSION} \
+          OS=${OS} \
+          MONGODB_URI="${MONGODB_URI}" \
+          ATLAS_URI="${ATLAS_URI}" \
+          MONGODB_VERSION="${version}" \
+          CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH} \
+          BUILD_CONFIGURATION="Debug EF10" \
+            ./evergreen/run-tests.sh
+
   cleanup:
     - command: shell.exec
       params:
@@ -431,6 +447,11 @@ tasks:
       - func: bootstrap-mongo-orchestration
       - func: run-tests
 
+  - name: main-tests-macos
+    commands:
+      - func: bootstrap-mongo-orchestration
+      - func: run-tests-macos
+
   - name: pack-packages
     commands:
       - func: pack-packages
@@ -566,13 +587,24 @@ buildvariants:
 - matrix_name: main-tests
   matrix_spec:
     version: ["5.0", "6.0", "7.0", "latest"]
-    os: "*"
+    os: ["windows-64", "ubuntu-2004"]
     driver: "*"
     topology: "replicaset"
   display_name: "${driver} Driver on ${os} with ${version} ${topology} Server"
   tags: ["tests-variant"]
   tasks:
     - name: main-tests
+
+- matrix_name: main-tests-macos
+  matrix_spec:
+    version: ["5.0", "6.0", "7.0", "latest"]
+    os: "macos-14"
+    driver: "*"
+    topology: "replicaset"
+  display_name: "${driver} Driver on ${os} with ${version} ${topology} Server"
+  tags: ["tests-variant"]
+  tasks:
+    - name: main-tests-macos
 
 - matrix_name: validate-apidocs
   matrix_spec:

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoUpdate.cs
@@ -247,7 +247,7 @@ internal class MongoUpdate(IUpdateEntry entry, WriteModel<BsonDocument> model)
                         var ordinalKeyProperty = FindOrdinalKeyProperty(embeddedEntry.EntityType);
                         if (ordinalKeyProperty != null && embeddedEntry.HasTemporaryValue(ordinalKeyProperty))
                         {
-                            embeddedEntry.SetStoreGeneratedValue(ordinalKeyProperty, ordinal);
+                            embeddedEntry.SetStoreGeneratedValue(ordinalKeyProperty, ordinal, setModified: false);
                         }
 
                         WriteEntity(writer, embeddedEntry, _ => true);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF10/SimpleContextModelBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF10/SimpleContextModelBuilder.cs
@@ -11,7 +11,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Design
     public partial class SimpleContextModel
     {
         private SimpleContextModel()
-            : base(skipDetectChanges: false, modelId: new Guid("436c97bc-761b-453c-a4f6-30ed2976f3ea"), entityTypeCount: 2)
+            : base(skipDetectChanges: false, modelId: new Guid("13956f7e-4a9d-432b-aa8f-478d1f251dfc"), entityTypeCount: 2)
         {
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -640,13 +640,15 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         Assert.Contains(entity.locations.GetType().ShortDisplayName(), ex.Message);
     }
 
-    [Fact]
-    public void OwnedEntity_with_collection_adjusted_correctly()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OwnedEntity_with_collection_adjusted_correctly(bool async)
     {
-        var collection = database.CreateCollection<PersonWithMultipleLocations>();
+        var collection = database.CreateCollection<PersonWithMultipleLocations>(values: [async]);
 
         {
-            using var db = SingleEntityDbContext.Create(collection);
+            await using var db = SingleEntityDbContext.Create(collection);
 
             var original = new PersonWithMultipleLocations
             {
@@ -659,39 +661,130 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             };
 
             db.Add(original);
-            db.SaveChanges();
+            await SaveChanges(db, async);
             Assert.Single(original.locations, l => l.latitude == 1.1m);
 
             original.locations.Add(new() {latitude = 3.3m, longitude = 4.4m});
-            db.SaveChanges();
+            await SaveChanges(db, async);
 
             Assert.Equal(2, original.locations.Count);
         }
 
         {
-            using var db = SingleEntityDbContext.Create(collection);
+            await using var db = SingleEntityDbContext.Create(collection);
 
             var found = db.Entities.Single();
             Assert.Equal(2, found.locations.Count);
 
             found.locations.RemoveAt(0);
-            db.SaveChanges();
-
+            await SaveChanges(db, async);
+            AssertAllEntriesAreUnchanged(db);
             Assert.Single(found.locations, l => l.longitude == 4.4m);
 
-            // Known limitation of EF is you can't remove last item after a change in collection
-            // EF Issue #19135 would address that or moving entirely from owned entities to complex types in EF9
-            // found.locations.Clear();
-            // db.SaveChanges();
+            await SaveChanges(db, async);
+            AssertAllEntriesAreUnchanged(db);
+
+            found.locations.Clear();
+            await SaveChanges(db, async);
         }
 
-        // {
-        //     using var db = SingleEntityDbContext.Create(collection);
-        //     var found = db.Entities.Single();
-        //
-        //     Assert.Empty(found.locations);
-        // }
+        {
+            await using var db = SingleEntityDbContext.Create(collection);
+            var found = db.Entities.Single();
+
+            Assert.Empty(found.locations);
+        }
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OwnedEntity_with_nested_collection_adjusted_correctly(bool async)
+    {
+        var collection = database.CreateCollection<FirstLevel>(values: [async]);
+
+        {
+            await using var db = SingleEntityDbContext.Create(collection);
+
+            var original = new FirstLevel
+            {
+                _id = Guid.NewGuid(),
+                day = DayOfWeek.Monday,
+                reference = new() { name = "ref", day = DayOfWeek.Friday },
+                children =
+                [
+                    new SecondLevel
+                    {
+                        day = DayOfWeek.Tuesday,
+                        children =
+                        [
+                            new ThirdLevel { name = "A", day = DayOfWeek.Wednesday, reference = new() { name = "refA", day = DayOfWeek.Thursday } },
+                            new ThirdLevel { name = "B", day = DayOfWeek.Thursday, reference = new() { name = "refB", day = DayOfWeek.Friday } }
+                        ]
+                    }
+                ]
+            };
+
+            db.Entities.Add(original);
+            await SaveChanges(db, async);
+            AssertAllEntriesAreUnchanged(db);
+
+            // Add a second SecondLevel with its own children
+            original.children.Add(new SecondLevel
+            {
+                day = DayOfWeek.Saturday,
+                children = [new ThirdLevel { name = "C", day = DayOfWeek.Sunday, reference = new() { name = "refC", day = DayOfWeek.Monday } }]
+            });
+            await SaveChanges(db, async);
+            AssertAllEntriesAreUnchanged(db);
+
+            Assert.Equal(2, original.children.Count);
+        }
+
+        {
+            await using var db = SingleEntityDbContext.Create(collection);
+
+            var found = db.Entities.Single();
+            Assert.Equal(2, found.children.Count);
+            Assert.Equal(2, found.children[0].children.Count);
+            Assert.Single(found.children[1].children);
+
+            // Remove first child from nested collection
+            found.children[0].children.RemoveAt(0);
+            await SaveChanges(db, async);
+            AssertAllEntriesAreUnchanged(db);
+            Assert.Single(found.children[0].children, c => c.name == "B");
+
+            // Remove first SecondLevel entirely
+            found.children.RemoveAt(0);
+            await SaveChanges(db, async);
+            AssertAllEntriesAreUnchanged(db);
+            Assert.Single(found.children, c => c.day == DayOfWeek.Saturday);
+
+            // Verify no spurious changes on subsequent save
+            await SaveChanges(db, async);
+            AssertAllEntriesAreUnchanged(db);
+        }
+
+        {
+            await using var db = SingleEntityDbContext.Create(collection);
+            var found = db.Entities.Single();
+
+            Assert.Single(found.children);
+            Assert.Single(found.children[0].children, c => c.name == "C");
+        }
+    }
+
+    private static async Task SaveChanges(DbContext db, bool async)
+    {
+        if (async)
+            await db.SaveChangesAsync();
+        else
+            db.SaveChanges();
+    }
+
+    private static void AssertAllEntriesAreUnchanged<T>(SingleEntityDbContext<T> db) where T : class
+        => Assert.All(db.ChangeTracker.Entries(), e => Assert.Equal(EntityState.Unchanged, e.State));
 
     [Fact]
     public void OwnedEntity_with_two_owned_entities_materializes()

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -42,10 +42,8 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_nested_one_level_materializes_single_get_only()
     {
         database.CreateCollection<PersonWithLocation>().WriteTestDocs(PersonWithLocation1);
-        using var db = SingleEntityDbContext.Create(database.GetCollection<PersonWithGetOnlyLocation>(), mb =>
-        {
-            mb.Entity<PersonWithGetOnlyLocation>().OwnsOne(p => p.location);
-        });
+        using var db = SingleEntityDbContext.Create(database.GetCollection<PersonWithGetOnlyLocation>(),
+            mb => { mb.Entity<PersonWithGetOnlyLocation>().OwnsOne(p => p.location); });
 
         var actual = db.Entities.Single();
 
@@ -72,7 +70,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_nested_one_level_where_null()
     {
         var collection = database.CreateCollection<PersonWithOptionalLocation>();
-        collection.WriteTestDocs([new PersonWithOptionalLocation {_id = ObjectId.GenerateNewId(), name = "Milton"}]);
+        collection.WriteTestDocs([new PersonWithOptionalLocation { _id = ObjectId.GenerateNewId(), name = "Milton" }]);
         using var db = SingleEntityDbContext.Create(collection);
 
         var actual = db.Entities.Where(e => e.location == null).First();
@@ -155,7 +153,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_missing_document_element_does_not_throw()
     {
         database.CreateCollection<Person>().WriteTestDocs([
-            new Person {name = "Bill"}
+            new Person { name = "Bill" }
         ]);
 
         var collection = database.GetCollection<PersonWithOptionalLocation>();
@@ -214,7 +212,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_materializes_when_missing_non_required_owned_entity()
     {
         var collection = database.CreateCollection<Person>();
-        collection.WriteTestDocs([new Person {name = "Henry"}]);
+        collection.WriteTestDocs([new Person { name = "Henry" }]);
         using var db = SingleEntityDbContext.Create(database.GetCollection<PersonWithLocation>(),
             mb => { mb.Entity<PersonWithLocation>().Navigation(p => p.location).IsRequired(false); });
 
@@ -258,7 +256,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     {
         var collection = database.CreateCollection<PersonWithLocation>();
         var expected =
-            new PersonWithLocation {name = "Charlie", location = new Location {latitude = 1.234m, longitude = 1.567m}};
+            new PersonWithLocation { name = "Charlie", location = new Location { latitude = 1.234m, longitude = 1.567m } };
 
         {
             using var db = SingleEntityDbContext.Create(collection);
@@ -288,9 +286,9 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             name = "Alfred",
             locations =
             [
-                new() {latitude = 1.234m, longitude = 1.567m},
+                new() { latitude = 1.234m, longitude = 1.567m },
 
-                new() {latitude = 5.1m, longitude = 3.9m}
+                new() { latitude = 5.1m, longitude = 3.9m }
             ]
         };
 
@@ -319,7 +317,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
 
         var id = ObjectId.GenerateNewId();
         var expectedName = Guid.NewGuid().ToString();
-        var expectedLocation = new Location {latitude = 1.234m, longitude = 1.567m};
+        var expectedLocation = new Location { latitude = 1.234m, longitude = 1.567m };
 
         var modelBuilder = (ModelBuilder mb) =>
         {
@@ -337,7 +335,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
 
         {
             using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
-            dbContext.Entities.Add(new PersonWithLocation {_id = id, name = expectedName, location = expectedLocation});
+            dbContext.Entities.Add(new PersonWithLocation { _id = id, name = expectedName, location = expectedLocation });
             dbContext.SaveChanges();
         }
 
@@ -357,7 +355,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
 
         var id = ObjectId.GenerateNewId();
         var expectedName = Guid.NewGuid().ToString();
-        var expectedLocation = new Location {latitude = 1.234m, longitude = 1.567m};
+        var expectedLocation = new Location { latitude = 1.234m, longitude = 1.567m };
 
         var modelBuilder = (ModelBuilder mb) =>
         {
@@ -375,7 +373,8 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
 
         {
             using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
-            dbContext.Entities.Add(new PersonWithMultipleLocations {_id = id, name = expectedName, locations = [expectedLocation]});
+            dbContext.Entities.Add(
+                new PersonWithMultipleLocations { _id = id, name = expectedName, locations = [expectedLocation] });
             dbContext.SaveChanges();
         }
 
@@ -419,7 +418,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     {
         var collection = database.CreateCollection<SimpleNonNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([
-            new SimpleNonNullableCollection {children = []}
+            new SimpleNonNullableCollection { children = [] }
         ]);
         using var db = SingleEntityDbContext.Create(
             collection,
@@ -437,7 +436,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     {
         var collection = database.CreateCollection<SimpleNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([
-            new SimpleNullableCollection {children = []}
+            new SimpleNullableCollection { children = [] }
         ]);
         using var db = SingleEntityDbContext.Create(
             collection,
@@ -456,7 +455,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     {
         var collection = database.CreateCollection<SimpleNonNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([
-            new SimpleNonNullableCollection {children = null!}
+            new SimpleNonNullableCollection { children = null! }
         ]);
         using var db = SingleEntityDbContext.Create(
             collection,
@@ -474,7 +473,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     {
         var collection = database.CreateCollection<SimpleNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([
-            new SimpleNullableCollection {children = null}
+            new SimpleNullableCollection { children = null }
         ]);
         using var db = SingleEntityDbContext.Create(
             collection,
@@ -569,20 +568,18 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     [Fact]
     public void OwnedEntity_with_ienumerable_collection_materializes_many()
     {
-        var expectedLocation = new Location {latitude = 1.01m, longitude = 1.02m};
+        var expectedLocation = new Location { latitude = 1.01m, longitude = 1.02m };
         var collection = database.CreateCollection<PersonWithIEnumerableLocations>();
         collection.WriteTestDocs([
             new()
             {
-                _id = ObjectId.GenerateNewId(),
-                name = "IEnumerableRound1",
-                locations = new List<Location> {expectedLocation}
+                _id = ObjectId.GenerateNewId(), name = "IEnumerableRound1", locations = new List<Location> { expectedLocation }
             },
             new()
             {
                 _id = ObjectId.GenerateNewId(),
                 name = "IEnumerableRound2",
-                locations = new List<Location> {new() {latitude = 1.03m, longitude = 1.04m}}
+                locations = new List<Location> { new() { latitude = 1.03m, longitude = 1.04m } }
             }
         ]);
 
@@ -601,7 +598,9 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         var collection = database.CreateCollection<PersonWithIEnumerableLocations>();
         var entity = new PersonWithIEnumerableLocations
         {
-            _id = ObjectId.GenerateNewId(), name = "IEnumerableSerialize", locations = new List<Location> {Location1, Location2}
+            _id = ObjectId.GenerateNewId(),
+            name = "IEnumerableSerialize",
+            locations = new List<Location> { Location1, Location2 }
         };
 
         {
@@ -632,7 +631,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         {
             _id = ObjectId.GenerateNewId(),
             name = "IEnumerableSerialize",
-            locations = EnumerableOnlyWrapper.Wrap(new List<Location> {Location1, Location2})
+            locations = EnumerableOnlyWrapper.Wrap(new List<Location> { Location1, Location2 })
         };
 
         var ex = Assert.Throws<InvalidOperationException>(() => db.Entities.Add(entity));
@@ -656,7 +655,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
                 name = "Many updates",
                 locations =
                 [
-                    new Location {latitude = 1.1m, longitude = 2.2m}
+                    new Location { latitude = 1.1m, longitude = 2.2m }
                 ]
             };
 
@@ -664,7 +663,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             await SaveChanges(db, async);
             Assert.Single(original.locations, l => l.latitude == 1.1m);
 
-            original.locations.Add(new() {latitude = 3.3m, longitude = 4.4m});
+            original.locations.Add(new() { latitude = 3.3m, longitude = 4.4m });
             await SaveChanges(db, async);
 
             Assert.Equal(2, original.locations.Count);
@@ -703,37 +702,36 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     {
         var collection = database.CreateCollection<PersonWithMultipleLocations>(values: [async]);
 
-        await using var db = SingleEntityDbContext.Create(collection);
-
-        var entity = new PersonWithMultipleLocations
+        await using var originalDb = SingleEntityDbContext.Create(collection);
+        var originalEntity = new PersonWithMultipleLocations
         {
             _id = ObjectId.GenerateNewId(),
             name = "Original",
             locations =
             [
-                new Location {latitude = 1.1m, longitude = 2.2m},
-                new Location {latitude = 3.3m, longitude = 4.4m}
+                new Location { latitude = 1.1m, longitude = 2.2m },
+                new Location { latitude = 3.3m, longitude = 4.4m }
             ]
         };
+        originalDb.Entities.Add(originalEntity);
+        await SaveChanges(originalDb, async);
 
-        db.Entities.Add(entity);
-        await SaveChanges(db, async);
-
-        // Use a second context to modify only the name field externally
+        // Use a second context to modify only the name field independently
         {
-            await using var secondDb = SingleEntityDbContext.Create(collection);
-            var found = db.Entities.Single();
+            await using var modificationDb = SingleEntityDbContext.Create(collection);
+            var found = modificationDb.Entities.Single();
             found.name = "Externally modified";
-            await SaveChanges(secondDb, async);
+            await SaveChanges(modificationDb, async);
         }
 
-        entity.locations.RemoveAt(0);
-        await SaveChanges(db, async);
+        // Trigger the owned entity update pipeline
+        originalEntity.locations.RemoveAt(0);
+        await SaveChanges(originalDb, async);
 
+        // Validate that the root entity was not written to
         {
-            await using var thirdDb = SingleEntityDbContext.Create(collection);
-
-            var found = db.Entities.Single();
+            await using var validationDb = SingleEntityDbContext.Create(collection);
+            var found = validationDb.Entities.Single();
             Assert.Equal("Externally modified", found.name);
             Assert.Single(found.locations);
         }
@@ -761,8 +759,18 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
                         day = DayOfWeek.Tuesday,
                         children =
                         [
-                            new ThirdLevel { name = "A", day = DayOfWeek.Wednesday, reference = new() { name = "refA", day = DayOfWeek.Thursday } },
-                            new ThirdLevel { name = "B", day = DayOfWeek.Thursday, reference = new() { name = "refB", day = DayOfWeek.Friday } }
+                            new ThirdLevel
+                            {
+                                name = "A",
+                                day = DayOfWeek.Wednesday,
+                                reference = new() { name = "refA", day = DayOfWeek.Thursday }
+                            },
+                            new ThirdLevel
+                            {
+                                name = "B",
+                                day = DayOfWeek.Thursday,
+                                reference = new() { name = "refB", day = DayOfWeek.Friday }
+                            }
                         ]
                     }
                 ]
@@ -776,7 +784,13 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             original.children.Add(new SecondLevel
             {
                 day = DayOfWeek.Saturday,
-                children = [new ThirdLevel { name = "C", day = DayOfWeek.Sunday, reference = new() { name = "refC", day = DayOfWeek.Monday } }]
+                children =
+                [
+                    new ThirdLevel
+                    {
+                        name = "C", day = DayOfWeek.Sunday, reference = new() { name = "refC", day = DayOfWeek.Monday }
+                    }
+                ]
             });
             await SaveChanges(db, async);
             AssertAllEntriesAreUnchanged(db);
@@ -851,7 +865,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_with_two_owned_entities_creates()
     {
         var collection = database.CreateCollection<PersonWithTwoLocations>();
-        PersonWithTwoLocations expected = new() {name = "Elizabeth", first = Location2, second = Location1};
+        PersonWithTwoLocations expected = new() { name = "Elizabeth", first = Location2, second = Location1 };
 
         {
             using var db = SingleEntityDbContext.Create(collection);
@@ -935,7 +949,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     [Fact]
     public void OwnedEntity_can_have_element_name_set_for_same_types()
     {
-        var expected = new PersonWithTwoLocationsRemapped {name = "Elizabeth", locationOne = Location1, locationTwo = Location2};
+        var expected = new PersonWithTwoLocationsRemapped { name = "Elizabeth", locationOne = Location1, locationTwo = Location2 };
 
         database.CreateCollection<PersonWithTwoLocationsRemapped>().WriteTestDocs([expected]);
 
@@ -1007,11 +1021,11 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_collection_can_be_tested_for_not_null()
     {
         var collection = database.CreateCollection<A>();
-        var expected = new A {_id = "1", children = [new B {name = "child1"}, new B {name = "child2"}]};
+        var expected = new A { _id = "1", children = [new B { name = "child1" }, new B { name = "child2" }] };
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entities.AddRange(expected, new A {_id = "2", children = null!});
+            db.Entities.AddRange(expected, new A { _id = "2", children = null! });
             db.SaveChanges();
         }
 
@@ -1026,11 +1040,11 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_collection_field_can_be_tested_for_not_null()
     {
         var collection = database.CreateCollection<AField>();
-        var expected = new AField {_id = "1", children = [new B {name = "child1"}, new B {name = "child2"}]};
+        var expected = new AField { _id = "1", children = [new B { name = "child1" }, new B { name = "child2" }] };
 
         {
             using var db = SingleEntityDbContext.Create(collection, mb => mb.Entity<AField>().OwnsMany(f => f.children));
-            db.Entities.AddRange(expected, new AField {_id = "2", children = null!});
+            db.Entities.AddRange(expected, new AField { _id = "2", children = null! });
             db.SaveChanges();
         }
 
@@ -1045,11 +1059,11 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_collection_can_be_tested_for_null()
     {
         var collection = database.CreateCollection<A>();
-        var expected = new A {_id = "1"};
+        var expected = new A { _id = "1" };
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entities.AddRange(expected, new A {_id = "2", children = [new B {name = "child1"}, new B {name = "child2"}]});
+            db.Entities.AddRange(expected, new A { _id = "2", children = [new B { name = "child1" }, new B { name = "child2" }] });
             db.SaveChanges();
         }
 
@@ -1064,11 +1078,12 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     public void OwnedEntity_collection_field_can_be_tested_for_null()
     {
         var collection = database.CreateCollection<AField>();
-        var expected = new AField {_id = "1"};
+        var expected = new AField { _id = "1" };
 
         {
             using var db = SingleEntityDbContext.Create(collection, mb => mb.Entity<AField>().OwnsMany(f => f.children));
-            db.Entities.AddRange(expected, new AField {_id = "2", children = [new B {name = "child1"}, new B {name = "child2"}]});
+            db.Entities.AddRange(expected,
+                new AField { _id = "2", children = [new B { name = "child1" }, new B { name = "child2" }] });
             db.SaveChanges();
         }
 
@@ -1128,7 +1143,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         {
             docs.InsertOne(new BsonDocument("_id", id)
             {
-                ["children"] = new BsonArray {new BsonDocument("name", "child1"), new BsonDocument("name", "child2")}
+                ["children"] = new BsonArray { new BsonDocument("name", "child1"), new BsonDocument("name", "child2") }
             });
         }
 
@@ -1301,53 +1316,53 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         public string Name { get; set; }
     }
 
-    private static readonly City City1 = new() {name = "San Diego"};
+    private static readonly City City1 = new() { name = "San Diego" };
 
     private static readonly LocationWithCity LocationWithCity1 =
-        new() {latitude = 32.715736m, longitude = -117.161087m, city = City1};
+        new() { latitude = 32.715736m, longitude = -117.161087m, city = City1 };
 
     private static readonly PersonWithCity[] PersonWithCity1 =
     [
-        new() {name = "Carmen", location = LocationWithCity1}
+        new() { name = "Carmen", location = LocationWithCity1 }
     ];
 
-    private static readonly Location Location1 = new() {latitude = 32.715736m, longitude = -117.161087m};
+    private static readonly Location Location1 = new() { latitude = 32.715736m, longitude = -117.161087m };
 
     private static readonly PersonWithLocation[] PersonWithLocation1 =
     [
-        new() {name = "Carmen", location = Location1}
+        new() { name = "Carmen", location = Location1 }
     ];
 
     private static readonly PersonWithLocation[] Person2WithLocation1 =
     [
-        new() {name = "Milton", location = Location1}
+        new() { name = "Milton", location = Location1 }
     ];
 
     private static readonly PersonWithLocation[] PersonWithMissingLocation1 =
     [
-        new() {name = "Elizabeth"}
+        new() { name = "Elizabeth" }
     ];
 
-    private static readonly Location Location2 = new() {latitude = 49.45981m, longitude = -2.53527m};
+    private static readonly Location Location2 = new() { latitude = 49.45981m, longitude = -2.53527m };
 
-    private static readonly Location Location3 = new() {latitude = 40.1m, longitude = -1.1m};
+    private static readonly Location Location3 = new() { latitude = 40.1m, longitude = -1.1m };
 
     private static readonly PersonWithMultipleLocations[] PersonWithLocations1 =
     [
-        new() {name = "Damien", locations = [Location2, Location1]},
-        new() {name = "Carmen", locations = [Location3]},
+        new() { name = "Damien", locations = [Location2, Location1] },
+        new() { name = "Carmen", locations = [Location3] },
     ];
 
     private static readonly PersonWithTwoLocations[] PersonWithTwoLocations1 =
     [
-        new() {name = "Henry", first = Location1, second = Location2}
+        new() { name = "Henry", first = Location1, second = Location2 }
     ];
 
     private static readonly FirstLevel FirstLevel1 = new()
     {
         _id = Guid.NewGuid(),
         day = DayOfWeek.Monday,
-        reference = new() {day = DayOfWeek.Friday, name = "This is the first level name"},
+        reference = new() { day = DayOfWeek.Friday, name = "This is the first level name" },
         children =
         [
             new SecondLevel
@@ -1359,7 +1374,7 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
                     {
                         name = "This is the third level name",
                         day = DayOfWeek.Wednesday,
-                        reference = new() {name = "This is the item reference name", day = DayOfWeek.Thursday}
+                        reference = new() { name = "This is the item reference name", day = DayOfWeek.Thursday }
                     }
                 ]
             }


### PR DESCRIPTION
Fixes [EF-293](https://github.com/dotnet/efcore/issues/33687) which reported owned entities were causing an exception if saved more than once after some types of modification to the collection.

There were three issue involved in this:

## Issue 1: Promoted root entities

When only an owned entity changes (e.g. removing a collection item), the root document is `Unchanged` from EF's perspective. Our `GetAllChangedRootEntries` promotes it to `Modified` for writing, but EF's `AcceptAllChanges` only processes its original entries list with the root staying permanently `Modified`.

**Fix:** Add promoted roots to EF's `entries` list so `AcceptAllChanges` processes them. This matches how the EF Cosmos provider handles the same scenario in (`CosmosDatabaseWrapper.cs:76-82`).

## Issue 2: Ordinal key marking

`SetStoreGeneratedValue` on ordinal key properties used the default overload which set the modified as true, which could mark owned entity entries as `Modified` even though they were `Unchanged` before save.

**Fix:** Pass `setModified: false`, matching the intent already expressed in `SetTemporaryOrdinals`. Safe because ordinal keys are immutable shadow key properties as EF doesn't run change detection on them.

Note that [Cosmos has this issue too](https://github.com/dotnet/efcore/issues/33687).

## Issue 3: FK cascade to nested owned entities

When ordinal keys are reassigned on collection items (e.g. after removing an item), EF's relationship fixup cascades the key change to FK properties on nested owned entities (e.g. a `Reference` owned by a `ThirdLevel` in a collection). This marks those nested entries as `Modified`, but they aren't in EF's entries list either.  I discovered this while adding an extra test for nested owned entity updates.

**Fix:** After materializing updates (which triggers ordinal reassignment and FK cascade), scan the state manager for any non-root entries promoted to `Modified` and add them to the entries list. The scan is scoped to non-root entities only to avoid interfering with entries EF manages directly.