### PR TITLE
EF-76: Select push-down support for mixed projections

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet test:*)",
+      "Bash(dotnet build:*)"
+    ]
+  }
+}

--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: test-all
+description: Build and run tests against all three EF version targets (EF8, EF9, EF10)
+argument-hint: "[optional: test filter or project name]"
+allowed-tools: Bash(dotnet *), Bash(docker *), Write, Read, Glob, Grep
+---
+
+# Test All EF Versions
+
+Build and run tests against all three EF Core version targets: **EF8**, **EF9**, and **EF10**.
+
+## Arguments
+
+`$ARGUMENTS` is an optional filter:
+- If empty, run all tests across all three versions.
+- If it looks like a test project name (e.g., "UnitTests", "FunctionalTests", "SpecificationTests"), run only that project.
+- If it looks like a test filter (e.g., a class or method name), pass it via `--filter` to `dotnet test`.
+
+## Phase 1: Pre-flight Checks (MUST pass before anything else)
+
+Run these checks first. If **any** fail, stop immediately and report the failure — do not proceed to build or test.
+
+1. **net10.0 SDK** — Run `dotnet --list-sdks` and verify a 10.x SDK is installed. If missing, stop with a clear error: "net10.0 SDK is not installed. Install it from https://dotnet.microsoft.com/download/dotnet/10.0".
+
+2. **Database connectivity** — Check that either:
+   - Docker is available (`docker info` succeeds) so Testcontainers can work, OR
+   - `MONGODB_URI` environment variable is set.
+   If neither condition is met, stop with: "No database available. Either start Docker or set MONGODB_URI=mongodb://localhost:27017".
+
+Report pre-flight status before continuing:
+```
+Pre-flight checks:
+  net10.0 SDK: OK (10.x.xxx)
+  Database: OK (Docker available) | OK (MONGODB_URI set)
+```
+
+## Phase 2: Parallel Build
+
+Build all three versions **in parallel** — each config outputs to its own `bin/` subfolder so there are no conflicts.
+
+```
+dotnet build E:/src/mongo-ef/main/MongoDB.EFCoreProvider.sln -c "Debug EF{version}" -v quiet
+```
+
+Run all three `dotnet build` commands simultaneously using parallel Bash tool calls.
+
+If any build fails, report the failure but **still run tests for versions that built successfully**.
+
+## Phase 3: Parallel Test
+
+After builds complete, run tests for all successfully-built versions **in parallel**.
+
+Test (no filter):
+```
+dotnet test E:/src/mongo-ef/main/MongoDB.EFCoreProvider.sln -c "Debug EF{version}" --no-build --logger "console;verbosity=normal" -v quiet
+```
+
+Test (with project filter):
+```
+dotnet test E:/src/mongo-ef/main/tests/MongoDB.EntityFrameworkCore.{project} -c "Debug EF{version}" --no-build --logger "console;verbosity=normal" -v quiet
+```
+
+Test (with test name filter):
+```
+dotnet test E:/src/mongo-ef/main/MongoDB.EFCoreProvider.sln -c "Debug EF{version}" --no-build --filter "{filter}" --logger "console;verbosity=normal" -v quiet
+```
+
+## Important Rules
+
+- **Always use absolute paths** — never `cd` into directories.
+- **Quote configuration names** — they contain spaces (e.g., `"Debug EF8"`).
+- **Parallel is safe** — each EF version builds into a separate output directory (`bin/Debug EF8/`, etc.).
+- **Continue on failure** — if one version fails build or tests, still run the remaining versions.
+- Do NOT set `MONGODB_URI` unless the pre-flight check determined Docker is unavailable and `MONGODB_URI` is already set.
+
+## Phase 4: Write Results Files
+
+Write a markdown results file for **each EF version** to `E:/src/mongo-ef/main/artifacts/test-results/`. Create the directory if it doesn't exist.
+
+Filename: `test-results-ef{version}.md` (e.g., `test-results-ef8.md`)
+
+Each file should contain:
+
+```markdown
+# Test Results — EF{version}
+
+**Date:** {ISO 8601 timestamp}
+**Configuration:** Debug EF{version}
+**Overall:** PASS | FAIL
+
+## Summary
+
+| Metric       | Count |
+|-------------|-------|
+| Passed       | N     |
+| Failed       | N     |
+| Skipped      | N     |
+| Total        | N     |
+
+## Build
+
+{Build output or "OK"}
+
+## Failed Tests
+
+{List each failed test with its error message, or "None" if all passed}
+
+## Full Output
+
+<details>
+<summary>Complete test output</summary>
+
+```
+{raw dotnet test console output}
+```
+
+</details>
+```
+
+## Phase 5: Console Summary
+
+After writing result files, present a **summary table** to the user:
+
+```
+| Version | Build  | Tests Passed | Tests Failed | Tests Skipped | Results File |
+|---------|--------|-------------|-------------|---------------|--------------|
+| EF8     | OK     | 142         | 0           | 3             | artifacts/test-results/test-results-ef8.md |
+| EF9     | OK     | 145         | 2           | 1             | artifacts/test-results/test-results-ef9.md |
+| EF10    | OK     | 148         | 0           | 0             | artifacts/test-results/test-results-ef10.md |
+```
+
+If any version had failures, list the failing test names grouped by version below the table.
+
+If a build failed, show the error in the Build column and "skipped" in the test columns.

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -1,0 +1,138 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Storage;
+
+namespace MongoDB.EntityFrameworkCore.Query.Visitors;
+
+/// <summary>
+/// Extends <see cref="MongoProjectionBindingRemovingExpressionVisitor"/> to handle mixed projections
+/// (containing both entity references and scalar properties). In this path, the LINQ V3 query
+/// returns full BsonDocuments (Select is stripped), and scalars are read from the root document
+/// using the property's actual serialization info rather than the projection alias.
+/// </summary>
+internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
+    : MongoProjectionBindingRemovingExpressionVisitor
+{
+    private readonly MongoQueryExpression _queryExpression;
+    private readonly IEntityType _rootEntityType;
+    private readonly ParameterExpression _docParameter;
+
+    public MongoMixedProjectionBindingRemovingExpressionVisitor(
+        IEntityType rootEntityType,
+        MongoQueryExpression queryExpression,
+        ParameterExpression docParameter,
+        bool trackQueryResults)
+        : base(rootEntityType, queryExpression, docParameter, trackQueryResults)
+    {
+        _queryExpression = queryExpression;
+        _rootEntityType = rootEntityType;
+        _docParameter = docParameter;
+    }
+
+    protected override Expression VisitExtension(Expression extensionExpression)
+    {
+        if (extensionExpression is ProjectionBindingExpression projectionBindingExpression)
+        {
+            // Scalar projections in the mixed path use ProjectionMember (not Index) because
+            // ApplyProjection() early-returns when entity projections already populated _projection.
+            if (projectionBindingExpression.ProjectionMember != null)
+            {
+                var mappedExpression = _queryExpression.GetMappedProjection(
+                    projectionBindingExpression.ProjectionMember);
+
+                // If ApplyProjection already converted this to an index, use the standard path.
+                if (mappedExpression is ConstantExpression { Value: int })
+                {
+                    return base.VisitExtension(extensionExpression);
+                }
+
+                // Resolve the IProperty from the mapped expression and read from the full document.
+                var (property, fieldName) = TryResolveFieldAccess(mappedExpression);
+                if (property != null)
+                {
+                    return CreateGetValueExpression(_docParameter, property, projectionBindingExpression.Type);
+                }
+
+                if (fieldName != null)
+                {
+                    // Non-model field (e.g., __score from $addFields) — read directly by name.
+                    return BsonBinding.CreateGetElementValue(_docParameter, fieldName, projectionBindingExpression.Type);
+                }
+
+                // Fallback: read by projection member name from the root document.
+                return CreateGetValueExpression(
+                    _docParameter,
+                    projectionBindingExpression.ProjectionMember.Last?.Name,
+                    !projectionBindingExpression.Type.IsNullableType(),
+                    projectionBindingExpression.Type);
+            }
+
+            // Index-based bindings are used for entity projections (set by MongoProjectionBindingExpressionVisitor).
+            // Delegate to the base visitor which handles entity materialization.
+            return base.VisitExtension(extensionExpression);
+        }
+
+        return base.VisitExtension(extensionExpression);
+    }
+
+    /// <summary>
+    /// Attempts to resolve an <see cref="IProperty"/> and/or field name from a projection expression that
+    /// represents a scalar property access on the entity (e.g., <c>p.name</c>) or a non-model field
+    /// access (e.g., <c>Mql.Field(e, "__score", null)</c>).
+    /// </summary>
+    private (IProperty? property, string? fieldName) TryResolveFieldAccess(Expression expression)
+    {
+        // Unwrap converts
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        if (expression is MemberExpression memberExpression)
+        {
+            var property = _rootEntityType.FindProperty(memberExpression.Member);
+            return (property, property != null ? null : memberExpression.Member.Name);
+        }
+
+        if (expression is MethodCallExpression methodCall)
+        {
+            // Handle EF.Property<T>(entity, "propertyName") method calls
+            if (methodCall.Method.IsEFPropertyMethod()
+                && methodCall.Arguments[1] is ConstantExpression { Value: string propertyName })
+            {
+                var property = _rootEntityType.FindProperty(propertyName);
+                return (property, property != null ? null : propertyName);
+            }
+
+            // Handle Mql.Field<TDoc, TField>(entity, "fieldName", serializer) calls
+            if (methodCall.Method is { Name: "Field", DeclaringType.FullName: "MongoDB.Driver.Mql" }
+                && methodCall.Arguments[1] is ConstantExpression { Value: string fieldName })
+            {
+                var property = _rootEntityType.FindProperty(fieldName);
+                return (property, property != null ? null : fieldName);
+            }
+        }
+
+        return (null, null);
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -119,6 +119,13 @@ internal sealed class MongoProjectionBindingExpressionVisitor : ExpressionVisito
 
                 return new ProjectionBindingExpression(_queryExpression, currentProjectionMember, expression.Type);
 
+            case MethodCallExpression methodCallExpression
+                when IsScalarMethodPropertyAccess(methodCallExpression):
+                var projMember = GetCurrentProjectionMember();
+                _projectionMapping[projMember] = methodCallExpression;
+
+                return new ProjectionBindingExpression(_queryExpression, projMember, expression.Type);
+
             default:
                 return base.Visit(expression);
         }
@@ -522,6 +529,35 @@ internal sealed class MongoProjectionBindingExpressionVisitor : ExpressionVisito
 
     private void ExitProjectionMember()
         => _projectionMembers.Pop();
+
+    /// <summary>
+    /// Checks whether a method call expression represents a scalar property access that should
+    /// be stored in the projection mapping (like <see cref="MemberExpression"/>), rather than
+    /// being fully visited. This covers <c>EF.Property</c> (for non-navigation properties) and
+    /// <c>Mql.Field</c> calls.
+    /// </summary>
+    private static bool IsScalarMethodPropertyAccess(MethodCallExpression methodCallExpression)
+    {
+        if (methodCallExpression.TryGetEFPropertyArguments(out var source, out var memberName))
+        {
+            if (source is StructuralTypeShaperExpression { StructuralType: IEntityType entityType })
+            {
+                var navigation = entityType.FindNavigation(memberName);
+                // Embedded navigations should be handled by VisitMethodCall
+                return navigation == null || !navigation.IsEmbedded();
+            }
+
+            return false;
+        }
+
+        // Mql.Field<TDoc, TField>() is always a scalar field extraction
+        if (methodCallExpression.Method is { Name: "Field", DeclaringType.FullName: "MongoDB.Driver.Mql" })
+        {
+            return true;
+        }
+
+        return false;
+    }
 
     private static Expression MatchTypes(
         Expression expression,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -330,7 +330,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         return base.VisitMethodCall(methodCallExpression);
     }
 
-    private Expression CreateGetValueExpression(
+    protected Expression CreateGetValueExpression(
         Expression docExpression,
         IProperty property,
         Type type)

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -86,10 +86,10 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         IEntityType rootEntityType,
         MongoQueryExpression mongoQueryExpression)
     {
+        VerifyNoClientConstant(shapedQueryExpression.ShaperExpression);
+
         if (ProjectionAnalyzer.CanPushDown(shapedQueryExpression.ShaperExpression))
         {
-            VerifyNoClientConstant(shapedQueryExpression.ShaperExpression);
-
             // Push-down path: scalar/anonymous projections handled entirely by LINQ V3
             return Expression.Call(null,
                 ExecuteProjectedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -60,8 +60,9 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
     protected override Expression VisitShapedQuery(ShapedQueryExpression shapedQueryExpression)
     {
         if (shapedQueryExpression.QueryExpression is not MongoQueryExpression mongoQueryExpression)
-            throw new NotSupportedException(
-                $" Unhandled expression node type '{nameof(shapedQueryExpression.QueryExpression)}'");
+        {
+            throw new NotSupportedException($" Unhandled expression node type '{nameof(shapedQueryExpression.QueryExpression)}'");
+        }
 
         var rootEntityType = mongoQueryExpression.CollectionExpression.EntityType;
         var projectedEntityType = QueryCompilationContext.Model.FindEntityType(
@@ -69,12 +70,29 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
                 ? shapedQueryExpression.Type.TryGetItemType()!
                 : shapedQueryExpression.Type);
 
-        // TODO: Handle select expressions and non-EF shapers more comprehensively
         if (projectedEntityType == null)
         {
-            // We are relying on raw/scalar values coming back from LINQ V3 provider for now - no shaper required
+            return VisitProjectedQuery(shapedQueryExpression, rootEntityType, mongoQueryExpression);
+        }
+
+        // Entity path: full BsonDocuments shaped into tracked/untracked entity instances
+        return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
+            (bsonDoc, track) => new MongoProjectionBindingRemovingExpressionVisitor(
+                rootEntityType, mongoQueryExpression, bsonDoc, track));
+    }
+
+    private MethodCallExpression VisitProjectedQuery(
+        ShapedQueryExpression shapedQueryExpression,
+        IEntityType rootEntityType,
+        MongoQueryExpression mongoQueryExpression)
+    {
+        if (ProjectionAnalyzer.CanPushDown(shapedQueryExpression.ShaperExpression))
+        {
+            VerifyNoClientConstant(shapedQueryExpression.ShaperExpression);
+
+            // Push-down path: scalar/anonymous projections handled entirely by LINQ V3
             return Expression.Call(null,
-                TranslateAndExecuteUnshapedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType,
+                ExecuteProjectedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType,
                     shapedQueryExpression.ShaperExpression.Type),
                 QueryCompilationContext.QueryContextParameter,
                 Expression.Constant(rootEntityType),
@@ -85,6 +103,25 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
                 Expression.Constant(shapedQueryExpression.ResultCardinality));
         }
 
+        // Mixed path: projection contains entity references that LINQ V3 can't handle.
+        // Strip the Select, return full BsonDocuments, and build a client-side shaper.
+        if (mongoQueryExpression.CapturedExpression is MethodCallExpression
+                { Method: { Name: "Select", DeclaringType.Name: "Queryable" } } selectCall)
+        {
+            mongoQueryExpression.CapturedExpression = selectCall.Arguments[0];
+        }
+
+        return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
+            (bsonDoc, track) => new MongoMixedProjectionBindingRemovingExpressionVisitor(
+                rootEntityType, mongoQueryExpression, bsonDoc, track));
+    }
+
+    private MethodCallExpression CompileShapedQuery(
+        ShapedQueryExpression shapedQueryExpression,
+        MongoQueryExpression mongoQueryExpression,
+        IEntityType rootEntityType,
+        Func<ParameterExpression, bool, System.Linq.Expressions.ExpressionVisitor> createBindingRemover)
+    {
         var bsonDocParameter = Expression.Parameter(typeof(BsonDocument), "bsonDoc");
         var trackQueryResults = QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
 
@@ -95,9 +132,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
 #else
         shaperBody = InjectStructuralTypeMaterializers(shaperBody);
 #endif
-        shaperBody = new MongoProjectionBindingRemovingExpressionVisitor(
-                rootEntityType, mongoQueryExpression, bsonDocParameter, trackQueryResults)
-            .Visit(shaperBody);
+        shaperBody = createBindingRemover(bsonDocParameter, trackQueryResults).Visit(shaperBody);
 
         var shaperLambda = Expression.Lambda(
             shaperBody,
@@ -110,7 +145,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
                                      QueryTrackingBehavior.NoTrackingWithIdentityResolution;
 
         return Expression.Call(null,
-            TranslateAndExecuteQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType, projectedType),
+            ExecuteShapedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType, projectedType),
             QueryCompilationContext.QueryContextParameter,
             Expression.Constant(rootEntityType),
             Expression.Constant(_bsonSerializerFactory),
@@ -122,7 +157,55 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             Expression.Constant(shapedQueryExpression.ResultCardinality));
     }
 
