### PR TITLE
EF-301: Update to driver 3.7

### DIFF
--- a/Versions.props
+++ b/Versions.props
@@ -3,6 +3,6 @@
     <EF8Version>8.0.23</EF8Version>
     <EF9Version>9.0.12</EF9Version>
     <EF10Version>10.0.2</EF10Version>
-    <CSharpDriverVersion>3.6.0</CSharpDriverVersion>
+    <CSharpDriverVersion>3.7.0</CSharpDriverVersion>
   </PropertyGroup>
 </Project>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/ValueConverterTests.cs
@@ -275,9 +275,13 @@ public class ValueConverterTests(TemporaryDatabaseFixture database)
         using var db =
             SingleEntityDbContext.Create(collection, defaultConverter ? DefaultNullableIntToString : NullableIntToString);
 
-        var found = db.Entities.First(e => e.days == days);
-        Assert.Equal(expected._id, found._id);
-        Assert.Equal(days, found.days);
+        // Fails EF-297 (value conversions with 3.7)
+        Assert.Contains("violates the constraint of type 'TDerived'",
+            Assert.Throws<ArgumentException>(() => db.Entities.First(e => e.days == days)).Message);
+
+        // var found = db.Entities.First(e => e.days == days);
+        // Assert.Equal(expected._id, found._id);
+        // Assert.Equal(days, found.days);
     }
 
     [Theory]
@@ -381,9 +385,13 @@ public class ValueConverterTests(TemporaryDatabaseFixture database)
         using var db =
             SingleEntityDbContext.Create(collection, defaultConverter ? DefaultNullableEnumToString : NullableEnumToString);
 
-        var found = db.Entities.First(e => e.day == day);
-        Assert.Equal(expected._id, found._id);
-        Assert.Equal(day, found.day);
+        // Fails EF-297 (value conversions with 3.7)
+        Assert.Contains("violates the constraint of type 'TDerived'",
+            Assert.Throws<ArgumentException>(() => db.Entities.First(e => e.day == day)).Message);
+
+        // var found = db.Entities.First(e => e.day == day);
+        // Assert.Equal(expected._id, found._id);
+        // Assert.Equal(day, found.day);
     }
 
     [Theory]
@@ -475,9 +483,13 @@ public class ValueConverterTests(TemporaryDatabaseFixture database)
         var collection = database.GetCollection<DayIsNullableEnum>(docs.CollectionNamespace);
         using var db = SingleEntityDbContext.Create(collection, null, ConfigDefaultNullableEnumToString);
 
-        var found = db.Entities.First(e => e.day == day);
-        Assert.Equal(expected._id, found._id);
-        Assert.Equal(day, found.day);
+        // Fails EF-297 (value conversions with 3.7)
+        Assert.Contains("violates the constraint of type 'TDerived'",
+            Assert.Throws<ArgumentException>(() => db.Entities.First(e => e.day == day)).Message);
+
+        // var found = db.Entities.First(e => e.day == day);
+        // Assert.Equal(expected._id, found._id);
+        // Assert.Equal(day, found.day);
     }
 
     [Theory]
@@ -518,12 +530,18 @@ public class ValueConverterTests(TemporaryDatabaseFixture database)
         docs.InsertOne(expected);
 
         var collection = database.GetCollection<DayIsNullableEnum>(docs.CollectionNamespace);
+
         using var db = SingleEntityDbContext.Create(collection,
             defaultConverter ? DefaultNullableEnumToNullableInt : NullableEnumToNullableInt);
 
-        var found = db.Entities.First(e => e.day == day);
-        Assert.Equal(expected._id, found._id);
-        Assert.Equal(day, found.day);
+        // Fails EF-297 (value conversions with 3.7)
+        Assert.Contains("violates the constraint of type 'TDerived'",
+            Assert.Throws<ArgumentException>(() => db.Entities.First(e => e.day == day)).Message);
+
+        // var found = db.Entities.First(e => e.day == day);
+        // var found = collection.AsQueryable().First(e => e.day == day);
+        // Assert.Equal(expected._id, found._id);
+        // Assert.Equal(day, found.day);
     }
 
     [Theory]

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -131,9 +131,15 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         using var db = SingleEntityDbContext.Create(collection);
 
         var location = db.Entities.First().locations[1];
-        var actual = db.Entities.FirstOrDefault(p => p.locations.Contains(location));
 