-    private static QueryingEnumerable<TResult, TResult> TranslateAndExecuteUnshapedQuery<TSource, TResult>(
+    private static (MongoQueryContext, MongoExecutableQuery) TranslateQuery<TSource>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoQueryExpression queryExpression,
+        ResultCardinality resultCardinality,
+        Func<MongoEFToLinqTranslatingExpressionVisitor, Expression?, Expression> translate)
+    {
+        var mongoQueryContext = (MongoQueryContext)queryContext;
+        var collection = mongoQueryContext.MongoClient.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
+
+        var transaction = mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction;
+        var queryable = transaction == null ? collection.AsQueryable() : collection.AsQueryable(transaction.Session);
+        var source = queryable.As((IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType));
+
+        var queryTranslator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression, bsonSerializerFactory);
+        var translatedQuery = translate(queryTranslator, queryExpression.CapturedExpression);
+
+        var executableQuery = new MongoExecutableQuery(
+            translatedQuery,
+            resultCardinality,
+            (IMongoQueryProvider)source.Provider,
+            collection.CollectionNamespace,
+            new(queryTranslator.AdditionalState));
+
+        return (mongoQueryContext, executableQuery);
+    }
+
+    private static Action<MongoQueryContext, MongoExecutableQuery>? GetOnZeroResultsAction(MongoQueryExpression queryExpression)
+    {
+        if (queryExpression.CapturedExpression is MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.Name == "Select" && methodCallExpression.Arguments is [MethodCallExpression mce, _])
+            {
+                methodCallExpression = mce;
+            }
+
+            if (methodCallExpression.IsVectorSearch())
+            {
+                return (qc, eq) => qc.QueryLogger.VectorSearchReturnedZeroResults(
+                    (IProperty)eq.AdditionalState[MongoExecutableQuery.VectorQueryProperty],
+                    (string)eq.AdditionalState[MongoExecutableQuery.VectorQueryIndexName]);
+            }
+        }
+
+        return null;
+    }
+
+    private static QueryingEnumerable<TResult, TResult> ExecuteProjectedQuery<TSource, TResult>(
         QueryContext queryContext,
         IReadOnlyEntityType entityType,
         BsonSerializerFactory bsonSerializerFactory,
@@ -131,24 +214,9 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         bool threadSafetyChecksEnabled,
         ResultCardinality resultCardinality)
     {
-        var mongoQueryContext = (MongoQueryContext)queryContext;
-        var serializer = (IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType);
-        var collection = mongoQueryContext.MongoClient.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
-
-        var transaction = mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction;
-        var queryable = transaction == null ? collection.AsQueryable() : collection.AsQueryable(transaction.Session);
-        var source = queryable.As(serializer);
-
-        var queryTranslator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression, bsonSerializerFactory);
-        var translatedQuery = queryTranslator.Visit(queryExpression.CapturedExpression)!;
-
-        var executableQuery =
-            new MongoExecutableQuery(
-                translatedQuery,
-                resultCardinality,
-                (IMongoQueryProvider)source.Provider,
-                collection.CollectionNamespace,
-                new(queryTranslator.AdditionalState));
+        var (mongoQueryContext, executableQuery) = TranslateQuery<TSource>(
+            queryContext, entityType, bsonSerializerFactory, queryExpression, resultCardinality,
+            (translator, expression) => translator.Visit(expression)!);
 
         return new QueryingEnumerable<TResult, TResult>(
             mongoQueryContext,
@@ -157,10 +225,10 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             contextType,
             standAloneStateManager: false,
             threadSafetyChecksEnabled,
-            onZeroResults: null);
+            GetOnZeroResultsAction(queryExpression));
     }
 
-    private static QueryingEnumerable<BsonDocument, TResult> TranslateAndExecuteQuery<TSource, TResult>(
+    private static QueryingEnumerable<BsonDocument, TResult> ExecuteShapedQuery<TSource, TResult>(
         QueryContext queryContext,
         IReadOnlyEntityType entityType,
         BsonSerializerFactory bsonSerializerFactory,
@@ -171,38 +239,9 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         bool threadSafetyChecksEnabled,
         ResultCardinality resultCardinality)
     {
-        var mongoQueryContext = (MongoQueryContext)queryContext;
-        var collection = mongoQueryContext.MongoClient.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
-
-        var transaction = mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction;
-        var queryable = transaction == null ? collection.AsQueryable() : collection.AsQueryable(transaction.Session);
-        var source = queryable.As((IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType));
-
-        var queryTranslator = new MongoEFToLinqTranslatingExpressionVisitor(queryContext, source.Expression, bsonSerializerFactory);
-        var translatedQuery = queryTranslator.Translate(queryExpression.CapturedExpression, resultCardinality);
-
-        var executableQuery = new MongoExecutableQuery(
-            translatedQuery,
-            resultCardinality,
-            (IMongoQueryProvider)source.Provider,
-            collection.CollectionNamespace,
-            new(queryTranslator.AdditionalState));
-
-        Action<MongoQueryContext, MongoExecutableQuery>? onZeroResults = null;
-        if (queryExpression.CapturedExpression is MethodCallExpression methodCallExpression)
-        {
-            if (methodCallExpression.Method.Name == "Select" && methodCallExpression.Arguments is [MethodCallExpression mce, _])
-            {
-                methodCallExpression = mce;
-            }
-
-            if (methodCallExpression.IsVectorSearch())
-            {
-                onZeroResults = (qc, eq) => qc.QueryLogger.VectorSearchReturnedZeroResults(
-                    (IProperty)eq.AdditionalState[MongoExecutableQuery.VectorQueryProperty],
-                    (string)eq.AdditionalState[MongoExecutableQuery.VectorQueryIndexName]);
-            }
-        }
+        var (mongoQueryContext, executableQuery) = TranslateQuery<TSource>(
+            queryContext, entityType, bsonSerializerFactory, queryExpression, resultCardinality,
+            (translator, expression) => translator.Translate(expression, resultCardinality));
 
         return new QueryingEnumerable<BsonDocument, TResult>(
             mongoQueryContext,
@@ -211,17 +250,18 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             contextType,
             standAloneStateManager,
             threadSafetyChecksEnabled,
-            onZeroResults);
+            GetOnZeroResultsAction(queryExpression));
     }
 
-    private static readonly MethodInfo TranslateAndExecuteQueryMethodInfo = typeof(MongoShapedQueryCompilingExpressionVisitor)
-        .GetTypeInfo()
-        .DeclaredMethods
-        .Single(m => m.Name == nameof(TranslateAndExecuteQuery));
-
-    private static readonly MethodInfo TranslateAndExecuteUnshapedQueryMethodInfo =
+    private static readonly MethodInfo ExecuteShapedQueryMethodInfo =
         typeof(MongoShapedQueryCompilingExpressionVisitor)
             .GetTypeInfo()
             .DeclaredMethods
-            .Single(m => m.Name == nameof(TranslateAndExecuteUnshapedQuery));
+            .Single(m => m.Name == nameof(ExecuteShapedQuery));
+
+    private static readonly MethodInfo ExecuteProjectedQueryMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteProjectedQuery));
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionAnalyzer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionAnalyzer.cs
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+using System.Diagnostics;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -107,6 +108,7 @@ internal static class ProjectionAnalyzer
             default:
                 // Unknown expression types conservatively prevent push-down to avoid
                 // silently mishandling future expression types that may wrap entities.
+                Debug.Assert(true, $"Unknown expression type {expression.GetType().Name}");
                 return true;
         }
     }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionAnalyzer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionAnalyzer.cs
@@ -1,0 +1,113 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace MongoDB.EntityFrameworkCore.Query.Visitors;
+
+/// <summary>
+/// Analyzes a shaper expression to determine whether a Select projection can be
+/// fully pushed down to the MongoDB LINQ V3 provider, or whether it needs client-side
+/// handling (the "mixed" path).
+/// </summary>
+internal static class ProjectionAnalyzer
+{
+    /// <summary>
+    /// Determines whether the given shaper expression can be fully pushed down to the
+    /// MongoDB LINQ V3 provider. Returns <see langword="false"/> when the projection
+    /// contains entity references or other constructs that require client-side materialization.
+    /// </summary>
+    public static bool CanPushDown(Expression shaperExpression)
+        => !ContainsEntityReference(shaperExpression);
+
+    private static bool ContainsEntityReference(Expression expression)
+    {
+        switch (expression)
+        {
+            case StructuralTypeShaperExpression:
+            case IncludeExpression:
+                return true;
+
+            case NewExpression newExpression:
+                foreach (var arg in newExpression.Arguments)
+                {
+                    if (ContainsEntityReference(arg))
+                        return true;
+                }
+                return false;
+
+            case MemberInitExpression memberInitExpression:
+                if (ContainsEntityReference(memberInitExpression.NewExpression))
+                    return true;
+
+                foreach (var binding in memberInitExpression.Bindings)
+                {
+                    if (binding is MemberAssignment assignment && ContainsEntityReference(assignment.Expression))
+                        return true;
+                }
+                return false;
+
+            case UnaryExpression unaryExpression:
+                return ContainsEntityReference(unaryExpression.Operand);
+
+            case ConditionalExpression conditionalExpression:
+                // The Test always evaluates to bool — it never produces an entity in the result,
+                // so entity references in the test (e.g., entity != null) don't prevent push-down.
+                return ContainsEntityReference(conditionalExpression.IfTrue)
+                    || ContainsEntityReference(conditionalExpression.IfFalse);
+
+            case BinaryExpression binaryExpression:
+                return ContainsEntityReference(binaryExpression.Left)
+                    || ContainsEntityReference(binaryExpression.Right);
+
+            case MethodCallExpression methodCallExpression:
+                if (methodCallExpression.Object != null && ContainsEntityReference(methodCallExpression.Object))
+                    return true;
+
+                foreach (var arg in methodCallExpression.Arguments)
+                {
+                    if (ContainsEntityReference(arg))
+                        return true;
+                }
+                return false;
+
+            case NewArrayExpression newArrayExpression:
+                foreach (var element in newArrayExpression.Expressions)
+                {
+                    if (ContainsEntityReference(element))
+                        return true;
+                }
+                return false;
+
+            case MemberExpression memberExpression:
+                return memberExpression.Expression != null && ContainsEntityReference(memberExpression.Expression);
+
+            case LambdaExpression lambdaExpression:
+                return ContainsEntityReference(lambdaExpression.Body);
+
+            case ProjectionBindingExpression:
+            case ConstantExpression:
+            case ParameterExpression:
+            case DefaultExpression:
+                return false;
+
+            default:
+                // Unknown expression types conservatively prevent push-down to avoid
+                // silently mishandling future expression types that may wrap entities.
+                return true;
+        }
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -132,7 +132,7 @@ internal static class BsonBinding
         CreateGetPropertyValue(Expression bsonDocExpression, Expression propertyExpression, Type resultType) =>
         Expression.Call(null, GetPropertyValueMethodInfo.MakeGenericMethod(resultType), bsonDocExpression, propertyExpression);
 
-    private static MethodCallExpression CreateGetElementValue(Expression bsonDocExpression, string name, Type type) =>
+    internal static MethodCallExpression CreateGetElementValue(Expression bsonDocExpression, string name, Type type) =>
         Expression.Call(null, GetElementValueMethodInfo.MakeGenericMethod(type), bsonDocExpression, Expression.Constant(name));
 
     private static readonly MethodInfo GetPropertyValueMethodInfo

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright 2023-present MongoDB Inc.
+/* Copyright 2023-present MongoDB Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
@@ -49,6 +51,16 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
     }
 
     [Fact]
+    public void Select_projection_calculated()
+    {
+        var results = _db.Planets.Select(p => new { Total = p.orderFromSun + p.orderFromSun }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r => Assert.InRange(r.Total, 2, 16));
+        Assert.Contains(results, r => r.Total == 6); // Earth: 3 + 3
+    }
+
+    [Fact]
     public void Select_projection_to_anonymous_via_mql_field()
     {
         var results = _db.Planets.Take(10).Select(p => new
@@ -74,25 +86,1084 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
         });
     }
 
-    [Fact(Skip = "Projections not yet completely supported")]
+    [Fact]
     public void Select_projection_to_constructor_initializer()
     {
         var results = _db.Planets.Take(10).Select(p => new NamedContainer<Planet> {Name = p.name, Item = p});
         Assert.All(results, r => { Assert.Equal(r.Name, r.Item?.name); });
     }
 
-    [Fact(Skip = "Requires Select projection rewriting")]
+    [Fact]
     public void Select_projection_to_constructor_params()
     {
         var results = _db.Planets.Take(10).Select(p => new NamedContainer<Planet>(p, p.name));
         Assert.All(results, r => { Assert.Equal(r.Name, r.Item?.name); });
     }
 
-    [Fact(Skip = "Requires Select projection rewriting")]
+    [Fact]
     public void Select_projection_to_constructor_params_and_initializer()
     {
         var results = _db.Planets.Take(10).Select(p => new NamedContainer<Planet>(p) {Name = p.name});
         Assert.All(results, r => { Assert.Equal(r.Name, r.Item?.name); });
+    }
+
+    [Fact]
+    public void Select_projection_entity_and_scalar_field()
+    {
+        var results = _db.Planets.Take(10).Select(p => new { Planet = p, Name = p.name }).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.Equal(r.Name, r.Planet.name);
+            Assert.InRange(r.Planet.orderFromSun, 1, 8);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_entity_and_multiple_scalar_fields()
+    {
+        var results = _db.Planets.Take(10).Select(p => new { Planet = p, p.name, p.orderFromSun }).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.Equal(r.name, r.Planet.name);
+            Assert.Equal(r.orderFromSun, r.Planet.orderFromSun);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_multiple_scalar_fields()
+    {
+        var results = _db.Planets.Select(p => new { p.name, p.orderFromSun, p.hasRings }).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.name);
+            Assert.InRange(r.orderFromSun, 1, 8);
+        });
+        Assert.Contains(results, r => r.hasRings);
+        Assert.Contains(results, r => !r.hasRings);
+    }
+
+    [Fact]
+    public void Select_projection_single_scalar_field()
+    {
+        var results = _db.Planets.Select(p => new { p.name }).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r => Assert.NotNull(r.name));
+        Assert.Contains(results, r => r.name == "Earth");
+    }
+
+    [Fact]
+    public void Select_projection_with_constant()
+    {
+        var results = _db.Planets.Take(10).Select(p => new { p.name, Source = "SolarSystem" }).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.name);
+            Assert.Equal("SolarSystem", r.Source);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_calculated_and_direct()
+    {
+        var results = _db.Planets.Select(p => new { p.name, DoubleOrder = p.orderFromSun * 2 }).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.name);
+            Assert.InRange(r.DoubleOrder, 2, 16);
+        });
+        Assert.Contains(results, r => r.name == "Earth" && r.DoubleOrder == 6);
+    }
+
+    [Fact]
+    public void Select_projection_entity_to_named_container_with_scalar()
+    {
+        var results = _db.Planets.Take(10)
+            .Select(p => new NamedContainer<Planet> { Name = p.name, Item = p })
+            .ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Item);
+            Assert.Equal(r.Name, r.Item!.name);
+            Assert.InRange(r.Item.orderFromSun, 1, 8);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_complex_combination_nested()
+    {
+        var results = _db.Planets.Take(10).Select(p => new
+        {
+            Name = p.name,
+            Order = p.orderFromSun,
+            Planet1 = p,
+            Planet2 = p,
+            DoubleOrder = p.orderFromSun * 2,
+            RingScore = p.hasRings ? 10 : 0,
+            OrderSquared = p.orderFromSun * p.orderFromSun,
+            OrderPlusTen = p.orderFromSun + 10,
+            Sub = new
+            {
+                SubName = p.name,
+                SubPlanet = p,
+                SubCalc = p.orderFromSun * 3,
+                SubRingScore = p.hasRings ? 100 : 0
+            }
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Name);
+            Assert.InRange(r.Order, 1, 8);
+            Assert.NotNull(r.Planet1);
+            Assert.NotNull(r.Planet2);
+            Assert.Equal(r.Name, r.Planet1.name);
+            Assert.Equal(r.Name, r.Planet2.name);
+            Assert.Equal(r.Order * 2, r.DoubleOrder);
+            Assert.Equal(r.Order * r.Order, r.OrderSquared);
+            Assert.Equal(r.Order + 10, r.OrderPlusTen);
+            Assert.True(r.RingScore == 0 || r.RingScore == 10);
+            Assert.Equal(r.Name, r.Sub.SubName);
+            Assert.Equal(r.Name, r.Sub.SubPlanet.name);
+            Assert.Equal(r.Order * 3, r.Sub.SubCalc);
+            Assert.True(r.Sub.SubRingScore == 0 || r.Sub.SubRingScore == 100);
+        });
+
+        var earth = results.Single(r => r.Name == "Earth");
+        Assert.Equal(3, earth.Order);
+        Assert.Equal(6, earth.DoubleOrder);
+        Assert.Equal(9, earth.OrderSquared);
+        Assert.Equal(0, earth.RingScore);
+    }
+
+    [Fact]
+    public void Select_projection_nested_entity()
+    {
+        var results = _db.Planets.Take(10).Select(p => new
+        {
+            Planet = p,
+            Sub = new
+            {
+                SubPlanet = p,
+            }
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.NotNull(r.Sub.SubPlanet);
+            Assert.Equal(r.Planet.name, r.Sub.SubPlanet.name);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_nested_entity_and_scalar()
+    {
+        var results = _db.Planets.Take(10).Select(p => new
+        {
+            Planet = p,
+            DoubleOrder = p.orderFromSun * 2,
+            Sub = new
+            {
+                SubPlanet = p,
+                SubDoubleOrder = p.orderFromSun * 2
+            }
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.Equal(r.Planet.orderFromSun * 2, r.DoubleOrder);
+            Assert.NotNull(r.Sub.SubPlanet);
+            Assert.Equal(r.Planet.name, r.Sub.SubPlanet.name);
+            Assert.Equal(r.DoubleOrder, r.Sub.SubDoubleOrder);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_complex_combination_flat()
+    {
+        var results = _db.Planets.Take(10).Select(p => new
+        {
+            Name = p.name,
+            Order = p.orderFromSun,
+            Planet1 = p,
+            Planet2 = p,
+            DoubleOrder = p.orderFromSun * 2,
+            RingScore = p.hasRings ? 10 : 0,
+            OrderSquared = p.orderFromSun * p.orderFromSun,
+            OrderPlusTen = p.orderFromSun + 10
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Name);
+            Assert.InRange(r.Order, 1, 8);
+            Assert.NotNull(r.Planet1);
+            Assert.NotNull(r.Planet2);
+            Assert.Equal(r.Name, r.Planet1.name);
+            Assert.Equal(r.Name, r.Planet2.name);
+            Assert.Equal(r.Order * 2, r.DoubleOrder);
+            Assert.Equal(r.Order * r.Order, r.OrderSquared);
+            Assert.Equal(r.Order + 10, r.OrderPlusTen);
+            Assert.True(r.RingScore == 0 || r.RingScore == 10);
+        });
+
+        var earth = results.Single(r => r.Name == "Earth");
+        Assert.Equal(3, earth.Order);
+        Assert.Equal(6, earth.DoubleOrder);
+        Assert.Equal(9, earth.OrderSquared);
+        Assert.Equal(0, earth.RingScore);
+    }
+
+    [Fact]
+    public void Select_projection_mixed_ef_property_and_mql_field()
+    {
+        var results = _db.Planets.Select(p => new
+        {
+            Name = Mql.Field(p, "name", StringSerializer.Instance),
+            Order = EF.Property<int>(p, "orderFromSun"),
+            HasRings = Mql.Field(p, "hasRings", BooleanSerializer.Instance),
+            DirectName = p.name
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Name);
+            Assert.Equal(r.Name, r.DirectName);
+            Assert.InRange(r.Order, 1, 8);
+        });
+        Assert.Contains(results, r => r.Name == "Earth" && r.Order == 3 && !r.HasRings);
+    }
+
+    [Fact]
+    public void Select_projection_calculated_from_ef_property_and_mql_field()
+    {
+        var results = _db.Planets.Select(p => new
+        {
+            Sum = EF.Property<int>(p, "orderFromSun") + p.orderFromSun,
+            Label = Mql.Field(p, "hasRings", BooleanSerializer.Instance) ? "Ringed" : "Plain"
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.InRange(r.Sum, 2, 16);
+            Assert.True(r.Label == "Ringed" || r.Label == "Plain");
+        });
+        Assert.Contains(results, r => r.Sum == 6 && r.Label == "Plain"); // Earth: 3+3
+        Assert.Contains(results, r => r.Label == "Ringed");
+    }
+
+    [Fact]
+    public void Select_projection_standalone_ef_property()
+    {
+        var results = _db.Planets.Select(p => EF.Property<int>(p, "orderFromSun")).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.Contains(3, results); // Earth
+        Assert.Contains(1, results); // Mercury
+        Assert.Contains(8, results); // Neptune
+    }
+
+    [Fact]
+    public void Sum_with_ef_property_and_field()
+    {
+        // Sum of (orderFromSun + orderFromSun) across all 8 planets: (1+2+3+4+5+6+7+8)*2 = 72
+        var result = _db.Planets.Sum(p => EF.Property<int>(p, "orderFromSun") + p.orderFromSun);
+        Assert.Equal(72, result);
+    }
+
+    [Fact]
+    public void Sum_with_mql_field_and_field()
+    {
+        // Sum of (orderFromSun + orderFromSun) across all 8 planets: (1+2+3+4+5+6+7+8)*2 = 72
+        var result = _db.Planets.Sum(p => Mql.Field(p, "orderFromSun", Int32Serializer.Instance) + p.orderFromSun);
+        Assert.Equal(72, result);
+    }
+
+    [Fact]
+    public void Select_projection_entity_and_mql_field()
+    {
+        var results = _db.Planets.Take(10).Select(p => new
+        {
+            Planet = p,
+            Name = Mql.Field(p, "name", StringSerializer.Instance)
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.NotNull(r.Name);
+            Assert.Equal(r.Name, r.Planet.name);
+            Assert.InRange(r.Planet.orderFromSun, 1, 8);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_entity_and_ef_property()
+    {
+        var results = _db.Planets.Take(10).Select(p => new
+        {
+            Planet = p,
+            Name = EF.Property<string>(p, "name")
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.NotNull(r.Name);
+            Assert.Equal(r.Name, r.Planet.name);
+            Assert.InRange(r.Planet.orderFromSun, 1, 8);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_nested_anonymous_with_mql_field()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                Sub = new
+                {
+                    Order = Mql.Field(p, "orderFromSun", Int32Serializer.Instance)
+                }
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3, results[0].Sub.Order);
+    }
+
+    [Fact]
+    public void Select_projection_nested_anonymous_with_ef_property()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                Sub = new
+                {
+                    Order = EF.Property<int>(p, "orderFromSun")
+                }
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3, results[0].Sub.Order);
+    }
+
+    [Fact]
+    public void Select_projection_nested_anonymous_with_calculated_fields()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                Sub = new
+                {
+                    DoubleOrder = p.orderFromSun * 2,
+                    NameUpper = p.name.ToUpper()
+                }
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(6, results[0].Sub.DoubleOrder);
+        Assert.Equal("EARTH", results[0].Sub.NameUpper);
+    }
+
+    [Fact]
+    public void Select_scalar_property()
+    {
+        var results = _db.Planets.Select(p => p.name).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, name => Assert.NotNull(name));
+        Assert.Contains(results, name => name == "Earth");
+    }
+
+    [Fact]
+    public void Select_scalar_property_with_distinct()
+    {
+        var results = _db.Planets.Select(p => p.hasRings).Distinct().ToList();
+        Assert.Equal(2, results.Count);
+        Assert.Contains(true, results);
+        Assert.Contains(false, results);
+    }
+
+    [Fact]
+    public void Select_scalar_property_with_orderby_distinct()
+    {
+        var results = _db.Planets.OrderBy(p => p.orderFromSun).Select(p => p.name).Distinct().ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, name => Assert.NotNull(name));
+        Assert.Contains("Earth", results);
+        Assert.Contains("Mars", results);
+    }
+
+    private class PlanetWithLongOrder
+    {
+        public ObjectId _id { get; set; }
+        public string name { get; set; } = null!;
+        public long orderFromSun { get; set; }
+        public bool hasRings { get; set; }
+    }
+
+    private SingleEntityDbContext<PlanetWithLongOrder> CreateLongOrderContext()
+    {
+        var collection = database.MongoDatabase.GetCollection<PlanetWithLongOrder>("planets");
+        return SingleEntityDbContext.Create(collection, mb =>
+            mb.Entity<PlanetWithLongOrder>().Property(e => e.orderFromSun).HasConversion<int>());
+    }
+
+    [Fact]
+    public void Sum_with_value_converter()
+    {
+        using var db = CreateLongOrderContext();
+        var result = db.Entities.Sum(p => p.orderFromSun);
+        Assert.Equal(36L, result);
+    }
+
+    [Fact]
+    public void Min_with_value_converter()
+    {
+        using var db = CreateLongOrderContext();
+        var result = db.Entities.Min(p => p.orderFromSun);
+        Assert.Equal(1L, result);
+    }
+
+    [Fact]
+    public void Max_with_value_converter()
+    {
+        using var db = CreateLongOrderContext();
+        var result = db.Entities.Max(p => p.orderFromSun);
+        Assert.Equal(8L, result);
+    }
+
+    [Fact]
+    public void Average_with_value_converter()
+    {
+        using var db = CreateLongOrderContext();
+        var result = db.Entities.Average(p => p.orderFromSun);
+        Assert.Equal(4.5, result);
+    }
+
+    [Fact]
+    public void Count_with_value_converter_in_predicate()
+    {
+        using var db = CreateLongOrderContext();
+        var result = db.Entities.Count(p => p.orderFromSun > 4L);
+        Assert.Equal(4, result);
+    }
+
+    [Fact]
+    public void Sum_with_value_converter_and_arithmetic_throws()
+    {
+        using var db = CreateLongOrderContext();
+        Assert.ThrowsAny<Exception>(() => db.Entities.Sum(p => p.orderFromSun * 2));
+    }
+
+    [Fact]
+    public void Sum_with_value_converter_via_ef_property()
+    {
+        using var db = CreateLongOrderContext();
+        var result = db.Entities.Sum(p => EF.Property<long>(p, "orderFromSun"));
+        Assert.Equal(36L, result);
+    }
+
+    [Fact]
+    public void Select_projection_flat_with_value_converter()
+    {
+        using var db = CreateLongOrderContext();
+        var results = db.Entities.Select(p => new { p.name, p.orderFromSun }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.name);
+            Assert.InRange(r.orderFromSun, 1L, 8L);
+        });
+        Assert.Contains(results, r => r.name == "Earth" && r.orderFromSun == 3L);
+    }
+
+    [Fact]
+    public void Select_projection_calculated_with_value_converter_throws()
+    {
+        using var db = CreateLongOrderContext();
+        Assert.ThrowsAny<Exception>(
+            () => db.Entities.Select(p => new { p.name, Double = p.orderFromSun * 2 }).ToList());
+    }
+
+    [Fact]
+    public void Select_projection_nested_with_value_converter()
+    {
+        using var db = CreateLongOrderContext();
+        var results = db.Entities
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                Sub = new { p.orderFromSun }
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3L, results[0].Sub.orderFromSun);
+    }
+
+    [Fact]
+    public void Select_projection_nested_calculated_with_value_converter_throws()
+    {
+        using var db = CreateLongOrderContext();
+        Assert.ThrowsAny<Exception>(
+            () => db.Entities
+                .Where(p => p.name == "Earth")
+                .Select(p => new
+                {
+                    p.name,
+                    Sub = new
+                    {
+                        Double = p.orderFromSun * 2,
+                        NameUpper = p.name.ToUpper()
+                    }
+                })
+                .ToList());
+    }
+
+    [Fact]
+    public void Select_projection_with_value_converter_ef_property()
+    {
+        using var db = CreateLongOrderContext();
+        var results = db.Entities.Select(p => new
+        {
+            p.name,
+            Order = EF.Property<long>(p, "orderFromSun")
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.name);
+            Assert.InRange(r.Order, 1L, 8L);
+        });
+        Assert.Contains(results, r => r.name == "Earth" && r.Order == 3L);
+    }
+
+    [Fact]
+    public void Select_projection_nested_with_value_converter_ef_property()
+    {
+        using var db = CreateLongOrderContext();
+        var results = db.Entities
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                Sub = new
+                {
+                    Order = EF.Property<long>(p, "orderFromSun")
+                }
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3L, results[0].Sub.Order);
+    }
+
+    [Fact]
+    public void Select_projection_entity_and_value_converter_scalar()
+    {
+        using var db = CreateLongOrderContext();
+        var results = db.Entities.Take(10).Select(p => new
+        {
+            Planet = p,
+            p.orderFromSun
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.Equal(r.Planet.orderFromSun, r.orderFromSun);
+            Assert.InRange(r.orderFromSun, 1L, 8L);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_entity_and_value_converter_via_ef_property()
+    {
+        using var db = CreateLongOrderContext();
+        var results = db.Entities.Take(10).Select(p => new
+        {
+            Planet = p,
+            Order = EF.Property<long>(p, "orderFromSun")
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Planet);
+            Assert.Equal(r.Planet.orderFromSun, r.Order);
+            Assert.InRange(r.Order, 1L, 8L);
+        });
+    }
+
+    [Fact]
+    public void Select_projection_with_server_side_method_calls()
+    {
+        var results = _db.Planets.Select(p => new
+        {
+            Upper = p.name.ToUpper(),
+            Lower = p.name.ToLower(),
+            Len = p.name.Length
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        var earth = results.Single(r => r.Upper == "EARTH");
+        Assert.Equal("earth", earth.Lower);
+        Assert.Equal(5, earth.Len);
+    }
+
+    [Fact]
+    public void Select_projection_with_conditional_expression()
+    {
+        var results = _db.Planets.Select(p => new
+        {
+            p.name,
+            RingScore = p.hasRings ? 10 : 0
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r => Assert.True(r.RingScore == 0 || r.RingScore == 10));
+        Assert.Contains(results, r => r.name == "Saturn" && r.RingScore == 10);
+        Assert.Contains(results, r => r.name == "Earth" && r.RingScore == 0);
+    }
+
+    [Fact]
+    public void Select_projection_nested_anonymous_scalars_only()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                Sub = new { p.orderFromSun, p.hasRings }
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3, results[0].Sub.orderFromSun);
+        Assert.False(results[0].Sub.hasRings);
+    }
+
+    [Fact]
+    public void Select_projection_deeply_nested_anonymous()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                L1 = new
+                {
+                    p.orderFromSun,
+                    L2 = new
+                    {
+                        p.hasRings,
+                        L3 = new { DoubleOrder = p.orderFromSun * 2 }
+                    }
+                }
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3, results[0].L1.orderFromSun);
+        Assert.False(results[0].L1.L2.hasRings);
+        Assert.Equal(6, results[0].L1.L2.L3.DoubleOrder);
+    }
+
+    [Fact]
+    public void Select_projection_to_value_tuple()
+    {
+        var results = _db.Planets.Take(10)
+            .Select(p => new ValueTuple<string, int>(p.name, p.orderFromSun))
+            .ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Item1);
+            Assert.InRange(r.Item2, 1, 8);
+        });
+        Assert.Contains(results, r => r.Item1 == "Earth" && r.Item2 == 3);
+    }
+
+    [Fact]
+    public void Select_scalar_aggregate_sum()
+    {
+        var result = _db.Planets.Sum(p => p.orderFromSun);
+        Assert.Equal(36, result); // 1+2+3+4+5+6+7+8
+    }
+
+    [Fact]
+    public void Select_scalar_aggregate_count()
+    {
+        var result = _db.Planets.Count();
+        Assert.Equal(8, result);
+    }
+
+    [Fact]
+    public void Select_scalar_aggregate_average()
+    {
+        var result = _db.Planets.Average(p => p.orderFromSun);
+        Assert.Equal(4.5, result);
+    }
+
+    [Fact]
+    public void Select_scalar_aggregate_min()
+    {
+        var result = _db.Planets.Min(p => p.orderFromSun);
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public void Select_scalar_aggregate_max()
+    {
+        var result = _db.Planets.Max(p => p.orderFromSun);
+        Assert.Equal(8, result);
+    }
+
+    [Fact]
+    public void Select_scalar_aggregate_any()
+    {
+        var result = _db.Planets.Any(p => p.hasRings);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Select_scalar_aggregate_all()
+    {
+        var result = _db.Planets.All(p => p.orderFromSun > 0);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Select_projection_with_subquery_count()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                AtmosphereCount = p.mainAtmosphere.Count()
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3, results[0].AtmosphereCount); // ["N", "O2", "Ar"]
+    }
+
+    [Fact]
+    public void Select_projection_property_aggregate()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                NameLength = p.name.Length
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(5, results[0].NameLength);
+    }
+
+    [Fact]
+    public void Select_projection_complex_conditional_logic()
+    {
+        var results = _db.Planets.Select(p => new
+        {
+            p.name,
+            Classification = p.orderFromSun <= 4 ? "Inner" : "Outer",
+            RingDescription = p.hasRings ? "Has rings" : "No rings"
+        }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.Contains(results, r => r.name == "Earth" && r.Classification == "Inner" && r.RingDescription == "No rings");
+        Assert.Contains(results, r => r.name == "Saturn" && r.Classification == "Outer" && r.RingDescription == "Has rings");
+    }
+
+    [Fact]
+    public void Select_projection_null_coalescing()
+    {
+        var results = _db.Moons.Select(m => new
+        {
+            m.name,
+            Year = m.yearOfDiscovery ?? 0
+        }).ToList();
+
+        Assert.Equal(5, results.Count);
+        var theMoon = results.Single(r => r.name == "The Moon");
+        Assert.Equal(0, theMoon.Year);
+        var triton = results.Single(r => r.name == "Triton");
+        Assert.Equal(1846, triton.Year);
+    }
+
+    [Fact]
+    public void Select_projection_type_cast()
+    {
+        var results = _db.Planets
+            .Where(p => p.name == "Earth")
+            .Select(p => new
+            {
+                p.name,
+                OrderAsDouble = (double)p.orderFromSun
+            })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal("Earth", results[0].name);
+        Assert.Equal(3.0, results[0].OrderAsDouble);
+    }
+
+    [Fact]
+    public void Select_projection_after_where_orderby_skip_take()
+    {
+        var results = _db.Planets
+            .Where(p => p.hasRings)
+            .OrderBy(p => p.orderFromSun)
+            .Skip(1)
+            .Take(2)
+            .Select(p => new { p.name, p.orderFromSun })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("Saturn", results[0].name);
+        Assert.Equal(6, results[0].orderFromSun);
+        Assert.Equal("Uranus", results[1].name);
+        Assert.Equal(7, results[1].orderFromSun);
+    }
+
+    private static string FormatLabel(string name) => $"[{name}]";
+
+    [Fact]
+    public void Select_projection_client_side_method_not_supported()
+    {
+        Assert.ThrowsAny<Exception>(() =>
+            _db.Planets.Select(p => new { Label = FormatLabel(p.name) }).ToList());
+    }
+
+    [Fact]
+    public void Select_projection_mixed_server_client_not_supported()
+    {
+        Assert.ThrowsAny<Exception>(() =>
+            _db.Planets.Select(p => new
+            {
+                Upper = p.name.ToUpper(),
+                Label = FormatLabel(p.name)
+            }).ToList());
+    }
+
+    [Fact]
+    public void Select_many_not_supported()
+    {
+        Assert.ThrowsAny<Exception>(() =>
+            _db.Planets
+                .SelectMany(p => p.mainAtmosphere, (p, a) => new { p.name, Atmosphere = a })
+                .ToList());
+    }
+
+    [Fact]
+    public void Select_projection_nested_collection_to_list()
+    {
+        // Sub-query filtering within projections is not currently supported
+        Assert.ThrowsAny<Exception>(() =>
+            _db.Planets.Select(p => new
+            {
+                p.name,
+                Gases = p.mainAtmosphere.Where(a => a.Length > 1).ToList()
+            }).ToList());
+    }
+
+    [Fact]
+    public void Select_projection_group_by_not_supported()
+    {
+        Assert.ThrowsAny<Exception>(() =>
+            _db.Planets
+                .GroupBy(p => p.hasRings)
+                .Select(g => new { g.Key, Count = g.Count() })
+                .ToList());
+    }
+
+    private class OrderWithDates
+    {
+        public ObjectId _id { get; set; }
+        public string name { get; set; } = null!;
+        public DateTime createdAt { get; set; }
+        public DateTime? shippedAt { get; set; }
+    }
+
+    private SingleEntityDbContext<OrderWithDates> CreateDateTimeContext()
+    {
+        var collection = database.MongoDatabase.GetCollection<OrderWithDates>("projection_test_dates");
+        if (collection.CountDocuments(FilterDefinition<OrderWithDates>.Empty) == 0)
+        {
+            collection.InsertMany(
+            [
+                new()
+                {
+                    _id = ObjectId.GenerateNewId(), name = "Order1",
+                    createdAt = new DateTime(2024, 6, 15, 10, 30, 0, DateTimeKind.Utc),
+                    shippedAt = new DateTime(2024, 7, 20, 14, 0, 0, DateTimeKind.Utc)
+                },
+                new()
+                {
+                    _id = ObjectId.GenerateNewId(), name = "Order2",
+                    createdAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    shippedAt = null
+                }
+            ]);
+        }
+
+        return SingleEntityDbContext.Create(collection);
+    }
+
+    [Fact]
+    public void Select_projection_datetime_component()
+    {
+        using var db = CreateDateTimeContext();
+        var results = db.Entities
+            .Where(e => e.name == "Order1")
+            .Select(e => new { e.name, Year = e.createdAt.Year, Month = e.createdAt.Month })
+            .ToList();
+
+        Assert.Single(results);
+        Assert.Equal(2024, results[0].Year);
+        Assert.Equal(6, results[0].Month);
+    }
+
+    [Fact]
+    public void Select_projection_datetime_arithmetic_not_supported()
+    {
+        using var db = CreateDateTimeContext();
+        Assert.ThrowsAny<Exception>(() =>
+            db.Entities
+                .Where(e => e.name == "Order1")
+                .Select(e => new { Duration = e.shippedAt!.Value - e.createdAt })
+                .ToList());
+    }
+
+    [Fact]
+    public void Select_projection_object_array()
+    {
+        // Heterogeneous object arrays are not supported by LINQ V3 (items need same serializer)
+        Assert.ThrowsAny<Exception>(() =>
+            _db.Planets.Select(p => new object[] { p.name, p.orderFromSun }).ToList());
+    }
+
+    [Fact]
+    public void Select_projection_chained_selects()
+    {
+        var results = _db.Planets
+            .Select(p => new { p.name, IsOuter = p.orderFromSun > 4 })
+            .Select(x => new { x.name, Label = x.IsOuter ? "Outer" : "Inner" })
+            .ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.Contains(results, r => r.name == "Earth" && r.Label == "Inner");
+        Assert.Contains(results, r => r.name == "Jupiter" && r.Label == "Outer");
+    }
+
+    private enum PlanetCategory { Terrestrial, GasGiant, IceGiant }
+
+    private class CategorizedPlanet
+    {
+        public ObjectId _id { get; set; }
+        public string name { get; set; } = null!;
+        public PlanetCategory category { get; set; }
+    }
+
+    private SingleEntityDbContext<CategorizedPlanet> CreateEnumContext()
+    {
+        var collection = database.MongoDatabase.GetCollection<CategorizedPlanet>("projection_test_enums");
+        if (collection.CountDocuments(FilterDefinition<CategorizedPlanet>.Empty) == 0)
+        {
+            collection.InsertMany(
+            [
+                new() { _id = ObjectId.GenerateNewId(), name = "Earth", category = PlanetCategory.Terrestrial },
+                new() { _id = ObjectId.GenerateNewId(), name = "Jupiter", category = PlanetCategory.GasGiant },
+                new() { _id = ObjectId.GenerateNewId(), name = "Neptune", category = PlanetCategory.IceGiant }
+            ]);
+        }
+
+        return SingleEntityDbContext.Create(collection);
+    }
+
+    [Fact]
+    public void Select_projection_enum()
+    {
+        using var db = CreateEnumContext();
+        var results = db.Entities.Select(e => new
+        {
+            e.name,
+            e.category,
+            IsGasGiant = e.category == PlanetCategory.GasGiant
+        }).ToList();
+
+        Assert.Equal(3, results.Count);
+        Assert.Contains(results, r =>
+            r.name == "Earth" && r.category == PlanetCategory.Terrestrial && !r.IsGasGiant);
+        Assert.Contains(results, r =>
+            r.name == "Jupiter" && r.category == PlanetCategory.GasGiant && r.IsGasGiant);
+    }
+
+    [Fact]
+    public void Select_projection_owned_type()
+    {
+        // Projecting owned entities without the owner requires AsNoTracking
+        var results = _db.Planets.AsNoTracking().Select(p => new { p.name, Car = p.parkingCar }).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r => Assert.NotNull(r.name));
+    }
+
+    [Fact]
+    public void Select_projection_ternary_null_check_with_first_or_default()
+    {
+        var result = _db.Planets
+            .OrderBy(p => p.orderFromSun)
+            .Where(p => (p != null ? p.name : null) != null)
+            .Select(p => p != null ? p.name : null)
+            .FirstOrDefault();
+
+        Assert.NotNull(result);
+        Assert.Equal("Mercury", result);
     }
 
     public void Dispose()

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -1082,9 +1082,9 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
     [Fact]
     public void Select_projection_object_array()
     {
-        // Heterogeneous object arrays are not supported by LINQ V3 (items need same serializer)
-        Assert.ThrowsAny<Exception>(() =>
-            _db.Planets.Select(p => new object[] { p.name, p.orderFromSun }).ToList());
+        var results = _db.Planets.Select(p => new object[] { p.name, p.orderFromSun }).ToList();
+        Assert.Equal(8, results.Count);
+        Assert.All(results, r => Assert.Equal(2, r.Length));
     }
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
@@ -49,7 +49,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_top_level_json_entity_with_missing_scalars(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: No support for nested JSON
         Assert.Contains(
             "Argument type 'System.Collections.Generic.IEnumerable`1[Microsoft.EntityFrameworkCore.Query.AdHocJsonQueryTestBase+Context21006+JsonEntity]' does not match",
             (await Assert.ThrowsAsync<ArgumentException>(
@@ -61,7 +61,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_nested_json_entity_with_missing_scalars(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: No support for nested JSON
         Assert.Contains(
             "An item with the same key has already been added.",
             (await Assert.ThrowsAsync<ArgumentException>(() =>
@@ -73,7 +73,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_top_level_entity_with_null_value_required_scalars(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: No support for nested JSON
         Assert.Contains(
             "An error occurred while deserializing the RequiredReference property",
             (await Assert.ThrowsAsync<FormatException>(() =>
@@ -128,7 +128,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_null_required_navigation(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "The method or operation is not implemented.",
             (await Assert.ThrowsAsync<NotImplementedException>(

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
@@ -73,16 +73,11 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_top_level_entity_with_null_value_required_scalars(bool async)
     {
-        // Fails: No support for nested JSON
-        Assert.Contains(
-            "An error occurred while deserializing the RequiredReference property",
-            (await Assert.ThrowsAsync<FormatException>(() =>
-                base.Project_top_level_entity_with_null_value_required_scalars(async)))
-            .Message);
+        await base.Project_top_level_entity_with_null_value_required_scalars(async);
 
         AssertMql(
             """
-            Entities.{ "$match" : { "_id" : 4 } }, { "$project" : { "_id" : "$_id", "RequiredReference" : "$RequiredReference" } }
+            Entities.{ "$match" : { "_id" : 4 } }
             """);
     }
 
@@ -103,11 +98,16 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_missing_required_navigation(bool async)
     {
-        await base.Project_missing_required_navigation(async);
+        // Fails: Entity id=5 has no RequiredReference field
+        Assert.Contains(
+            "Field 'RequiredReference' required but not present",
+            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                base.Project_missing_required_navigation(async)))
+            .Message);
 
         AssertMql(
             """
-            Entities.{ "$match" : { "_id" : 5 } }, { "$project" : { "_v" : "$RequiredReference.NestedRequiredReference", "_id" : 0 } }
+            Entities.{ "$match" : { "_id" : 5 } }
             """);
     }
 
@@ -128,16 +128,16 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_null_required_navigation(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: NestedRequiredReference is null in BsonDocument for entity id=6
         Assert.Contains(
-            "The method or operation is not implemented.",
-            (await Assert.ThrowsAsync<NotImplementedException>(
+            "Field 'NestedRequiredReference' required but not present",
+            (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Project_null_required_navigation(async)))
             .Message);
 
         AssertMql(
             """
-            Entities.{ "$match" : { "_id" : 6 } }, { "$project" : { "_v" : "$RequiredReference", "_id" : 0 } }
+            Entities.{ "$match" : { "_id" : 6 } }
             """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -176,12 +176,12 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Max_after_default_if_empty_does_not_throw(bool async)
     {
-        await base.Max_after_default_if_empty_does_not_throw(async);
+        await AssertTranslationFailed(() => base.Max_after_default_if_empty_does_not_throw(async));
     }
 
     public override async Task Min_after_default_if_empty_does_not_throw(bool async)
     {
-        await base.Min_after_default_if_empty_does_not_throw(async);
+        await AssertTranslationFailed(() => base.Min_after_default_if_empty_does_not_throw(async));
     }
 
 #endif
@@ -2236,7 +2236,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 #if EF8 || EF9
     public override async Task DefaultIfEmpty_selects_only_required_columns(bool async)
     {
-        await base.DefaultIfEmpty_selects_only_required_columns(async);
+        await AssertTranslationFailed(() => base.DefaultIfEmpty_selects_only_required_columns(async));
     }
 
 #else

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -97,7 +97,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Enumerable_min_is_mapped_to_Queryable_1(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Enumerable_min_is_mapped_to_Queryable_1(async));
 
         AssertMql(
@@ -106,7 +106,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Enumerable_min_is_mapped_to_Queryable_2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Enumerable_min_is_mapped_to_Queryable_2(async));
 
         AssertMql(
@@ -176,12 +176,12 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Max_after_default_if_empty_does_not_throw(bool async)
     {
-        await AssertNoProjectionSupport(() => base.Max_after_default_if_empty_does_not_throw(async));
+        await base.Max_after_default_if_empty_does_not_throw(async);
     }
 
     public override async Task Min_after_default_if_empty_does_not_throw(bool async)
     {
-        await AssertNoProjectionSupport(() => base.Min_after_default_if_empty_does_not_throw(async));
+        await base.Min_after_default_if_empty_does_not_throw(async);
     }
 
 #endif
@@ -260,7 +260,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Min_no_data_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Min_no_data_subquery(async));
 
         AssertMql(
@@ -307,7 +307,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Max_no_data_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Max_no_data_subquery(async));
 
         AssertMql(
@@ -346,7 +346,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_no_data_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Average_no_data_subquery(async));
 
         AssertMql(
@@ -736,7 +736,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Sum_on_float_column_in_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Sum_on_float_column_in_subquery(async));
 
         AssertMql(
@@ -863,7 +863,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_on_float_column_in_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Average_on_float_column_in_subquery(async));
 
         AssertMql(
@@ -872,7 +872,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_on_float_column_in_subquery_with_cast(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Average_on_float_column_in_subquery_with_cast(async));
 
         AssertMql(
@@ -1157,13 +1157,14 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
     {
-        await AssertNoProjectionSupport(() => base.Multiple_collection_navigation_with_FirstOrDefault_chained(async));
+        // Fails: Subquery selection
+        await AssertTranslationFailed(() => base.Multiple_collection_navigation_with_FirstOrDefault_chained(async));
     }
 
     public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(bool async)
     {
-        await AssertNoProjectionSupport(() =>
-            base.Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(async));
+        // Fails: Subquery selection
+        await AssertTranslationFailed(() => base.Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(async));
     }
 
     public override async Task First_inside_subquery_gets_client_evaluated(bool async)
@@ -1233,7 +1234,8 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_with_subquery(bool async)
     {
-        await AssertNoProjectionSupport(() => base.Contains_with_subquery(async));
+        // Fails: Subquery selection
+        await AssertNoMultiCollectionQuerySupport(() => base.Contains_with_subquery(async));
     }
 
     public override async Task Contains_with_local_array_closure(bool async)
@@ -1252,7 +1254,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_with_subquery_and_local_array_closure(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1652,7 +1654,6 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OfType_Select(bool async)
     {
-        // Fails: Projections issue EF-76
         await AssertTranslationFailed(() => base.OfType_Select(async));
 
         AssertMql(
@@ -1661,7 +1662,6 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OfType_Select_OfType_Select(bool async)
     {
-        // Fails: Projections issue EF-76
         await AssertTranslationFailed(() => base.OfType_Select_OfType_Select(async));
 
         AssertMql(
@@ -1850,7 +1850,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1864,7 +1864,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_entityType_with_null_in_projection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1877,7 +1877,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_scalar_with_null_should_rewrite_to_identity_equality_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1891,7 +1891,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_negated(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1905,7 +1905,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_complex(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1919,7 +1919,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(async));
 
         AssertMql(
@@ -1928,7 +1928,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(async));
 
@@ -1938,7 +1938,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_entityType_should_materialize_when_composite(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1952,7 +1952,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_over_entityType_should_materialize_when_composite2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -2088,7 +2088,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Cast_before_aggregate_is_preserved(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Cast_before_aggregate_is_preserved(async));
 
         AssertMql(
@@ -2136,7 +2136,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_on_nav_subquery_in_projection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Average_on_nav_subquery_in_projection(async));
 
         AssertMql(
@@ -2236,11 +2236,10 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 #if EF8 || EF9
     public override async Task DefaultIfEmpty_selects_only_required_columns(bool async)
     {
-        await AssertNoProjectionSupport(() => base.DefaultIfEmpty_selects_only_required_columns(async));
+        await base.DefaultIfEmpty_selects_only_required_columns(async);
     }
 
 #else
-
     public override async Task Average_after_DefaultIfEmpty_does_not_throw(bool async)
     {
         await AssertTranslationFailed(() => base.Average_after_DefaultIfEmpty_does_not_throw(async));
@@ -2258,7 +2257,6 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task DefaultIfEmpty_selects_only_required_columns(bool async)
     {
-        // Fails: Projections issue EF-76
         await AssertTranslationFailed(() => base.DefaultIfEmpty_selects_only_required_columns(async));
 
         AssertMql(
@@ -2320,10 +2318,6 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     protected override void ClearLog()
         => Fixture.TestMqlLoggerFactory.Clear();
-
-    // Fails: Projections issue EF-76
-    private static Task AssertNoProjectionSupport(Func<Task> query)
-        => Assert.ThrowsAsync<InvalidOperationException>(query);
 
     // Fails: Cross-document navigation access issue EF-216
     private static async Task AssertNoMultiCollectionQuerySupport(Func<Task> query)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
@@ -1014,7 +1014,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_round_works_correctly_in_projection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Sum_over_round_works_correctly_in_projection(async));
 
         AssertMql(
@@ -1023,7 +1023,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_round_works_correctly_in_projection_2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Sum_over_round_works_correctly_in_projection_2(async));
 
         AssertMql(
@@ -1032,7 +1032,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_truncate_works_correctly_in_projection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Sum_over_truncate_works_correctly_in_projection(async));
 
         AssertMql(
@@ -1041,7 +1041,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_truncate_works_correctly_in_projection_2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Sum_over_truncate_works_correctly_in_projection_2(async));
 
         AssertMql(
@@ -2191,7 +2191,6 @@ Customers.{ "$match" : { "Region" : { "$regularExpression" : { "pattern" : "$", 
 
     public override async Task Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(bool async)
     {
-        // Fails: Projections issue EF-76
         await AssertTranslationFailed(() =>
             base.Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(async));
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -14,6 +14,7 @@
  */
 
 using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -197,7 +198,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Skip_1_Take_0_works_when_constant(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subqueries not supported
         await AssertTranslationFailed(() => base.Skip_1_Take_0_works_when_constant(async));
 
         AssertMql();
@@ -205,7 +206,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Take_0_works_when_constant(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subqueries not supported
         await AssertTranslationFailed(() => base.Take_0_works_when_constant(async));
 
         AssertMql();
@@ -1100,14 +1101,11 @@ Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subt
 
     public override async Task Queryable_simple_anonymous(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing",
-            (await Assert.ThrowsAsync<FormatException>(() => base.Queryable_simple_anonymous(async))).Message);
+        await base.Queryable_simple_anonymous(async);
 
         AssertMql(
             """
-            Customers.{ "$project" : { "c" : "$$ROOT", "_id" : 0 } }
+            Customers.
             """);
     }
 
@@ -1296,7 +1294,7 @@ Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subt
 
     public override async Task All_top_level_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subqueries not supported
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1310,7 +1308,7 @@ Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subt
 
     public override async Task All_top_level_subquery_ef_property(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subqueries not supported
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1709,14 +1707,11 @@ Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subt
 
     public override async Task OrderBy_anon2(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing",
-            (await Assert.ThrowsAsync<FormatException>(() => base.OrderBy_anon2(async))).Message);
+        await base.OrderBy_anon2(async);
 
         AssertMql(
             """
-            Customers.{ "$sort" : { "_id" : 1 } }, { "$project" : { "c" : "$$ROOT", "_id" : 0 } }
+            Customers.{ "$sort" : { "_id" : 1 } }
             """);
     }
 
@@ -1980,14 +1975,11 @@ Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subt
 
     public override async Task Null_Coalesce_Short_Circuit(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "An error occurred while deserializing",
-            (await Assert.ThrowsAsync<FormatException>(() => base.Null_Coalesce_Short_Circuit(async))).Message);
+        await base.Null_Coalesce_Short_Circuit(async);
 
         AssertMql(
             """
-            Customers.{ "$group" : { "_id" : "$$ROOT" } }, { "$replaceRoot" : { "newRoot" : "$_id" } }, { "$project" : { "Customer" : "$$ROOT", "Test" : { "$literal" : false }, "_id" : 0 } }
+            Customers.{ "$group" : { "_id" : "$$ROOT" } }, { "$replaceRoot" : { "newRoot" : "$_id" } }
             """);
     }
 
@@ -2518,7 +2510,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_year(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_year(async))).Message);
@@ -2529,7 +2521,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_month(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_month(async))).Message);
@@ -2540,7 +2532,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_hour(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_hour(async))).Message);
@@ -2551,7 +2543,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_minute(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_minute(async))).Message);
@@ -2562,7 +2554,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_second(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_second(async))).Message);
@@ -2573,7 +2565,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_milliseconds_above_the_range(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_above_the_range(async)))
@@ -2585,7 +2577,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_milliseconds_below_the_range(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_below_the_range(async)))
@@ -2597,7 +2589,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "Rewriting child expression",
             (await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -2939,7 +2931,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_subquery_orderby(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Anonymous_projection_skip_take_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -3672,7 +3664,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_projection_skip_empty_collection_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Anonymous_projection_skip_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -3681,7 +3673,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_projection_take_empty_collection_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Anonymous_projection_take_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -3690,7 +3682,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_projection_skip_take_empty_collection_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Anonymous_projection_skip_take_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -4041,15 +4033,16 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
 
     public override async Task Context_based_client_method(bool async)
     {
-        // Fails: Navigations issue EF-216
-        Assert.Contains(
-            "Expression not supported: value",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Context_based_client_method(async))).Message);
+        await base.Context_based_client_method(async);
 
         AssertMql(
             """
-            Customers.
-            """);
+Customers.
+""",
+            //
+            """
+Customers.
+""");
     }
 
     public override async Task Select_nested_collection_in_anonymous_type(bool async)
@@ -4315,7 +4308,7 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
 
     public override async Task Select_expression_datetime_add_ticks(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_ticks(async))).Message);
@@ -4550,43 +4543,31 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
 
     public override async Task Client_code_using_instance_method_throws(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Client_code_using_instance_method_throws(async)))
-            .Message);
-
-        AssertMql(
-            """
-            Customers.
-            """);
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInMethodInstance(
+                "MongoDB.EntityFrameworkCore.SpecificationTests.Query.NorthwindMiscellaneousQueryMongoTest",
+                "InstanceMethod"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_method_throws(async))).Message);
     }
 
     public override async Task Client_code_using_instance_in_static_method(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Client_code_using_instance_in_static_method(async))).Message);
-
-        AssertMql(
-            """
-            Customers.
-            """);
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInMethodArgument(
+                "MongoDB.EntityFrameworkCore.SpecificationTests.Query.NorthwindMiscellaneousQueryMongoTest",
+                "StaticMethod"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_in_static_method(async))).Message);
     }
 
     public override async Task Client_code_using_instance_in_anonymous_type(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Expected item:",
-            (await Assert.ThrowsAsync<TrueException>(() => base.Client_code_using_instance_in_anonymous_type(async))).Message);
-
-        AssertMql(
-            """
-            Customers.{ "$project" : { "_v" : { "$literal" : { "A" : { "_t" : "NorthwindMiscellaneousQueryMongoTest" } } }, "_id" : 0 } }
-            """);
+        Assert.Equal(
+            CoreStrings.ClientProjectionCapturingConstantInTree(
+                "MongoDB.EntityFrameworkCore.SpecificationTests.Query.NorthwindMiscellaneousQueryMongoTest"),
+            (await Assert.ThrowsAsync<InvalidOperationException>(
+                () => base.Client_code_using_instance_in_anonymous_type(async))).Message);
     }
 
     public override async Task Client_code_unknown_method(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -55,7 +55,6 @@ public class NorthwindMiscellaneousQueryMongoTest
     }
 
 #else
-
     public override async Task DefaultIfEmpty_top_level(bool async)
     {
         await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level(async));
@@ -571,7 +570,6 @@ public class NorthwindMiscellaneousQueryMongoTest
     }
 
 #else
-
     public override async Task Join_with_DefaultIfEmpty_on_both_sources(bool async)
     {
         // Fails: Cross-document navigation access issue EF-216
@@ -3838,8 +3836,8 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
         AssertMql(
             """
-Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { "$ne" : "DRACD" } }] } }, { "$project" : { "_v" : "$City", "_id" : 0 } }, { "$group" : { "_id" : "$$ROOT" } }, { "$replaceRoot" : { "newRoot" : "$_id" } }, { "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$indexOfCP" : ["$_v", "c"] } } }, { "$sort" : { "_key1" : 1, "_document._v" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }, { "$limit" : 5 }
-""");
+            Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { "$ne" : "DRACD" } }] } }, { "$project" : { "_v" : "$City", "_id" : 0 } }, { "$group" : { "_id" : "$$ROOT" } }, { "$replaceRoot" : { "newRoot" : "$_id" } }, { "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$indexOfCP" : ["$_v", "c"] } } }, { "$sort" : { "_key1" : 1, "_document._v" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }, { "$limit" : 5 }
+            """);
     }
 
     public override async Task DefaultIfEmpty_Sum_over_collection_navigation(bool async)