-        Assert.Equal("Damien", actual.name);
+        // Fails EF-299 entity equality
+        Assert.Contains(
+            "Entity to entity comparison is not supported",
+            Assert.Throws<NotSupportedException>(() => db.Entities.FirstOrDefault(p => !p.locations.Contains(location))).Message);
+
+        // var actual = db.Entities.FirstOrDefault(p => p.locations.Contains(location));
+        //
+        // Assert.Equal("Damien", actual.name);
     }
 
     [Fact]
@@ -144,9 +150,15 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         using var db = SingleEntityDbContext.Create(collection);
 
         var location = db.Entities.First().locations[1];
-        var actual = db.Entities.FirstOrDefault(p => !p.locations.Contains(location));
 
-        Assert.Equal("Carmen", actual.name);
+        // Fails EF-299 entity equality
+        Assert.Contains(
+            "Entity to entity comparison is not supported",
+            Assert.Throws<NotSupportedException>(() => db.Entities.FirstOrDefault(p => !p.locations.Contains(location))).Message);
+
+        // var actual = db.Entities.FirstOrDefault(p => !p.locations.Contains(location));
+        //
+        // Assert.Equal("Carmen", actual.name);
     }
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereDictionaryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/WhereDictionaryTests.cs
@@ -206,8 +206,12 @@ public class WhereDictionaryTests(TemporaryDatabaseFixture database)
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
-            Assert.Single(results);
+
+            // Fails EF-300 different dictionary types
+            Assert.Throws<NullReferenceException>(() => db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray());
+
+            // var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
+            // Assert.Single(results);
         }
     }
 
@@ -286,8 +290,12 @@ public class WhereDictionaryTests(TemporaryDatabaseFixture database)
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
-            Assert.Single(results);
+
+            // Fails EF-300 different dictionary types
+            Assert.Throws<NullReferenceException>(() => db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray());
+
+            // var results = db.Entities.Where(e => e.Dictionary.ContainsKey("key1")).ToArray();
+            // Assert.Single(results);
         }
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Mapping/BuiltInDataTypesMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Mapping/BuiltInDataTypesMongoTest.cs
@@ -17,7 +17,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using MongoDB.Driver;
-using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Linq;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
 using Xunit.Sdk;