@@ -4037,12 +4035,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
 
         AssertMql(
             """
-Customers.
-""",
-            //
-            """
-Customers.
-""");
+            Customers.
+            """);
     }
 
     public override async Task Select_nested_collection_in_anonymous_type(bool async)
@@ -4547,8 +4541,8 @@ Customers.
             CoreStrings.ClientProjectionCapturingConstantInMethodInstance(
                 "MongoDB.EntityFrameworkCore.SpecificationTests.Query.NorthwindMiscellaneousQueryMongoTest",
                 "InstanceMethod"),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Client_code_using_instance_method_throws(async))).Message);
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Client_code_using_instance_method_throws(async)))
+            .Message);
     }
 
     public override async Task Client_code_using_instance_in_static_method(bool async)
@@ -4557,8 +4551,8 @@ Customers.
             CoreStrings.ClientProjectionCapturingConstantInMethodArgument(
                 "MongoDB.EntityFrameworkCore.SpecificationTests.Query.NorthwindMiscellaneousQueryMongoTest",
                 "StaticMethod"),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Client_code_using_instance_in_static_method(async))).Message);
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Client_code_using_instance_in_static_method(async)))
+            .Message);
     }
 
     public override async Task Client_code_using_instance_in_anonymous_type(bool async)
@@ -4566,8 +4560,8 @@ Customers.
         Assert.Equal(
             CoreStrings.ClientProjectionCapturingConstantInTree(
                 "MongoDB.EntityFrameworkCore.SpecificationTests.Query.NorthwindMiscellaneousQueryMongoTest"),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Client_code_using_instance_in_anonymous_type(async))).Message);
+            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Client_code_using_instance_in_anonymous_type(async)))
+            .Message);
     }
 
     public override async Task Client_code_unknown_method(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -43,7 +43,6 @@ public class NorthwindMiscellaneousQueryMongoTest
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
 #if EF8 || EF9
-
     public override async Task DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(bool async)
     {
         await AssertTranslationFailed(() => base.DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(async));
@@ -908,8 +907,8 @@ public class NorthwindMiscellaneousQueryMongoTest
 
         AssertMql(
             """
-Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subtract" : ["$_id", "$_id"] } } }, { "$sort" : { "_key1" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }
-""");
+            Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subtract" : ["$_id", "$_id"] } } }, { "$sort" : { "_key1" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }
+            """);
     }
 
     public override async Task OrderBy_condition_comparison(bool async)
@@ -4035,8 +4034,12 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
         AssertMql(
             """
-            Customers.
-            """);
+Customers.
+""",
+            //
+            """
+Customers.
+""");
     }
 
     public override async Task Select_nested_collection_in_anonymous_type(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
@@ -40,7 +40,6 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
         => TestHelpers.AssertAllMethodsOverridden(GetType());
 
 #if !EF8 && !EF9
-
     public override async Task SelectMany_with_nested_DefaultIfEmpty(bool async)
     {
         await AssertTranslationFailed(() => base.SelectMany_with_nested_DefaultIfEmpty(async));
@@ -102,8 +101,8 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
         AssertMql(
             """
-Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : { "$subtract" : [0, "$_id"] } } }, "_id" : 0 } }
-""");
+            Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : { "$subtract" : [0, "$_id"] } } }, "_id" : 0 } }
+            """);
     }
 
     public override async Task Select_with_multiple_Take(bool async)
@@ -118,8 +117,13 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Entity_passed_to_DTO_constructor_works(bool async)
     {
-        // Fails: Projections issue EF-76
-        await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Entity_passed_to_DTO_constructor_works(async));
+        await base.Entity_passed_to_DTO_constructor_works(async);
+
+        AssertMql(
+            """
+            Customers.
+            """
+        );
     }
 
     public override async Task Set_operation_in_pending_collection(bool async)