@@ -27,18 +27,6 @@ namespace MongoDB.EntityFrameworkCore.SpecificationTests.Mapping;
 public class BuiltInDataTypesMongoTest(BuiltInDataTypesMongoTest.BuiltInDataTypesMongoFixture fixture)
     : BuiltInDataTypesTestBase<BuiltInDataTypesMongoTest.BuiltInDataTypesMongoFixture>(fixture)
 {
-    // Fails: Enum casting issue EF-215
-    public override async Task Can_filter_projection_with_captured_enum_variable(bool async)
-        => Assert.Contains(
-            "Unexpected target type: Microsoft.EntityFrameworkCore.BuiltInDataTypesTestBase`1+EmailTemplateTypeDto[",
-            (await Assert.ThrowsAsync<Exception>(() => base.Can_filter_projection_with_captured_enum_variable(async))).Message);
-
-    // Fails: Enum casting issue EF-215
-    public override async Task Can_filter_projection_with_inline_enum_variable(bool async)
-        => Assert.Contains(
-            "Unexpected target type: Microsoft.EntityFrameworkCore.BuiltInDataTypesTestBase`1+EmailTemplateTypeDto[",
-            (await Assert.ThrowsAsync<Exception>(() => base.Can_filter_projection_with_inline_enum_variable(async))).Message);
-
     #if !EF8
     // Fails: Include issue EF-117
     public override async Task Can_insert_and_read_back_with_string_key()
@@ -64,10 +52,8 @@ public class BuiltInDataTypesMongoTest(BuiltInDataTypesMongoTest.BuiltInDataType
 
     // Fails: Projecting DateTimeOffset members EF-218
     public override async Task Optional_datetime_reading_null_from_database()
-        => Assert.Contains(
-            "Serializer for System.DateTimeOffset does not represent members as fields.",
-            (await Assert.ThrowsAsync<NotSupportedException>(() => base.Optional_datetime_reading_null_from_database()))
-            .Message);
+        => await Assert.ThrowsAsync<ExpressionNotSupportedException>(
+            () => base.Optional_datetime_reading_null_from_database());
     #else
     // Fails: Include issue EF-117
     public override void Can_insert_and_read_back_with_string_key()
@@ -92,9 +78,8 @@ public class BuiltInDataTypesMongoTest(BuiltInDataTypesMongoTest.BuiltInDataType
 
     // Fails: Projecting DateTimeOffset members EF-218
     public override void Optional_datetime_reading_null_from_database()
-        => Assert.Contains(
-            "Serializer for System.DateTimeOffset does not represent members as fields.",
-            Assert.Throws<NotSupportedException>(() => base.Optional_datetime_reading_null_from_database()).Message);
+        => Assert.Throws<ExpressionNotSupportedException>(
+            () => base.Optional_datetime_reading_null_from_database());
     #endif
 
     private static void AssertTranslationFailed(Action query)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -117,8 +117,8 @@ public class NorthwindAggregateOperatorsQueryMongoTest
     {
         // Fails: Does not use translation failed message
         Assert.Contains(
-            "Serializer for Microsoft.EntityFramework",
-            (await Assert.ThrowsAsync<ContainsException>(() =>
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() =>
                 base.Average_with_unmapped_property_access_throws_meaningful_exception(async))).Message);
 
         AssertMql(

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindCompiledQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindCompiledQueryMongoTest.cs
@@ -171,8 +171,8 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
     {
          // Fails: Compiled query with non-query operator issue EF-232
          Assert.Contains(
-             "LogicalBinaryExpression' to type 'System.Linq.Expressions.MethodCallExpression'",
-             Assert.Throws<InvalidCastException>(() => base.Compiled_query_when_does_not_end_in_query_operator()).Message);
+             "No ultimate source found",
+             Assert.Throws<ArgumentException>(() => base.Compiled_query_when_does_not_end_in_query_operator()).Message);
 
          AssertMql(
              """

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
@@ -15,6 +15,7 @@
 
 #if EF8 || EF9
 
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -759,7 +760,7 @@ Customers.{ "$match" : { "_id" : { "$gte" : "AROUT" } } }
     {
         // Fails: String.Replace issue EF-223
         Assert.Contains(
-            "Expression not supported: \"AROUT\".Replace",
+            "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.String_Compare_to_nested(async))).Message);
 
         AssertMql(
@@ -1752,10 +1753,8 @@ OrderDetails.
 
     public override async Task Convert_ToByte(bool async)
     {
-        // Fails: Translate Convert methods issue EF-235
-        Assert.Contains(
-            "Expression not supported: ToByte(",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Convert_ToByte(async))).Message);
+        // Fails: Throws a different exception on EF9
+        await Assert.ThrowsAsync<TargetInvocationException>(() => base.Convert_ToByte(async));
 
         AssertMql(
             """
@@ -1791,10 +1790,8 @@ OrderDetails.
 
     public override async Task Convert_ToInt16(bool async)
     {
-        // Fails: Translate Convert methods issue EF-235
-        Assert.Contains(
-            "Expression not supported: ToInt16(",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Convert_ToInt16(async))).Message);
+        // Fails: Throws a different exception on EF9
+        await Assert.ThrowsAsync<TargetInvocationException>(() => base.Convert_ToInt16(async));
 
         AssertMql(
             """

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -905,14 +905,11 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task OrderBy_arithmetic(bool async)
     {
-        // Fails: Cross-document navigation access issue EF-216
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.OrderBy_arithmetic(async))).Message);
+        await base.OrderBy_arithmetic(async);
 
         AssertMql(
             """
-            Employees.
+            Employees.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subtract" : ["$_id", "$_id"] } } }, { "$sort" : { "_key1" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }
             """);
     }
 
@@ -4679,8 +4676,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws.
         Assert.Contains(
-            "Serializer for",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Where_query_composition5(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_query_composition5(async))).Message);
 
         AssertMql(
             """
@@ -4692,8 +4689,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws.
         Assert.Contains(
-            "Serializer for",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Where_query_composition6(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_query_composition6(async))).Message);
 
         AssertMql(
             """
@@ -4744,8 +4741,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws.
         Assert.Contains(
-            "Serializer for",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.OrderBy_client_mixed(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.OrderBy_client_mixed(async))).Message);
 
         AssertMql(
             """
@@ -4814,8 +4811,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws.
         Assert.Contains(
-            "Serializer for",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Queryable_reprojection(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Queryable_reprojection(async))).Message);
 
         AssertMql(
             """
@@ -4827,8 +4824,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.All_client(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.All_client(async))).Message);
         AssertMql(
             """
             Customers.
@@ -4839,8 +4836,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.All_client_and_server_top_level(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.All_client_and_server_top_level(async))).Message);
 
         AssertMql(
             """
@@ -4852,8 +4849,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.All_client_or_server_top_level(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.All_client_or_server_top_level(async))).Message);
 
         AssertMql(
             """
@@ -4865,8 +4862,8 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
     {
         // Fails: Not throwing expected translation failed exception from EF, but still throws
         Assert.Contains(
-            "Serializer for",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.First_client_predicate(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.First_client_predicate(async))).Message);
 
         AssertMql(
             """

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
@@ -185,29 +185,22 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
 
     public override async Task Project_to_object_array(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Project_to_object_array(async))).Message);
+        await base.Project_to_object_array(async);
 
         AssertMql(
             """
-            Employees.
+            Employees.{ "$match" : { "_id" : 1 } }, { "$project" : { "_v" : ["$_id", "$ReportsTo", "$Title"], "_id" : 0 } }
             """);
     }
 
     public override async Task Projection_of_entity_type_into_object_array(bool async)
     {
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Constructor on type 'MongoDB.Bson.Serialization.Serializers.ArraySerializer",
-            (await Assert.ThrowsAsync<MissingMethodException>(() =>
-                base.Projection_of_entity_type_into_object_array(async))).Message);
+        await Assert.ThrowsAsync<NotImplementedException>(()
+            => base.Projection_of_entity_type_into_object_array(async));
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^A", "options" : "s" } } } }, { "$project" : { "_v" : ["$$ROOT"], "_id" : 0 } }
             """);
     }
 
@@ -648,7 +641,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
     {
         // Fails: Projections issue EF-76
         Assert.Contains(
-            "Expression not supported: Format(\"{0}\", Convert(e.EmployeeID, Object)).",
+            "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
                 base.Projection_in_a_subquery_should_be_liftable(async))).Message);
 
@@ -662,7 +655,7 @@ Orders.{ "$project" : { "_v" : { "$cond" : { "if" : { "$ne" : [{ "$mod" : ["$_id
     {
         // Fails: Projections issue EF-76
         Assert.Contains(
-            "Expression not supported: (o.OrderDate.Value",
+            "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
                 base.Projection_containing_DateTime_subtraction(async))).Message);
 
@@ -922,7 +915,7 @@ Customers.{ "$project" : { "_v" : { "$eq" : ["$_id", "ALFKI"] }, "_id" : 0 } }
     {
         // Fails: Projections issue EF-76
         Assert.Contains(
-            "Expression not supported: o.OrderDate.GetValueOrDefault().",
+            "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
                 base.Select_GetValueOrDefault_on_DateTime(async))).Message);
 
@@ -1527,10 +1520,8 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
     public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
     {
         // Fails: Projections issue EF-76
-        Assert.Contains(
-            "Expression not supported: ClientMethod(o.CustomerID).",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Ternary_in_client_eval_assigns_correct_types(async))).Message);
+        await Assert.ThrowsAsync<ExpressionNotSupportedException>(()
+            => base.Ternary_in_client_eval_assigns_correct_types(async));
 
         AssertMql(
             """
@@ -1775,7 +1766,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$project" : { "_v" : { "$indexO
     {
         // Fails: Projections issue EF-76
         Assert.Contains(
-            "Expression not supported: ClientMethod(c).",
+            "Expression not supported: ClientMethod(c)",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
                 base.Client_method_in_projection_requiring_materialization_2(async))).Message);
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
@@ -169,11 +169,11 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
 
         AssertMql(
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, 2] } } }
+            Employees.{ "$match" : { "ReportsTo" : 2 } }
             """,
             //
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, 5] } } }
+            Employees.{ "$match" : { "ReportsTo" : 5 } }
             """);
     }
 
@@ -323,15 +323,15 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
 
         AssertMql(
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, 2] } } }
+            Employees.{ "$match" : { "ReportsTo" : 2 } }
             """,
             //
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, 5] } } }
+            Employees.{ "$match" : { "ReportsTo" : 5 } }
             """,
             //
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, null] } } }
+            Employees.{ "$match" : { "ReportsTo" : null } }
             """);
     }
 
@@ -341,15 +341,15 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
 
         AssertMql(
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, null] } } }
+            Employees.{ "$match" : { "ReportsTo" : null } }
             """,
             //
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, 5] } } }
+            Employees.{ "$match" : { "ReportsTo" : 5 } }
             """,
             //
             """
-            Employees.{ "$match" : { "$expr" : { "$eq" : [{ "$toLong" : "$ReportsTo" }, 2] } } }
+            Employees.{ "$match" : { "ReportsTo" : 2 } }
             """);
     }
 
@@ -406,8 +406,8 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
     {
         // Fails: Not throwing expected translation failed exception from EF.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Where_client(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client(async))).Message);
 
         AssertMql(
             """
@@ -444,8 +444,8 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
     {
         // Fails: Not throwing expected translation failed exception from EF.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Where_client_and_server_top_level(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_and_server_top_level(async))).Message);
 
         AssertMql(
             """
@@ -457,8 +457,8 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
     {
         // Fails: Not throwing expected translation failed exception from EF.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Where_client_or_server_top_level(async))).Message);
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_or_server_top_level(async))).Message);
 
         AssertMql(
             """
@@ -470,8 +470,8 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
     {
         // Fails: Not throwing expected translation failed exception from EF.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Where_client_and_server_non_top_level(async)))
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_and_server_non_top_level(async)))
             .Message);
 
         AssertMql(
@@ -484,8 +484,8 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
     {
         // Fails: Not throwing expected translation failed exception from EF.
         Assert.Contains(
-            "Serializer for Microsoft.",
-            (await Assert.ThrowsAsync<ContainsException>(() => base.Where_client_deep_inside_predicate_and_server_top_level(async)))
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_deep_inside_predicate_and_server_top_level(async)))
             .Message);
 
         AssertMql(
@@ -953,8 +953,8 @@ Products.{ "$match" : { "UnitsInStock" : { "$gte" : 20 } } }
         await base.Where_comparison_to_nullable_bool(async);
         AssertMql(
             """
-            Customers.{ "$match" : { "$expr" : { "$eq" : [{ "$let" : { "vars" : { "start" : { "$subtract" : [{ "$strLenCP" : "$_id" }, 2] } }, "in" : { "$and" : [{ "$gte" : ["$$start", 0] }, { "$eq" : [{ "$indexOfCP" : ["$_id", "KI", "$$start"] }, "$$start"] }] } } }, true] } } }
-            """);
+Customers.{ "$match" : { "$expr" : { "$let" : { "vars" : { "start" : { "$subtract" : [{ "$strLenCP" : "$_id" }, 2] } }, "in" : { "$and" : [{ "$gte" : ["$$start", 0] }, { "$eq" : [{ "$indexOfCP" : ["$_id", "KI", "$$start"] }, "$$start"] }] } } } } }
+""");
     }
 
     public override async Task Where_true(bool async)