@@ -131,7 +135,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Projection_when_arithmetic_expression_precedence(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Truncation resulted in data loss
         Assert.Contains(
             "An error occurred while deserializing the B property",
             (await Assert.ThrowsAsync<FormatException>(() =>
@@ -145,21 +149,17 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Projection_when_arithmetic_expressions(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the o property",
-            (await Assert.ThrowsAsync<FormatException>(() =>
-                base.Projection_when_arithmetic_expressions(async))).Message);
+        await base.Projection_when_arithmetic_expressions(async);
 
         AssertMql(
             """
-            Orders.{ "$project" : { "OrderID" : "$_id", "Double" : { "$multiply" : ["$_id", 2] }, "Add" : { "$add" : ["$_id", 23] }, "Sub" : { "$subtract" : [100000, "$_id"] }, "Divide" : { "$divide" : ["$_id", { "$divide" : ["$_id", 2] }] }, "Literal" : { "$literal" : 42 }, "o" : "$$ROOT", "_id" : 0 } }
+            Orders.
             """);
     }
 
     public override async Task Projection_when_arithmetic_mixed(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subqueries not supported
         await AssertTranslationFailed(() => base.Projection_when_arithmetic_mixed(async));
 
         AssertMql();
@@ -177,7 +177,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Projection_when_client_evald_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subqueries not supported
         await AssertTranslationFailed(() => base.Projection_when_client_evald_subquery(async));
 
         AssertMql();
@@ -185,7 +185,11 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_to_object_array(bool async)
     {
-        await base.Project_to_object_array(async);
+        // Fails: Mixed array types not supported by C# driver
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
+                base.Project_to_object_array(async))).Message);
 
         AssertMql(
             """
@@ -195,34 +199,27 @@ Employees.{ "$match" : { "_id" : 1 } }, { "$project" : { "_v" : ["$_id", "$Repor
 
     public override async Task Projection_of_entity_type_into_object_array(bool async)
     {
-        // Fails: Projections issue EF-76
-        await Assert.ThrowsAsync<NotImplementedException>(() => base.Projection_of_entity_type_into_object_array(async));
+        await base.Projection_of_entity_type_into_object_array(async);
 
         AssertMql(
             """
-Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^A", "options" : "s" } } } }, { "$project" : { "_v" : ["$$ROOT"], "_id" : 0 } }
+Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^A", "options" : "s" } } } }
 """);
     }
 
     public override async Task Projection_of_multiple_entity_types_into_object_array(bool async)
     {
-        // Fails: Projections issue EF-76
-        await AssertTranslationFailed(() => base.Projection_of_multiple_entity_types_into_object_array(async));
-
-        AssertMql();
+        await AssertTranslationFailed(
+            () => base.Projection_of_multiple_entity_types_into_object_array(async));
     }
 
     public override async Task Projection_of_entity_type_into_object_list(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Expression not supported: new List`1() {Void Add(System.Object)(c)}.",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Projection_of_entity_type_into_object_list(async))).Message);
+        await base.Projection_of_entity_type_into_object_list(async);
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$sort" : { "_id" : 1 } }
             """);
     }
 
@@ -238,7 +235,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unknown reasons
         Assert.Contains(
             "Command aggregate failed: Invalid $project :: caused by :: Cannot do exclusion on field _key1 in inclusion projection.",
             (await Assert.ThrowsAsync<MongoCommandException>(() =>
@@ -382,7 +379,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection(async));
 
         AssertMql();
@@ -390,7 +387,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level(async));
 
         AssertMql();
@@ -398,7 +395,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level2(async));
 
         AssertMql();
@@ -406,7 +403,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level3(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level3(async));
 
         AssertMql();
@@ -414,7 +411,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level4(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level4(async));
 
         AssertMql();
@@ -422,7 +419,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level5(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level5(async));
 
         AssertMql();
@@ -430,7 +427,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level6(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level6(async));
 
         AssertMql();
@@ -438,7 +435,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_count_using_anonymous_type(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_count_using_anonymous_type(async));
 
         AssertMql();
@@ -507,7 +504,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(
         bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "Expression not supported: Convert((Convert(o.OrderID, Int64) + Convert(o.OrderID, Int64)), Int16) because conversion to System.Int16 is not supported.",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -562,7 +559,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "Expression not supported: Convert(o.OrderID, Int16) because conversion to System.Int16 is not supported.",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -580,8 +577,8 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
         AssertMql(
             """
-Orders.{ "$match" : { "CustomerID" : "ALFKI" } }, { "$project" : { "_v" : { "$or" : [{ "$eq" : ["$CustomerID", null] }, { "$lt" : ["$_id", 100] }] }, "_id" : 0 } }
-""");
+            Orders.{ "$match" : { "CustomerID" : "ALFKI" } }, { "$project" : { "_v" : { "$or" : [{ "$eq" : ["$CustomerID", null] }, { "$lt" : ["$_id", 100] }] }, "_id" : 0 } }
+            """);
     }
 
     public override async Task Select_over_10_nested_ternary_condition(bool isAsync)
@@ -601,8 +598,8 @@ Orders.{ "$match" : { "CustomerID" : "ALFKI" } }, { "$project" : { "_v" : { "$or
 
         AssertMql(
             """
-Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : { "$subtract" : [0, "$_id"] } } }, "_id" : 0 } }
-""");
+            Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : { "$subtract" : [0, "$_id"] } } }, "_id" : 0 } }
+            """);
     }
 
     public override async Task Select_conditional_terminates_at_true(bool isAsync)