@@ -1303,7 +1303,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
 
         AssertMql(
             """
-            Products.{ "$match" : { "$expr" : { "$gt" : [{ "$toDouble" : "$UnitPrice" }, 100.0] } } }
+            Products.{ "$match" : { "UnitPrice" : { "$gt" : 100.0 } } }
             """);
     }
 
@@ -2211,14 +2211,11 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
 
     public override async Task Where_string_indexof(bool async)
     {
-        // Fails: String.IndexOf issue EF-224
-        Assert.Contains(
-            "Values differ", // (Expected 1, got 90)
-            (await Assert.ThrowsAsync<EqualException>(() => base.Where_string_indexof(async))).Message);
+        await base.Where_string_indexof(async);
 
         AssertMql(
             """
-            Customers.{ "$match" : { "City" : { "$not" : { "$regularExpression" : { "pattern" : "^Sea", "options" : "s" } } } } }
+            Customers.{ "$match" : { "$expr" : { "$ne" : [{ "$indexOfCP" : ["$City", "Sea"] }, -1] } } }
             """);
     }
 
@@ -2226,7 +2223,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
     {
         // Fails: String.Replace issue EF-223
         Assert.Contains(
-            "Expression not supported: c.City.Replace(\"Sea\", \"Rea\").",
+            "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Where_string_replace(async))).Message);
 
         AssertMql(
@@ -2393,10 +2390,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
     public override async Task Where_datetimeoffset_now_component(bool async)
     {
         // Fails: DateTimeOffset issue CSHARP-5296
-        Assert.Contains(
-            "Expression not supported: Convert(",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Where_datetimeoffset_now_component(async)))
-            .Message);
+        await Assert.ThrowsAsync<ArgumentException>(() => base.Where_datetimeoffset_now_component(async));
 
         AssertMql(
             """
@@ -2407,10 +2401,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
     public override async Task Where_datetimeoffset_utcnow_component(bool async)
     {
         // Fails: DateTimeOffset issue CSHARP-5296
-        Assert.Contains(
-            "Expression not supported: Convert(",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Where_datetimeoffset_utcnow_component(async)))
-            .Message);
+        await Assert.ThrowsAsync<ArgumentException>(() => base.Where_datetimeoffset_utcnow_component(async));
 
         AssertMql(
             """

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchExactMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchExactMongoTest.cs
@@ -258,7 +258,7 @@ Books.{ "$vectorSearch" : { "path" : "Preface.Floats", "limit" : 4, "index" : "F
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsIndex", "exact" : true, "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Author" : "$Author", "Score" : "$__score", "_id" : 0 } }
+Books.
 """);
     }
 
@@ -268,7 +268,7 @@ Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsInd
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsIndex", "exact" : true, "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Book" : "$$ROOT", "Score" : "$__score", "_id" : 0 } }
+Books.
 """);
     }
 
@@ -278,7 +278,7 @@ Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsInd
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "index" : "FloatsIndex", "exact" : true, "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Book" : { "_id" : "$_id", "Title" : "$Title", "Author" : "$Author", "Isbn" : "$Isbn", "Comments" : "$comments", "Pages" : "$Pages", "IsPublished" : "$is_published" }, "Score" : "$__score", "_id" : 0 } }
+Books.
 """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTest.cs
@@ -257,7 +257,7 @@ Books.{ "$vectorSearch" : { "path" : "Preface.Floats", "limit" : 4, "numCandidat
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40, "index" : "FloatsIndex", "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Author" : "$Author", "Score" : "$__score", "_id" : 0 } }
+Books.
 """);
     }
 