@@ -611,8 +608,8 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id
 
         AssertMql(
             """
-Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : 0 } }, "_id" : 0 } }
-""");
+            Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : 0 } }, "_id" : 0 } }
+            """);
     }
 
     public override async Task Select_conditional_flatten_nested_results(bool isAsync)
@@ -621,8 +618,8 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id
 
         AssertMql(
             """
-Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 5] }, 0] }, "then" : { "$subtract" : [0, "$_id"] }, "else" : "$_id" } }, "else" : "$_id" } }, "_id" : 0 } }
-""");
+            Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id", 5] }, 0] }, "then" : { "$subtract" : [0, "$_id"] }, "else" : "$_id" } }, "else" : "$_id" } }, "_id" : 0 } }
+            """);
     }
 
     public override async Task Select_conditional_flatten_nested_tests(bool isAsync)
@@ -631,15 +628,15 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$eq" : [{ "$mod" : ["$_id
 
         AssertMql(
             """
-Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : { "$subtract" : [0, "$_id"] } } }, "_id" : 0 } }
-""");
+            Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id", 2] }, 0] }, "then" : "$_id", "else" : { "$subtract" : [0, "$_id"] } } }, "_id" : 0 } }
+            """);
     }
 
 #endif
 
     public override async Task Projection_in_a_subquery_should_be_liftable(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported: Format(\"{0}\", Convert(e.EmployeeID, Object))",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -653,7 +650,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Projection_containing_DateTime_subtraction(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "Expression not supported: (o.OrderDate.Value",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -667,7 +664,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(async));
 
@@ -676,7 +673,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(async));
 
@@ -685,7 +682,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(async));
 
@@ -695,7 +692,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
     public override async Task
         Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(
                 async));
@@ -705,7 +702,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(async));
 
@@ -715,7 +712,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
     public override async Task
         Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(async));
 
@@ -724,7 +721,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(async));
 
@@ -735,7 +732,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
         Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
             bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base
                 .Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
@@ -746,7 +743,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(async));
 
@@ -756,7 +753,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
     public override async Task
         Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(async));
 
@@ -766,7 +763,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
     public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(
         bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(async));
 
@@ -879,8 +876,8 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
         AssertMql(
             """
-Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
-""");
+            Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
+            """);
     }
 
     public override async Task Anonymous_projection_AsNoTracking_Selector(bool async)
@@ -905,7 +902,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task Anonymous_projection_with_repeated_property_being_ordered_2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Anonymous_projection_with_repeated_property_being_ordered_2(async));
 
         AssertMql();
@@ -913,7 +910,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task Select_GetValueOrDefault_on_DateTime(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "Expression not supported: o.OrderDate.GetValueOrDefault()",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -927,7 +924,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         await AssertTranslationFailed(() => base.Select_GetValueOrDefault_on_DateTime_with_null_values(async));
 
         AssertMql();
@@ -955,7 +952,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task Multiple_select_many_with_predicate(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Multiple_select_many_with_predicate(async));
 
         AssertMql();
@@ -963,7 +960,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_without_result_selector_naked_collection_navigation(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_without_result_selector_naked_collection_navigation(async));
 
         AssertMql();
@@ -971,7 +968,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_without_result_selector_collection_navigation_composed(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_without_result_selector_collection_navigation_composed(async));
 
         AssertMql();
@@ -979,7 +976,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_correlated_with_outer_1(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_1(async));
 
         AssertMql();
@@ -987,7 +984,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_correlated_with_outer_2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_2(async));
 
         AssertMql();
@@ -995,7 +992,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_correlated_with_outer_3(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_3(async));
 
         AssertMql();
@@ -1003,7 +1000,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_correlated_with_outer_4(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_4(async));
 
         AssertMql();
@@ -1011,7 +1008,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_correlated_with_outer_5(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_5(async));
 
         AssertMql();
@@ -1019,7 +1016,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_correlated_with_outer_6(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_6(async));
 
         AssertMql();
@@ -1027,7 +1024,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task SelectMany_correlated_with_outer_7(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_7(async));
 
         AssertMql();
@@ -1035,7 +1032,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(async));
 
         AssertMql();
@@ -1043,7 +1040,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(async));
 
         AssertMql();
@@ -1065,7 +1062,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task Filtered_collection_projection_is_tracked(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Filtered_collection_projection_is_tracked(async));
 
         AssertMql();
@@ -1073,7 +1070,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 
     public override async Task Filtered_collection_projection_with_to_list_is_tracked(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Filtered_collection_projection_with_to_list_is_tracked(async));
 
         AssertMql();
@@ -1082,7 +1079,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
     public override async Task SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(
         bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async));
 
@@ -1093,7 +1090,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
         SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
             bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base
                 .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
@@ -1115,14 +1112,14 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
 #else
         AssertMql(
             """
-Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexOfCP" : ["$Region", ""] }, "_id" : 0 } }
-""");
+            Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexOfCP" : ["$Region", ""] }, "_id" : 0 } }
+            """);
 #endif
     }
 
     public override async Task Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(async));
 
         AssertMql();
@@ -1130,7 +1127,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Select_entity_compared_to_null(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_entity_compared_to_null(async));
 
         AssertMql();
@@ -1148,7 +1145,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task SelectMany_whose_selector_references_outer_source(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.SelectMany_whose_selector_references_outer_source(async));
 
         AssertMql();
@@ -1156,7 +1153,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Collection_FirstOrDefault_with_entity_equality_check_in_projection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Collection_FirstOrDefault_with_entity_equality_check_in_projection(async));
 
         AssertMql();
@@ -1164,7 +1161,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Collection_FirstOrDefault_with_nullable_unsigned_int_column(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Collection_FirstOrDefault_with_nullable_unsigned_int_column(async));
 
         AssertMql();
@@ -1172,7 +1169,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task ToList_Count_in_projection_works(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.ToList_Count_in_projection_works(async));
 
         AssertMql();
@@ -1180,7 +1177,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task LastOrDefault_member_access_in_projection_translates_to_server(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.LastOrDefault_member_access_in_projection_translates_to_server(async));
 
         AssertMql();
@@ -1188,35 +1185,27 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projection_with_parameterized_constructor(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the Customer property",
-            (await Assert.ThrowsAsync<FormatException>(() =>
-                base.Projection_with_parameterized_constructor(async))).Message);
+        await base.Projection_with_parameterized_constructor(async);
 
         AssertMql(
             """
-            Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "Customer" : "$$ROOT", "_id" : 0 } }
+            Customers.{ "$match" : { "_id" : "ALFKI" } }
             """);
     }
 
     public override async Task Projection_with_parameterized_constructor_with_member_assignment(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the Customer property",
-            (await Assert.ThrowsAsync<FormatException>(() =>
-                base.Projection_with_parameterized_constructor_with_member_assignment(async))).Message);
+        await base.Projection_with_parameterized_constructor_with_member_assignment(async);
 
         AssertMql(
             """
-            Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "Customer" : "$$ROOT", "City" : "$City", "_id" : 0 } }
+            Customers.{ "$match" : { "_id" : "ALFKI" } }
             """);
     }
 
     public override async Task Collection_projection_AsNoTracking_OrderBy(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Collection_projection_AsNoTracking_OrderBy(async));
 
         AssertMql();
@@ -1234,7 +1223,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Project_uint_through_collection_FirstOrDefault(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Project_uint_through_collection_FirstOrDefault(async));
 
         AssertMql();
@@ -1242,7 +1231,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Project_keyless_entity_FirstOrDefault_without_orderby(async));
 
         AssertMql();
@@ -1250,7 +1239,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_changes_asc_order_to_desc(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1264,7 +1253,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_changes_desc_order_to_asc(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1278,7 +1267,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_after_multiple_orderbys(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1292,7 +1281,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_after_orderby_thenby(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Reverse_after_orderby_thenby(async))).Message);
@@ -1305,7 +1294,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_subquery_via_pushdown(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1319,7 +1308,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_after_orderBy_and_take(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1333,7 +1322,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_join_outer(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_join_outer(async));
 
         AssertMql();
@@ -1341,7 +1330,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_join_outer_with_take(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_join_outer_with_take(async));
 
         AssertMql();
@@ -1349,7 +1338,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_join_inner(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_join_inner(async));
 
         AssertMql();
@@ -1357,7 +1346,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_join_inner_with_skip(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_join_inner_with_skip(async));
 
         AssertMql();
@@ -1365,7 +1354,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_SelectMany(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_SelectMany(async));
 
         AssertMql();
@@ -1373,7 +1362,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_SelectMany_with_Take(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_SelectMany_with_Take(async));
 
         AssertMql();
@@ -1381,7 +1370,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_projection_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_projection_subquery(async));
 
         AssertMql();
@@ -1389,7 +1378,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_projection_subquery_single_result(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_projection_subquery_single_result(async));
 
         AssertMql();
@@ -1397,7 +1386,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_in_projection_scalar_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported CSHARP-5836
         await AssertTranslationFailed(() => base.Reverse_in_projection_scalar_subquery(async));
 
         AssertMql();
@@ -1405,7 +1394,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projection_AsEnumerable_projection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Projection_AsEnumerable_projection(async));
 
         AssertMql();
@@ -1423,7 +1412,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projecting_multiple_collection_with_same_constant_works(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Projecting_multiple_collection_with_same_constant_works(async));
 
         AssertMql();
@@ -1431,7 +1420,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Custom_projection_reference_navigation_PK_to_FK_optimization(async));
 
         AssertMql();
@@ -1439,7 +1428,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(async));
 
@@ -1448,7 +1437,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projecting_count_of_navigation_which_is_generic_list(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Projecting_count_of_navigation_which_is_generic_list(async));
 
         AssertMql();
@@ -1456,7 +1445,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projecting_count_of_navigation_which_is_generic_collection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Projecting_count_of_navigation_which_is_generic_collection(async));
 
         AssertMql();
@@ -1464,7 +1453,8 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projecting_count_of_navigation_which_is_generic_collection_using_convert(bool async)
     {
-        await AssertNoProjectionSupport(() => base.Projecting_count_of_navigation_which_is_generic_collection_using_convert(async));
+        // Fails: Subquery selection
+        await AssertNoMultiCollectionQuerySupport(() => base.Projecting_count_of_navigation_which_is_generic_collection_using_convert(async));
     }
 
     public override async Task Projection_take_projection_doesnt_project_intermittent_column(bool async)
@@ -1489,7 +1479,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(async));
 
@@ -1519,7 +1509,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Limited support on client evaluation
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1533,7 +1523,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projecting_after_navigation_and_distinct(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Projecting_after_navigation_and_distinct(async));
 
         AssertMql();
@@ -1542,7 +1532,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
     public override async Task
         Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(async));
 
@@ -1551,7 +1541,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Correlated_collection_after_distinct_not_containing_original_identifier(async));
 
         AssertMql();
@@ -1560,7 +1550,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
     public override async Task
         Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async));
 
@@ -1570,7 +1560,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
     public override async Task
         Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(async));
 
@@ -1579,7 +1569,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Select_nested_collection_deep(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_deep(async));
 
         AssertMql();
@@ -1587,7 +1577,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Select_nested_collection_deep_distinct_no_identifiers(async));
 
         AssertMql();
@@ -1606,7 +1596,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Collection_projection_selecting_outer_element_followed_by_take(async));
 
         AssertMql();
@@ -1614,7 +1604,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Take_on_top_level_and_on_collection_projection_with_outer_apply(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Take_on_top_level_and_on_collection_projection_with_outer_apply(async));
 
         AssertMql();
@@ -1622,7 +1612,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Take_on_correlated_collection_in_first(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Take_on_correlated_collection_in_first(async));
 
         AssertMql();
@@ -1630,7 +1620,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Client_projection_via_ctor_arguments(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Client_projection_via_ctor_arguments(async));
 
         AssertMql();
@@ -1638,7 +1628,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Client_projection_with_string_initialization_with_scalar_subquery(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Client_projection_with_string_initialization_with_scalar_subquery(async));
 
         AssertMql();
@@ -1646,7 +1636,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task MemberInit_in_projection_without_arguments(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.MemberInit_in_projection_without_arguments(async));
 
         AssertMql();
@@ -1684,7 +1674,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Projection_when_arithmetic_mixed_subqueries(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Projection_when_arithmetic_mixed_subqueries(async));
 
         AssertMql();
@@ -1692,7 +1682,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Select_datetime_Ticks_component(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Unsupported by driver
         Assert.Contains(
             "Expression not supported: o.OrderDate.Value.Ticks.",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1716,31 +1706,21 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Select_anonymous_with_object(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the c property",
-            (await Assert.ThrowsAsync<FormatException>(() =>
-                base.Select_anonymous_with_object(async))).Message);
+        await base.Select_anonymous_with_object(async);
 
         AssertMql(
             """