@@ -267,7 +267,7 @@ Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40, "index" : "FloatsIndex", "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Book" : "$$ROOT", "Score" : "$__score", "_id" : 0 } }
+Books.
 """);
     }
 
@@ -277,7 +277,7 @@ Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40
 
         AssertMql(
             """
-Books.{ "$vectorSearch" : { "path" : "Floats", "limit" : 4, "numCandidates" : 40, "index" : "FloatsIndex", "queryVector" : [0.33000001311302185, -0.51999998092651367] } }, { "$addFields" : { "__score" : { "$meta" : "vectorSearchScore" } } }, { "$match" : { "$or" : [{ "Title" : { "$regularExpression" : { "pattern" : "Action", "options" : "s" } } }, { "Title" : { "$regularExpression" : { "pattern" : "DbContext", "options" : "s" } } }] } }, { "$project" : { "Book" : { "_id" : "$_id", "Title" : "$Title", "Author" : "$Author", "Isbn" : "$Isbn", "Comments" : "$comments", "Pages" : "$Pages", "IsPublished" : "$is_published" }, "Score" : "$__score", "_id" : 0 } }
+Books.
 """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTestBase.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/VectorSearchMongoTestBase.cs
@@ -438,13 +438,18 @@ public abstract class VectorSearchMongoTestBase
             .Where(e => e.Title.Contains("Action") || e.Title.Contains("DbContext"))
             .Select(e => new { e.Author, Score = Mql.Field<Book, double>(e, "__score", null) });
 
-        var results = async ? await queryable.ToListAsync() : queryable.ToList();
-
-        Assert.Equal(2, results.Count);
-        Assert.Equal("Jon P Smith", results[0].Author);
-        Assert.Equal("Julie Lerman", results[1].Author);
-        Assert.Equal(0.99974566698074341, results[0].Score, 5);
-        Assert.Equal(0.99961328506469727, results[1].Score, 5);
+        // Fails EF-298 Projection of unmapped properties
+        await Assert.ThrowsAsync<Driver.Linq.ExpressionNotSupportedException>(async () =>
+        {
+            var results = async ? await queryable.ToListAsync() : queryable.ToList();
+        });
+        // var results = async ? await queryable.ToListAsync() : queryable.ToList();
+        //
+        // Assert.Equal(2, results.Count);
+        // Assert.Equal("Jon P Smith", results[0].Author);
+        // Assert.Equal("Julie Lerman", results[1].Author);
+        // Assert.Equal(0.99974566698074341, results[0].Score, 5);
+        // Assert.Equal(0.99961328506469727, results[1].Score, 5);
     }
 
     [ConditionalTheory]
@@ -482,12 +487,11 @@ public abstract class VectorSearchMongoTestBase
             .Where(e => e.Title.Contains("Action") || e.Title.Contains("DbContext"))
             .Select(e => new { Book = e, Score = Mql.Field<Book, double>(e, "__score", null) });
 
-        // Fails: Projections issue EF-76
-        Assert.Contains(
-            "An error occurred while deserializing the Book ",
-            (await Assert.ThrowsAsync<FormatException>(async () =>
-                _ = async ? await queryable.ToListAsync() : queryable.ToList()))
-            .Message);
+        // Fails EF-298 Projection of unmapped properties
+        await Assert.ThrowsAsync<Driver.Linq.ExpressionNotSupportedException>(async () =>
+        {
+            var results = async ? await queryable.ToListAsync() : queryable.ToList();
+        });
     }
 
     [ConditionalTheory]
@@ -516,21 +520,27 @@ public abstract class VectorSearchMongoTestBase
                 Score = Mql.Field<Book, double>(e, "__score", null)
             });
 
-        var results = async ? await queryable.ToListAsync() : queryable.ToList();
-        Assert.Equal(2, results.Count);
+        // Fails EF-298 Projection of unmapped properties
+        await Assert.ThrowsAsync<Driver.Linq.ExpressionNotSupportedException>(async () =>
+        {
+            var results = async ? await queryable.ToListAsync() : queryable.ToList();
+        });
 
-        Assert.Equal("Entity Framework Core in Action", results[0].Book.Title);
-        Assert.Equal("Jon P Smith", results[0].Book.Author);
-        Assert.Equal([1, 1, 1, 1], results[0].Book.Isbn);
-        Assert.Equal(["Fab", "Froody"], results[0].Book.Comments);
-        Assert.Equal(500, results[0].Book.Pages);
-
-        Assert.Equal("Programming Entity Framework: DbContext", results[1].Book.Title);
-        Assert.Equal("Julie Lerman", results[1].Book.Author);
-        Assert.Equal([1, 1, 1, 2], results[1].Book.Isbn);
-        Assert.Equal(["Fab", "Froody"], results[1].Book.Comments);
-        Assert.Equal(600, results[1].Book.Pages);
-        Assert.False(results[1].Book.IsPublished);
+        // var results = async ? await queryable.ToListAsync() : queryable.ToList();
+        // Assert.Equal(2, results.Count);
+        //
+        // Assert.Equal("Entity Framework Core in Action", results[0].Book.Title);
+        // Assert.Equal("Jon P Smith", results[0].Book.Author);
+        // Assert.Equal([1, 1, 1, 1], results[0].Book.Isbn);
+        // Assert.Equal(["Fab", "Froody"], results[0].Book.Comments);
+        // Assert.Equal(500, results[0].Book.Pages);
+        //
+        // Assert.Equal("Programming Entity Framework: DbContext", results[1].Book.Title);
+        // Assert.Equal("Julie Lerman", results[1].Book.Author);
+        // Assert.Equal([1, 1, 1, 2], results[1].Book.Isbn);
+        // Assert.Equal(["Fab", "Froody"], results[1].Book.Comments);
+        // Assert.Equal(600, results[1].Book.Pages);
+        // Assert.False(results[1].Book.IsPublished);
     }
 
     [ConditionalTheory]


### PR DESCRIPTION
Filed:

- [EF-297](https://jira.mongodb.org/browse/EF-297): Value conversions can fail when using driver 3.7
- [EF-298](https://jira.mongodb.org/browse/EF-298): Projection of unmapped property fails with driver 3.7
- [EF-299](https://jira.mongodb.org/browse/EF-299): Owned entity equality started failing for some cases with driver 3.7
- [EF-300](https://jira.mongodb.org/browse/EF-300): Contains on Dictionary type that does not match model type fails with driver 3.7