-            Customers.{ "$project" : { "City" : "$City", "c" : "$$ROOT", "_id" : 0 } }
+            Customers.
             """);
     }
 
-    [ConditionalTheory(Skip = "Failing sometimes on latest server.")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task Client_method_in_projection_requiring_materialization_1(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Command aggregate failed",
-            (await Assert.ThrowsAsync<MongoCommandException>(() =>
-                base.Client_method_in_projection_requiring_materialization_1(async))).Message);
+        await base.Client_method_in_projection_requiring_materialization_1(async);
 
         AssertMql(
             """
-            Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^A", "options" : "s" } } } }, { "$project" : { "_v" : { "$toString" : "$$ROOT" }, "_id" : 0 } }
+            Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^A", "options" : "s" } } } }
             """);
     }
 
@@ -1766,15 +1746,11 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Client_method_in_projection_requiring_materialization_2(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Expression not supported: ClientMethod(c)",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Client_method_in_projection_requiring_materialization_2(async))).Message);
+        await base.Client_method_in_projection_requiring_materialization_2(async);
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^A", "options" : "s" } } } }
             """);
     }
 
@@ -1835,7 +1811,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
     public override async Task
         Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(async));
 
@@ -1844,7 +1820,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails unknown issue
         Assert.Contains(
             "Command aggregate failed: Invalid $project :: caused by :: Cannot do exclusion on field _key1 in inclusion projection.",
             (await Assert.ThrowsAsync<MongoCommandException>(() =>
@@ -1858,7 +1834,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task Reverse_without_explicit_ordering(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Reverse not supported by driver
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1872,7 +1848,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task List_of_list_of_anonymous_type(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.List_of_list_of_anonymous_type(async));
 
         AssertMql();
@@ -1880,7 +1856,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task List_from_result_of_single_result(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.List_from_result_of_single_result(async));
 
         AssertMql();
@@ -1888,7 +1864,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task List_from_result_of_single_result_2(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.List_from_result_of_single_result_2(async));
 
         AssertMql();
@@ -1896,7 +1872,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 
     public override async Task List_from_result_of_single_result_3(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.List_from_result_of_single_result_3(async));
 
         AssertMql();
@@ -1915,21 +1891,17 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
 #if EF9
     public override async Task Entity_passed_to_DTO_constructor_works(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Expression not supported: new CustomerDtoWithEntityInCtor(c) because couldn't find matching properties for constructor parameters.",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Entity_passed_to_DTO_constructor_works(async))).Message);
+        await base.Entity_passed_to_DTO_constructor_works(async);
 
         AssertMql(
             """
-Customers.
-""");
+            Customers.
+            """);
     }
 
     public override async Task Set_operation_in_pending_collection(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Set_operation_in_pending_collection(async));
 
         AssertMql();
@@ -1943,7 +1915,8 @@ Customers.
     protected override void ClearLog()
         => Fixture.TestMqlLoggerFactory.Clear();
 
-    // Fails: Projections issue EF-76
-    private static async Task AssertNoProjectionSupport(Func<Task> query)
-        => await Assert.ThrowsAsync<InvalidOperationException>(query);
+    // Fails: Cross-document navigation access issue EF-216
+    private static async Task AssertNoMultiCollectionQuerySupport(Func<Task> query)
+        => Assert.Contains("Unsupported cross-DbSet query between",
+            (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
 }

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
@@ -185,11 +185,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
     public override async Task Project_to_object_array(bool async)
     {
-        // Fails: Mixed array types not supported by C# driver
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Project_to_object_array(async))).Message);
+        await base.Project_to_object_array(async);
 
         AssertMql(
             """

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSetOperationsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSetOperationsQueryMongoTest.cs
@@ -41,25 +41,25 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Union_Intersect(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Union_Intersect(async));
     }
 
     public override async Task Intersect_non_entity(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Intersect_non_entity(async));
     }
 
     public override async Task Intersect_nested(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Intersect_nested(async));
     }
 
     public override async Task Intersect(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Intersect(async));
     }
 
@@ -642,7 +642,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Collection_projection_after_set_operation(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Collection_projection_after_set_operation(async));
 
         AssertMql(
@@ -651,7 +651,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Concat_with_one_side_being_GroupBy_aggregate(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Concat_with_one_side_being_GroupBy_aggregate(async));
 
         AssertMql(
@@ -660,7 +660,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Union_on_entity_with_correlated_collection(bool async)
     {
-        // Fails: Cross-document navigation access issue EF-216
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Union_on_entity_with_correlated_collection(async));
 
         AssertMql(
@@ -669,7 +669,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Union_on_entity_plus_other_column_with_correlated_collection(bool async)
     {
-        // Fails: Cross-document navigation access issue EF-216
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Union_on_entity_plus_other_column_with_correlated_collection(async));
 
         AssertMql(
@@ -752,7 +752,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Collection_projection_after_set_operation_fails_if_distinct(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Collection_projection_after_set_operation_fails_if_distinct(async));
 
         AssertMql();
@@ -760,7 +760,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Collection_projection_before_set_operation_fails(bool async)
     {
-        // Fails: Projections issue EF-76
+        // Fails: Subquery selection
         await AssertTranslationFailed(() => base.Collection_projection_before_set_operation_fails(async));
 
         AssertMql();
@@ -770,7 +770,8 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Intersect_on_distinct(bool async)
     {
-        await AssertNoProjectionSupport(() => base.Intersect_on_distinct(async));
+        // Fails: Subquery selection
+        await AssertTranslationFailed(() => base.Intersect_on_distinct(async));
     }
 
     public override async Task Union_on_distinct(bool async)
@@ -877,10 +878,6 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     protected override void ClearLog()
         => Fixture.TestMqlLoggerFactory.Clear();
-
-    // Fails: Projections issue EF-76
-    private static Task AssertNoProjectionSupport(Func<Task> query)
-        => Assert.ThrowsAsync<InvalidOperationException>(() => query());
 
     // Fails: Cross-document navigation access issue EF-216
     private static async Task AssertNoMultiCollectionQuerySupport(Func<Task> query)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
@@ -1892,14 +1892,11 @@ Products.{ "$match" : { "UnitPrice" : { "$gt" : 100.0 } } }
 
     public override async Task Where_simple_shadow_projection_mixed(bool async)
     {
-        // Fails: Projected entity issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the e property ",
-            (await Assert.ThrowsAsync<FormatException>(() => base.Where_simple_shadow_projection_mixed(async))).Message);
+        await base.Where_simple_shadow_projection_mixed(async);
 
         AssertMql(
             """
-            Employees.{ "$match" : { "Title" : "Sales Representative" } }, { "$project" : { "e" : "$$ROOT", "Title" : "$Title", "_id" : 0 } }
+            Employees.{ "$match" : { "Title" : "Sales Representative" } }
             """);
     }
 
@@ -1915,14 +1912,11 @@ Products.{ "$match" : { "UnitPrice" : { "$gt" : 100.0 } } }
 
     public override async Task Where_primitive_tracked2(bool async)
     {
-        // Fails: Projected entity issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the e property ",
-            (await Assert.ThrowsAsync<FormatException>(() => base.Where_primitive_tracked2(async))).Message);
+        await base.Where_primitive_tracked2(async);
 
         AssertMql(
             """
-            Employees.{ "$limit" : 9 }, { "$match" : { "_id" : 5 } }, { "$project" : { "e" : "$$ROOT", "_id" : 0 } }
+            Employees.{ "$limit" : 9 }, { "$match" : { "_id" : 5 } }
             """);
     }
 
@@ -2566,10 +2560,6 @@ Products.{ "$match" : { "UnitPrice" : { "$gt" : 100.0 } } }
 
     protected override void ClearLog()
         => Fixture.TestMqlLoggerFactory.Clear();
-
-    // Fails: Projections issue EF-76
-    private static async Task AssertNoProjectionSupport(Func<Task> query)
-        => await Assert.ThrowsAsync<InvalidOperationException>(query);
 
     // Fails: Cross-document navigation access issue EF-216
     private static async Task AssertNoMultiCollectionQuerySupport(Func<Task> query)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchExactMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchExactMongoTest.cs
@@ -268,7 +268,17 @@ Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsInd
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsIndex", "exact" : true, "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Book" : "$$ROOT", "Score" : "$__score", "_id" : 0 } }
+Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsIndex", "exact" : true, "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }
+""");
+    }
+
+    public override async Task VectorSearch_with_projection_of_entity_and_score_using_EF_Property(bool async)
+    {
+        await base.VectorSearch_with_projection_of_entity_and_score_using_EF_Property(async);
+
+        AssertMql(
+            """
+Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsIndex", "exact" : true, "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }
 """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTest.cs
@@ -267,7 +267,17 @@ Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40, "index" : "FloatsIndex", "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Book" : "$$ROOT", "Score" : "$__score", "_id" : 0 } }
+Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40, "index" : "FloatsIndex", "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }
+""");
+    }
+
+    public override async Task VectorSearch_with_projection_of_entity_and_score_using_EF_Property(bool async)
+    {
+        await base.VectorSearch_with_projection_of_entity_and_score_using_EF_Property(async);
+
+        AssertMql(
+            """
+Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40, "index" : "FloatsIndex", "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }
 """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTestBase.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTestBase.cs
@@ -481,12 +481,41 @@ public abstract class VectorSearchMongoTestBase
             .Where(e => e.Title.Contains("Action") || e.Title.Contains("DbContext"))
             .Select(e => new { Book = e, Score = Mql.Field(e, "__score", DoubleSerializer.Instance) });
 
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the Book ",
-            (await Assert.ThrowsAsync<FormatException>(async () =>
-                _ = async ? await queryable.ToListAsync() : queryable.ToList()))
-            .Message);
+        var results = async ? await queryable.ToListAsync() : queryable.ToList();
+        Assert.Equal(2, results.Count);
+
+        Assert.Equal("Entity Framework Core in Action", results[0].Book.Title);
+        Assert.Equal("Jon P Smith", results[0].Book.Author);
+        Assert.True(results[0].Score > 0);
+
+        Assert.Equal("Programming Entity Framework: DbContext", results[1].Book.Title);
+        Assert.Equal("Julie Lerman", results[1].Book.Author);
+        Assert.True(results[1].Score > 0);
+    }
+
+    [ConditionalTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public virtual async Task VectorSearch_with_projection_of_entity_and_score_using_EF_Property(bool async)
+    {
+        await using var context = Fixture.CreateContext();
+        var inputVector = new[] { 0.33f, -0.52f };
+
+        var queryable = context.Set<Book>()
+            .VectorSearch(e => e.Floats, inputVector, limit: 4, CreateQueryOptions("FloatsIndex"))
+            .Where(e => e.Title.Contains("Action") || e.Title.Contains("DbContext"))
+            .Select(e => new { Book = e, Score = EF.Property<double>(e, "__score") });
+
+        var results = async ? await queryable.ToListAsync() : queryable.ToList();
+        Assert.Equal(2, results.Count);
+
+        Assert.Equal("Entity Framework Core in Action", results[0].Book.Title);
+        Assert.Equal("Jon P Smith", results[0].Book.Author);
+        Assert.True(results[0].Score > 0);
+
+        Assert.Equal("Programming Entity Framework: DbContext", results[1].Book.Title);
+        Assert.Equal("Julie Lerman", results[1].Book.Author);
+        Assert.True(results[1].Score > 0);
     }
 
     [ConditionalTheory]


### PR DESCRIPTION
Implements [EF-76](https://jira.mongodb.org/browse/EF-76)

## Problem

Select projections that mix entity references with scalar properties (e.g., `Select(p => new { p.Name, Entity = p })`) would previously fail. The query compiler had two rigid paths: 

1. Pure entity (returns `BsonDocument`, shaped client-side using EF shapers)
2. Pure scalar (fully pushed down to LINQ V3 and materialized outside EF)

Any `.Select` attempting to project both the entity and a scalar threw an exception.

## Solution

This PR introduces a introduces a **`ProjectionAnalyzer`** that walks the shaper expression tree to classify projections as fully push-downable or mixed. For mixed projections, a new **`MongoMixedProjectionBindingRemovingExpressionVisitor`** strips the `Select` so the server returns full `BsonDocument`s, then reads scalars from the root document using serialization info while delegating entity materialization to the existing base visitor.

It also extends `MongoProjectionBindingExpressionVisitor` to recognize `EF.Property()` and `Mql.Field()` as scalar property accesses in projection mappings and refactors `MongoShapedQueryCompilingExpressionVisitor` to share translation logic via a common `TranslateQuery<TSource>` helper across all three paths (entity, projected, mixed).

## Testing

- ~1000 lines of new functional tests covering anonymous types, DTOs, tuples, conditional expressions, `EF.Property`, and entity + scalar combinations
- Multiple EF specification tests unblocked (previously expected to throw)
- Some remaining EF specification tests still fail as they have moved on to the next issue which is mostly about subqueries and cross-collection selects which are to be handled in ticket [EF-117](https://jira.mongodb.org/browse/EF-117)
