### PR TITLE
EF-313: Rewrite binding for robustness with non-trivial shapes

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -19,7 +19,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 using MongoDB.EntityFrameworkCore.Storage;
 
@@ -28,14 +27,13 @@ namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 /// <summary>
 /// Extends <see cref="MongoProjectionBindingRemovingExpressionVisitor"/> to handle mixed projections
 /// (containing both entity references and scalar properties). In this path, the LINQ V3 query
-/// returns full BsonDocuments (Select is stripped), and scalars are read from the root document
-/// using the property's actual serialization info rather than the projection alias.
+/// returns full BsonDocuments (Select is stripped), and scalars are read from the document that
+/// owns the mapped property using the property's actual serialization info.
 /// </summary>
 internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
     : MongoProjectionBindingRemovingExpressionVisitor
 {
     private readonly MongoQueryExpression _queryExpression;
-    private readonly IEntityType _rootEntityType;
     private readonly ParameterExpression _docParameter;
 
     public MongoMixedProjectionBindingRemovingExpressionVisitor(
@@ -46,7 +44,6 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
         : base(rootEntityType, queryExpression, docParameter, trackingBehavior)
     {
         _queryExpression = queryExpression;
-        _rootEntityType = rootEntityType;
         _docParameter = docParameter;
     }
 
@@ -54,86 +51,66 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
     {
         if (extensionExpression is ProjectionBindingExpression projectionBindingExpression)
         {
-            // Scalar projections in the mixed path use ProjectionMember (not Index) because
-            // ApplyProjection() early-returns when entity projections already populated _projection.
             if (projectionBindingExpression.ProjectionMember != null)
             {
                 var mappedExpression = _queryExpression.GetMappedProjection(
                     projectionBindingExpression.ProjectionMember);
 
-                // If ApplyProjection already converted this to an index, use the standard path.
+                // Resolve the source expression: after ApplyProjection it's wrapped as Constant(index),
+                // so we unwrap to get the actual stored expression; otherwise use it directly.
+                Expression? sourceExpression;
+                string? alias;
                 if (mappedExpression is ConstantExpression { Value: int })
                 {
-                    return base.VisitExtension(extensionExpression);
+                    var projection = GetProjection(projectionBindingExpression);
+                    alias = projection.Alias;
+                    if (alias is null)
+                        return _docParameter;
+                    sourceExpression = projection.Expression;
                 }
-
-                // Resolve the IProperty from the mapped expression and read from the full document.
-                var (property, fieldName) = TryResolveFieldAccess(mappedExpression);
-                if (property != null)
+                else
                 {
-                    return CreateGetValueExpression(_docParameter, property, projectionBindingExpression.Type);
+                    alias = projectionBindingExpression.ProjectionMember.Last?.Name;
+                    sourceExpression = mappedExpression;
                 }
 
-                if (fieldName != null)
+                var fieldAccess = TryResolveFieldAccess(sourceExpression);
+                if (fieldAccess.Property != null)
                 {
-                    // Non-model field (e.g., __score from $addFields) — read directly by name.
-                    return BsonBinding.CreateGetElementValue(_docParameter, fieldName, projectionBindingExpression.Type);
+                    if (fieldAccess.DocumentExpression is ParameterExpression parameterExpression
+                        && fieldAccess.MemberInfo != null
+                        && fieldAccess.MemberInfo.DeclaringType?.IsAssignableFrom(parameterExpression.Type) == true)
+                    {
+                        var memberAccess = Expression.MakeMemberAccess(parameterExpression, fieldAccess.MemberInfo);
+                        return memberAccess.Type == projectionBindingExpression.Type
+                            ? memberAccess
+                            : Expression.Convert(memberAccess, projectionBindingExpression.Type);
+                    }
+
+                    return CreateGetValueExpression(
+                        fieldAccess.DocumentExpression ?? _docParameter,
+                        fieldAccess.Property,
+                        projectionBindingExpression.Type);
                 }
 
-                // Fallback: read by projection member name from the root document.
+                if (fieldAccess.FieldName != null)
+                {
+                    return BsonBinding.CreateGetElementValue(
+                        fieldAccess.DocumentExpression ?? _docParameter,
+                        fieldAccess.FieldName,
+                        projectionBindingExpression.Type);
+                }
+
                 return CreateGetValueExpression(
                     _docParameter,
-                    projectionBindingExpression.ProjectionMember.Last?.Name,
+                    alias,
                     !projectionBindingExpression.Type.IsNullableType(),
                     projectionBindingExpression.Type);
             }
 
-            // Index-based bindings are used for entity projections (set by MongoProjectionBindingExpressionVisitor).
-            // Delegate to the base visitor which handles entity materialization.
             return base.VisitExtension(extensionExpression);
         }
 
         return base.VisitExtension(extensionExpression);
-    }
-
-    /// <summary>
-    /// Attempts to resolve an <see cref="IProperty"/> and/or field name from a projection expression that
-    /// represents a scalar property access on the entity (e.g., <c>p.name</c>) or a non-model field
-    /// access (e.g., <c>Mql.Field(e, "__score", null)</c>).
-    /// </summary>
-    private (IProperty? property, string? fieldName) TryResolveFieldAccess(Expression expression)
-    {
-        // Unwrap converts
-        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
-        {
-            expression = unary.Operand;
-        }
-
-        if (expression is MemberExpression memberExpression)
-        {
-            var property = _rootEntityType.FindProperty(memberExpression.Member);
-            return (property, property != null ? null : memberExpression.Member.Name);
-        }
-
-        if (expression is MethodCallExpression methodCall)
-        {
-            // Handle EF.Property<T>(entity, "propertyName") method calls
-            if (methodCall.Method.IsEFPropertyMethod()
-                && methodCall.Arguments[1] is ConstantExpression { Value: string propertyName })
-            {
-                var property = _rootEntityType.FindProperty(propertyName);
-                return (property, property != null ? null : propertyName);
-            }
-
-            // Handle Mql.Field<TDoc, TField>(entity, "fieldName", serializer) calls
-            if (methodCall.Method is { Name: "Field", DeclaringType.FullName: "MongoDB.Driver.Mql" }
-                && methodCall.Arguments[1] is ConstantExpression { Value: string fieldName })
-            {
-                var property = _rootEntityType.FindProperty(fieldName);
-                return (property, property != null ? null : fieldName);
-            }
-        }
-
-        return (null, null);
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
@@ -41,8 +42,8 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
         IEntityType rootEntityType,
         MongoQueryExpression queryExpression,
         ParameterExpression docParameter,
-        bool trackQueryResults)
-        : base(rootEntityType, queryExpression, docParameter, trackQueryResults)
+        QueryTrackingBehavior trackingBehavior)
+        : base(rootEntityType, queryExpression, docParameter, trackingBehavior)
     {
         _queryExpression = queryExpression;
         _rootEntityType = rootEntityType;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -43,9 +43,9 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     private readonly ParameterExpression DocParameter;
     private readonly bool _trackQueryResults;
     private readonly Dictionary<ParameterExpression, Expression> _materializationContextBindings = new();
-    private readonly Dictionary<Expression, ParameterExpression> ProjectionBindings = new();
+    private readonly Dictionary<Expression, ParameterExpression> _projectionBindings = new();
     private readonly Dictionary<Expression, (IEntityType EntityType, Expression BsonDocExpression)> _ownerMappings = new();
-    private readonly Dictionary<Expression, Expression> _ordinalParameterBindings = new();
+    private readonly Dictionary<Expression, Expression> _ordinalMappings = new();
     private List<IncludeExpression> _pendingIncludes = [];
 
     /// <summary>
@@ -98,15 +98,15 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                             throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
                     }
 
-                    var bsonArray = ProjectionBindings[objectArrayProjection];
+                    var bsonArray = _projectionBindings[objectArrayProjection];
                     var jObjectParameter = Expression.Parameter(typeof(BsonDocument), bsonArray.Name + "Object");
                     var ordinalParameter = Expression.Parameter(typeof(int), bsonArray.Name + "Ordinal");
 
                     var accessExpression = objectArrayProjection.InnerProjection.ParentAccessExpression;
-                    ProjectionBindings[accessExpression] = jObjectParameter;
+                    _projectionBindings[accessExpression] = jObjectParameter;
                     _ownerMappings[accessExpression] =
                         (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
-                    _ordinalParameterBindings[accessExpression] = Expression.Add(
+                    _ordinalMappings[accessExpression] = Expression.Add(
                         ordinalParameter, Expression.Constant(1, typeof(int)));
 
                     var innerShaper = (BlockExpression)Visit(collectionShaperExpression.InnerShaper);
@@ -200,14 +200,14 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     if (projectionExpression is ObjectArrayProjectionExpression objectArrayProjectionExpression)
                     {
                         innerAccessExpression = objectArrayProjectionExpression.AccessExpression;
-                        ProjectionBindings[objectArrayProjectionExpression] = parameterExpression;
+                        _projectionBindings[objectArrayProjectionExpression] = parameterExpression;
                         fieldName ??= objectArrayProjectionExpression.Name;
                     }
                     else
                     {
                         var entityProjectionExpression = (EntityProjectionExpression)projectionExpression;
                         var accessExpression = entityProjectionExpression.ParentAccessExpression;
-                        ProjectionBindings[accessExpression] = parameterExpression;
+                        _projectionBindings[accessExpression] = parameterExpression;
                         fieldName ??= entityProjectionExpression.Name;
 
                         switch (accessExpression)
@@ -340,7 +340,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 var ownership = entityType.FindOwnership();
                 if (ownership?.IsUnique == false && property.IsOwnedTypeOrdinalKey())
                 {
-                    var readExpression = _ordinalParameterBindings[docExpression];
+                    var readExpression = _ordinalMappings[docExpression];
                     if (readExpression.Type != type)
                     {
                         readExpression = Expression.Convert(readExpression, type);
@@ -417,7 +417,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         };
 
         var innerExpression = docExpression;
-        if (ProjectionBindings.TryGetValue(docExpression, out var innerVariable))
+        if (_projectionBindings.TryGetValue(docExpression, out var innerVariable))
         {
             innerExpression = innerVariable;
         }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -54,20 +54,17 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     /// <param name="rootEntityType">The <see cref="IEntityType"/> this projection relates to.</param>
     /// <param name="queryExpression">The <see cref="MongoQueryExpression"/> this visitor should use.</param>
     /// <param name="docParameter">The parameter that will hold the <see cref="BsonDocument"/> input parameter to the shaper.</param>
-    /// <param name="trackQueryResults">
-    /// <see langword="true"/> if the results from this query are being tracked for changes,
-    /// <see langword="false"/> if they are not.
-    /// </param>
+    /// <param name="trackingBehavior">The <see cref="QueryTrackingBehavior"/> for this query.</param>
     public MongoProjectionBindingRemovingExpressionVisitor(
         IEntityType rootEntityType,
         MongoQueryExpression queryExpression,
         ParameterExpression docParameter,
-        bool trackQueryResults)
+        QueryTrackingBehavior trackingBehavior)
     {
         _queryExpression = queryExpression;
         _rootEntityType = rootEntityType;
         DocParameter = docParameter;
-        _trackQueryResults = trackQueryResults;
+        _trackQueryResults = trackingBehavior == QueryTrackingBehavior.TrackAll;
     }
 
     protected override Expression VisitExtension(Expression extensionExpression)

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -26,6 +26,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using MongoDB.Bson;
+using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 using MongoDB.EntityFrameworkCore.Storage;
@@ -75,6 +76,39 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 {
                     var projection = GetProjection(projectionBindingExpression);
 
+                    // Alias is null when the projection's expression has no natural name —
+                    // the BsonDoc itself is the value.
+                    if (projection.Alias is null)
+                    {
+                        return DocParameter;
+                    }
+
+                    // Resolve the source IProperty so we apply its serializer / nullability —
+                    // not whatever EF property happens to share the alias name on the root entity.
+                    var fieldAccess = TryResolveFieldAccess(projection.Expression);
+                    if (fieldAccess.Property != null)
+                    {
+                        return BsonBinding.CreateGetValueExpression(
+                            DocParameter,
+                            projection.Alias,
+                            fieldAccess.Property,
+                            projectionBindingExpression.Type);
+                    }
+
+                    // For genuinely non-property expressions (arithmetic, constants, Mql.Field) the
+                    // push-down result document has the alias as its BSON element name — read it raw.
+                    // When projection.Expression is null (EF key-property binding via BindProperty)
+                    // there is no source expression to inspect; fall through to the property-lookup
+                    // path so the alias is resolved against the declared entity type, which gives us
+                    // the correct BSON element name (e.g. OrderID → _id).
+                    if (projection.Expression != null)
+                    {
+                        return BsonBinding.CreateGetElementValue(
+                            DocParameter,
+                            projection.Alias,
+                            projectionBindingExpression.Type);
+                    }
+
                     return CreateGetValueExpression(
                         DocParameter,
                         projection.Alias,
@@ -104,11 +138,9 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
 
                     var accessExpression = objectArrayProjection.InnerProjection.ParentAccessExpression;
                     _projectionBindings[accessExpression] = jObjectParameter;
-                    _ownerMappings[accessExpression] =
-                        (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
-                    _ordinalMappings[accessExpression] = Expression.Add(
-                        ordinalParameter, Expression.Constant(1, typeof(int)));
-
+                    _ownerMappings[accessExpression] = (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
+                    _ownerMappings[jObjectParameter] = (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
+                    _ordinalMappings[accessExpression] = Expression.Add(ordinalParameter, Expression.Constant(1, typeof(int)));
                     var innerShaper = (BlockExpression)Visit(collectionShaperExpression.InnerShaper);
 
                     innerShaper = AddIncludes(innerShaper);
@@ -201,7 +233,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     {
                         innerAccessExpression = objectArrayProjectionExpression.AccessExpression;
                         _projectionBindings[objectArrayProjectionExpression] = parameterExpression;
-                        fieldName ??= objectArrayProjectionExpression.Name;
+                        fieldName ??= FindProjectionAlias(objectArrayProjectionExpression) ?? objectArrayProjectionExpression.Name;
                     }
                     else
                     {
@@ -214,12 +246,21 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                         {
                             case ObjectAccessExpression innerObjectAccessExpression:
                                 innerAccessExpression = innerObjectAccessExpression.AccessExpression;
-                                _ownerMappings[accessExpression] =
-                                    (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
+                                _ownerMappings[accessExpression] = (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
                                 fieldRequired = innerObjectAccessExpression.Required;
                                 break;
                             case RootReferenceExpression:
                                 innerAccessExpression = DocParameter;
+                                if (_ownerMappings.TryGetValue(accessExpression, out var ownerInfo))
+                                {
+                                    _ownerMappings[parameterExpression] = (ownerInfo.EntityType, ownerInfo.BsonDocExpression);
+                                }
+
+                                if (_ordinalMappings.TryGetValue(accessExpression, out var ordinalExpression))
+                                {
+                                    _ordinalMappings[parameterExpression] = ordinalExpression;
+                                }
+
                                 break;
                             default:
                                 throw new InvalidOperationException(
@@ -353,8 +394,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 if (principalProperty != null)
                 {
                     Expression? ownerBsonDocExpression = null;
-                    if (_ownerMappings.TryGetValue(docExpression,
-                            out var ownerInfo))
+                    if (_ownerMappings.TryGetValue(docExpression, out var ownerInfo))
                     {
                         ownerBsonDocExpression = ownerInfo.BsonDocExpression;
                     }
@@ -435,6 +475,107 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         var elementType = typeMapping?.ClrType ?? type;
         return BsonBinding.CreateGetValueExpression(innerExpression, propertyName, required, elementType, entityType);
     }
+
+    protected ResolvedFieldAccess TryResolveFieldAccess(Expression expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        if (expression is MemberExpression memberExpression)
+        {
+            var source = TryResolveFieldAccessSource(memberExpression.Expression);
+            var property = source.EntityType?.FindProperty(memberExpression.Member);
+            return property != null
+                ? new ResolvedFieldAccess(property, source.DocumentExpression, null, memberExpression.Member)
+                : new ResolvedFieldAccess(null, source.DocumentExpression, memberExpression.Member.Name, memberExpression.Member);
+        }
+
+        if (expression is MethodCallExpression methodCall)
+        {
+            if (methodCall.Method.IsEFPropertyMethod()
+                && methodCall.Arguments[1] is ConstantExpression { Value: string propertyName })
+            {
+                var source = TryResolveFieldAccessSource(methodCall.Arguments[0]);
+                var property = source.EntityType?.FindProperty(propertyName);
+                return property != null
+                    ? new ResolvedFieldAccess(property, source.DocumentExpression, null, null)
+                    : new ResolvedFieldAccess(null, source.DocumentExpression, propertyName, null);
+            }
+
+            if (methodCall.Method.IsGenericMethod
+                && methodCall.Method.GetGenericMethodDefinition() == MqlFieldMethodInfo
+                && methodCall.Arguments[1] is ConstantExpression { Value: string fieldName })
+            {
+                var source = TryResolveFieldAccessSource(methodCall.Arguments[0]);
+                return new ResolvedFieldAccess(null, source.DocumentExpression, fieldName, null);
+            }
+        }
+
+        return new ResolvedFieldAccess(null, null, null, null);
+    }
+
+    private (IEntityType? EntityType, Expression? DocumentExpression) TryResolveFieldAccessSource(Expression? expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        if (expression is EntityTypedExpression entityTypedExpression)
+        {
+            return (entityTypedExpression.EntityType, entityTypedExpression);
+        }
+
+        if (expression is RootReferenceExpression rootReferenceExpression)
+        {
+            return (rootReferenceExpression.EntityType, rootReferenceExpression);
+        }
+
+        if (expression is ObjectAccessExpression objectAccessExpression)
+        {
+            return (objectAccessExpression.Navigation.TargetEntityType, objectAccessExpression);
+        }
+
+        // When a projection lambda does `new { o.Prop }`, EF stores MemberExpr(STS_root, "Prop")
+        // in the projection mapping. Recognise the root entity's shaper here so we can resolve
+        // the property and use its own BSON element name instead of the projected alias.
+        if (expression is StructuralTypeShaperExpression { StructuralType: IEntityType shaperEntityType }
+            && shaperEntityType == _rootEntityType)
+        {
+            return (shaperEntityType, DocParameter);
+        }
+
+        if (expression is ParameterExpression parameterExpression)
+        {
+            var entityType = _rootEntityType.Model.GetEntityTypes()
+                .FirstOrDefault(e => e.ClrType == parameterExpression.Type);
+            if (entityType != null)
+            {
+                return (entityType, parameterExpression);
+            }
+        }
+
+        if (expression != null && _ownerMappings.TryGetValue(expression, out var ownerInfo))
+        {
+            return (ownerInfo.EntityType, ownerInfo.BsonDocExpression);
+        }
+
+        return (null, null);
+    }
+
+    private static readonly MethodInfo MqlFieldMethodInfo =
+        typeof(Mql).GetMethod(nameof(Mql.Field), BindingFlags.Public | BindingFlags.Static)!;
+
+    protected readonly record struct ResolvedFieldAccess(
+        IProperty? Property,
+        Expression? DocumentExpression,
+        string? FieldName,
+        MemberInfo? MemberInfo);
+
+    private string? FindProjectionAlias(Expression expression)
+        => _queryExpression.Projection.FirstOrDefault(p => p.Expression.Equals(expression))?.Alias;
 
     private BlockExpression AddIncludes(BlockExpression shaperBlock)
     {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -77,8 +77,8 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
 
         // Entity path: full BsonDocuments shaped into tracked/untracked entity instances
         return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
-            (bsonDoc, track) => new MongoProjectionBindingRemovingExpressionVisitor(
-                rootEntityType, mongoQueryExpression, bsonDoc, track));
+            (bsonDoc, behavior) => new MongoProjectionBindingRemovingExpressionVisitor(
+                rootEntityType, mongoQueryExpression, bsonDoc, behavior));
     }
 
     private MethodCallExpression VisitProjectedQuery(
@@ -112,18 +112,18 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         }
 
         return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
-            (bsonDoc, track) => new MongoMixedProjectionBindingRemovingExpressionVisitor(
-                rootEntityType, mongoQueryExpression, bsonDoc, track));
+            (bsonDoc, behavior) => new MongoMixedProjectionBindingRemovingExpressionVisitor(
+                rootEntityType, mongoQueryExpression, bsonDoc, behavior));
     }
 
     private MethodCallExpression CompileShapedQuery(
         ShapedQueryExpression shapedQueryExpression,
         MongoQueryExpression mongoQueryExpression,
         IEntityType rootEntityType,
-        Func<ParameterExpression, bool, System.Linq.Expressions.ExpressionVisitor> createBindingRemover)
+        Func<ParameterExpression, QueryTrackingBehavior, System.Linq.Expressions.ExpressionVisitor> createBindingRemover)
     {
         var bsonDocParameter = Expression.Parameter(typeof(BsonDocument), "bsonDoc");
-        var trackQueryResults = QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+        var trackingBehavior = QueryCompilationContext.QueryTrackingBehavior;
 
         var shaperBody = shapedQueryExpression.ShaperExpression;
         shaperBody = new BsonDocumentInjectingExpressionVisitor().Visit(shaperBody);
@@ -132,7 +132,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
 #else
         shaperBody = InjectStructuralTypeMaterializers(shaperBody);
 #endif
-        shaperBody = createBindingRemover(bsonDocParameter, trackQueryResults).Visit(shaperBody);
+        shaperBody = createBindingRemover(bsonDocParameter, trackingBehavior).Visit(shaperBody);
 
         var shaperLambda = Expression.Lambda(
             shaperBody,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -104,12 +104,11 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         }
 
         // Mixed path: projection contains entity references that LINQ V3 can't handle.
-        // Strip the Select, return full BsonDocuments, and build a client-side shaper.
-        if (mongoQueryExpression.CapturedExpression is MethodCallExpression
-                { Method: { Name: "Select", DeclaringType.Name: "Queryable" } } selectCall)
-        {
-            mongoQueryExpression.CapturedExpression = selectCall.Arguments[0];
-        }
+        // Strip the Select so the driver returns full BsonDocuments keyed by EF-configured
+        // element names; the client-side shaper handles the projection. The Select may sit
+        // directly on the captured expression, or under a no-arg cardinality terminator
+        // (Single/First/etc.) which we also need to rebind to the un-projected source type.
+        mongoQueryExpression.CapturedExpression = StripPushedDownSelect(mongoQueryExpression.CapturedExpression);
 
         return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
             (bsonDoc, behavior) => new MongoMixedProjectionBindingRemovingExpressionVisitor(
@@ -155,6 +154,35 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             Expression.Constant(standAloneStateManager),
             Expression.Constant(_threadSafetyChecksEnabled),
             Expression.Constant(shapedQueryExpression.ResultCardinality));
+    }
+
+    private static Expression? StripPushedDownSelect(Expression? captured)
+    {
+        if (captured is not MethodCallExpression call || call.Method.DeclaringType != typeof(Queryable))
+        {
+            return captured;
+        }
+
+        if (call.Method.Name == nameof(Queryable.Select) && call.Arguments.Count == 2)
+        {
+            return call.Arguments[0];
+        }
+
+        if (call.Method.IsGenericMethod
+            && call.Method.GetParameters().Length == 1
+            && call.Method.Name is nameof(Queryable.Single) or nameof(Queryable.SingleOrDefault)
+                or nameof(Queryable.First) or nameof(Queryable.FirstOrDefault)
+                or nameof(Queryable.Last) or nameof(Queryable.LastOrDefault)
+            && call.Arguments is [MethodCallExpression { Method: { Name: nameof(Queryable.Select), DeclaringType: var st } } innerSelect]
+            && st == typeof(Queryable))
+        {
+            var newSource = innerSelect.Arguments[0];
+            var newSourceType = newSource.Type.GetGenericArguments()[0];
+            var rebound = call.Method.GetGenericMethodDefinition().MakeGenericMethod(newSourceType);
+            return Expression.Call(rebound, newSource);
+        }
+
+        return captured;
     }
 
     private static (MongoQueryContext, MongoExecutableQuery) TranslateQuery<TSource>(

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -86,6 +86,43 @@ internal static class BsonBinding
         throw new InvalidOperationException(CoreStrings.PropertyNotFound(name, declaredType.DisplayName()));
     }
 
+    /// <summary>
+    /// Create the expression which will obtain a projected element using the serializer metadata
+    /// from the source property rather than resolving metadata from the projected alias.
+    /// </summary>
+    /// <param name="bsonDocExpression">The expression to obtain the current <see cref="BsonDocument"/>.</param>
+    /// <param name="name">The projected element name in the current document.</param>
+    /// <param name="property">The source model property that defines serializer/nullability metadata.</param>
+    /// <param name="mappedType">What <see cref="Type"/> the value is to be treated as.</param>
+    /// <returns>A compilable expression the shaper can use to obtain this value.</returns>
+    public static Expression CreateGetValueExpression(
+        Expression bsonDocExpression,
+        string? name,
+        IProperty property,
+        Type mappedType)
+    {
+        if (name is null)
+        {
+            return bsonDocExpression;
+        }
+
+        if (mappedType == typeof(BsonArray))
+        {
+            return CreateGetBsonArray(bsonDocExpression, name);
+        }
+
+        if (mappedType == typeof(BsonDocument))
+        {
+            return CreateGetBsonDocument(bsonDocExpression, name, !property.IsNullable, property.DeclaringType);
+        }
+
+        return CreateGetPropertyValueAtElement(
+            bsonDocExpression,
+            Expression.Constant(name),
+            Expression.Constant(property),
+            property.IsNullable ? mappedType.MakeNullable() : mappedType);
+    }
+
     private static MethodCallExpression CreateGetBsonArray(Expression bsonDocExpression, string name)
         => Expression.Call(null, GetBsonArrayMethodInfo, bsonDocExpression, Expression.Constant(name));
 
@@ -132,12 +169,28 @@ internal static class BsonBinding
         CreateGetPropertyValue(Expression bsonDocExpression, Expression propertyExpression, Type resultType) =>
         Expression.Call(null, GetPropertyValueMethodInfo.MakeGenericMethod(resultType), bsonDocExpression, propertyExpression);
 
+    private static MethodCallExpression CreateGetPropertyValueAtElement(
+        Expression bsonDocExpression,
+        Expression elementNameExpression,
+        Expression propertyExpression,
+        Type resultType)
+        => Expression.Call(
+            null,
+            GetPropertyValueAtElementMethodInfo.MakeGenericMethod(resultType),
+            bsonDocExpression,
+            elementNameExpression,
+            propertyExpression);
+
     internal static MethodCallExpression CreateGetElementValue(Expression bsonDocExpression, string name, Type type) =>
         Expression.Call(null, GetElementValueMethodInfo.MakeGenericMethod(type), bsonDocExpression, Expression.Constant(name));
 
     private static readonly MethodInfo GetPropertyValueMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
             .Single(mi => mi.Name == nameof(GetPropertyValue));
+
+    private static readonly MethodInfo GetPropertyValueAtElementMethodInfo
+        = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .Single(mi => mi.Name == nameof(GetPropertyValueAtElement));
 
     private static readonly MethodInfo GetElementValueMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
@@ -160,6 +213,31 @@ internal static class BsonBinding
         if (property.IsNullable) return default;
 
         throw new InvalidOperationException($"Document element is missing for required non-nullable property '{property.Name}'.");
+    }
+
+    internal static T? GetPropertyValueAtElement<T>(BsonDocument document, string elementName, IReadOnlyProperty property)
+    {
+        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+        var projectedSerializationInfo = new BsonSerializationInfo(
+            elementName,
+            serializationInfo.Serializer,
+            serializationInfo.NominalType);
+
+        if (TryReadElementValue(document, projectedSerializationInfo, out T? value))
+        {
+            if (value == null && !property.IsNullable)
+            {
+                throw new InvalidOperationException($"Document element is null for required non-nullable property '{property.Name
+                }'.");
+            }
+
+            return value;
+        }
+
+        if (property.IsNullable) return default;
+
+        throw new InvalidOperationException($"Document element '{elementName}' is missing for required non-nullable property '{
+            property.Name}'.");
     }
 
     internal static T? GetElementValue<T>(BsonDocument document, string elementName)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -414,6 +414,108 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         }
     }
 
+    [Fact]
+    public void OwnedEntity_projection_alias_with_bson_representation_uses_owned_property_serializer()
+    {
+        var collection = database.CreateCollection<PersonWithLocation>();
+
+        var id = ObjectId.GenerateNewId();
+        var expectedLocation = new Location { latitude = 1.234m, longitude = 1.567m };
+
+        var modelBuilder = (ModelBuilder mb) =>
+        {
+            mb.Entity<PersonWithLocation>(p =>
+            {
+                p.OwnsOne(e => e.location, f =>
+                {
+                    f.HasElementName("Location");
+                    f.Property(g => g.longitude)
+                        .HasElementName("Longitude")
+                        .HasBsonRepresentation(BsonType.String);
+                });
+            });
+        };
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            dbContext.Entities.Add(new PersonWithLocation
+            {
+                _id = id,
+                name = Guid.NewGuid().ToString(),
+                location = expectedLocation
+            });
+            dbContext.SaveChanges();
+        }
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            var found = dbContext.Entities.AsNoTracking()
+                .Where(e => e._id == id)
+                .Select(e => new { Alias = e.location.longitude })
+                .Single();
+
+            Assert.Equal(expectedLocation.longitude, found.Alias);
+        }
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_projection_alias_with_bson_representation_uses_owned_property_serializer()
+    {
+        var collection = database.CreateCollection<PersonWithMultipleLocations>();
+
+        var id = ObjectId.GenerateNewId();
+        var expectedLocations = new[]
+        {
+            new Location { latitude = 1.234m, longitude = 1.567m },
+            new Location { latitude = 2.345m, longitude = 2.678m }
+        };
+
+        var modelBuilder = (ModelBuilder mb) =>
+        {
+            mb.Entity<PersonWithMultipleLocations>(p =>
+            {
+                p.OwnsMany(e => e.locations, f =>
+                {
+                    f.HasElementName("Locations");
+                    f.Property(g => g.longitude)
+                        .HasElementName("Longitude")
+                        .HasBsonRepresentation(BsonType.String);
+                });
+            });
+        };
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            dbContext.Entities.Add(new PersonWithMultipleLocations
+            {
+                _id = id,
+                name = "A",
+                locations = [.. expectedLocations]
+            });
+            dbContext.SaveChanges();
+        }
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            var actual = dbContext.Entities
+                .AsNoTracking()
+                .Where(e => e._id == id)
+                .Select(e => new
+                {
+                    e.name,
+                    e.locations,
+                    Longitudes = e.locations
+                        .Select(l => new { Alias = l.longitude })
+                        .ToList()
+                })
+                .Single();
+
+            Assert.Equal("A", actual.name);
+            Assert.Equal(expectedLocations.Length, actual.locations.Count);
+            Assert.Equal(expectedLocations.Select(l => l.longitude), actual.Longitudes.Select(l => l.Alias));
+        }
+    }
+
     class SimpleNonNullableCollection
     {
         public ObjectId _id { get; set; }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -536,6 +536,63 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
             mb.Entity<PlanetWithLongOrder>().Property(e => e.orderFromSun).HasConversion<int>());
     }
 
+    private class PlanetWithStringOrder
+    {
+        public ObjectId _id { get; set; }
+        public string name { get; set; } = null!;
+        public int orderFromSun { get; set; }
+    }
+
+    private SingleEntityDbContext<PlanetWithStringOrder> CreateStringOrderContext(string collectionName)
+    {
+        database.MongoDatabase.CreateCollection(collectionName);
+        var collection = database.MongoDatabase.GetCollection<PlanetWithStringOrder>(collectionName);
+        var configureModel = (ModelBuilder mb) =>
+        {
+            mb.Entity<PlanetWithStringOrder>().Property(e => e.orderFromSun).HasBsonRepresentation(BsonType.String);
+        };
+
+        using (var db = SingleEntityDbContext.Create(collection, configureModel))
+        {
+            db.Entities.AddRange(
+                new PlanetWithStringOrder { _id = ObjectId.GenerateNewId(), name = "Mercury", orderFromSun = 1 },
+                new PlanetWithStringOrder { _id = ObjectId.GenerateNewId(), name = "Venus", orderFromSun = 2 });
+            db.SaveChanges();
+        }
+
+        return SingleEntityDbContext.Create(collection, configureModel);
+    }
+
+    [Fact]
+    public void Select_projection_alias_with_bson_representation_uses_source_property_serializer()
+    {
+        using var db = CreateStringOrderContext(
+            nameof(Select_projection_alias_with_bson_representation_uses_source_property_serializer));
+        var results = db.Entities
+            .OrderBy(p => p.orderFromSun)
+            .Select(p => new { Position = p.orderFromSun })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results[0].Position);
+        Assert.Equal(2, results[1].Position);
+    }
+
+    [Fact]
+    public void Select_projection_alias_with_bson_representation_ef_property_uses_source_property_serializer()
+    {
+        using var db = CreateStringOrderContext(
+            nameof(Select_projection_alias_with_bson_representation_ef_property_uses_source_property_serializer));
+        var results = db.Entities
+            .OrderBy(p => p.orderFromSun)
+            .Select(p => new { Position = EF.Property<int>(p, nameof(PlanetWithStringOrder.orderFromSun)) })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results[0].Position);
+        Assert.Equal(2, results[1].Position);
+    }
+
     [Fact]
     public void Sum_with_value_converter()
     {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -2445,139 +2445,51 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
     }
 
     public override async Task Select_expression_long_to_string(bool async)
-    {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_long_to_string(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Select_expression_long_to_string(async);
 
     public override async Task Select_expression_int_to_string(bool async)
-    {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_int_to_string(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Select_expression_int_to_string(async);
 
     public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool async)
     {
-        // Fails: Client eval in final projection EF-250
         Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            "Expression not supported: o.OrderID.ToString(",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
                 base.ToString_with_formatter_is_evaluated_on_the_client(async))).Message);
-
-        AssertMql(
-        );
     }
 
     public override async Task Select_expression_other_to_string(bool async)
-    {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_other_to_string(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Select_expression_other_to_string(async);
 
     public override async Task Select_expression_date_add_year(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_year(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_date_add_year(async));
 
     public override async Task Select_expression_datetime_add_month(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_month(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_month(async));
 
     public override async Task Select_expression_datetime_add_hour(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_hour(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_hour(async));
 
     public override async Task Select_expression_datetime_add_minute(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_minute(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_minute(async));
 
     public override async Task Select_expression_datetime_add_second(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_second(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_second(async));
 
     public override async Task Select_expression_date_add_milliseconds_above_the_range(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_above_the_range(async)))
-            .Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+            () => base.Select_expression_date_add_milliseconds_above_the_range(async));
 
     public override async Task Select_expression_date_add_milliseconds_below_the_range(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_below_the_range(async)))
-            .Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+            () => base.Select_expression_date_add_milliseconds_below_the_range(async));
 
     public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
     {
-        // Fails: Unsupported by driver
         Assert.Contains(
-            "Rewriting child expression",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            "Cannot deserialize a 'Int32' from BsonType 'DateTime'",
+            (await Assert.ThrowsAsync<FormatException>(() =>
                 base.Select_expression_date_add_milliseconds_large_number_divided(async))).Message);
-
-        AssertMql(
-        );
     }
 
     public override async Task Add_minutes_on_constant_value(bool async)
@@ -3524,16 +3436,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
     }
 
     public override async Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
-    {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
-        Assert.Contains(
-            "Rewriting child expression",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                base.Convert_to_nullable_on_nullable_value_is_ignored(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Convert_to_nullable_on_nullable_value_is_ignored(async);
 
     public override async Task Navigation_inside_interpolated_string_is_expanded(bool async)
     {
@@ -4280,15 +4183,7 @@ Customers.
     }
 
     public override async Task Select_expression_datetime_add_ticks(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_ticks(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_ticks(async));
 
     public override async Task Where_subquery_expression_same_parametername(bool async)
     {


### PR DESCRIPTION
## Problem

Two distinct bugs, fixed here together because they share the same code path.

### Bug 1 — aliased scalar projections use the wrong serializer

A projection like `new { Alias = e.Prop }` pushes a `$project` stage to MongoDB that emits the field under the alias key. When the shaper reads it back, it looked up `Alias` as a *property name* on the root entity type in order to find a serializer. Three failure modes depending on what `Alias` happens to collide with:

| Alias collides with… | Outcome |
|---|---|
| no EF property at all | `InvalidOperationException: The property '<Root>.Alias' could not be found` |
| a different EF property with incompatible nullability | `ArgumentException` — Expression.Call rejects a `Nullable<T>` where `T` is expected |
| a different EF property with compatible type | query runs but uses the **wrong** serializer — silent data corruption |

The same bug affects properties on owned entities and owned collections.

### Bug 2 — `NoTrackingWithIdentityResolution` collapses distinct owned entities

When reading owned entities in `NoTracking` mode, the shaper needs a synthetic placeholder key (the owned type has no `_id` of its own — its identity comes from its principal's key). Previously, this synthetic key was emitted for *all* non-tracking modes, including `NoTrackingWithIdentityResolution`.

`NoTrackingWithIdentityResolution` uses a standalone state manager that deduplicates entity instances by key. With every owned entity sharing the same synthetic key, two owners with distinct owned entities would collapse into one — the second owner's entity silently returned the first's data.

## Fix

### Aliased serializer resolution

`VisitExtension` now walks the projection's source expression (via `TryResolveFieldAccess`, promoted from the mixed visitor to the base class) to find the originating `IProperty`. It then reads the BSON element by alias key but deserializes using that property's own serializer and nullability metadata.

A new `BsonBinding.CreateGetValueExpression(doc, elementKey, sourceProperty, type)` overload separates the lookup key from the property metadata so the two concerns can no longer collide.

The mixed-projection path (a `Select` that contains both entity references and scalar properties, which LINQ V3 cannot push down) is also corrected: the pushed-down `Select` is now stripped from the LINQ expression before execution so the driver returns full entity `BsonDocument`s; the client-side shaper then handles the projection.

### Synthetic key scoping

`_useSyntheticOwnedKeys` is now set only when `trackingBehavior == QueryTrackingBehavior.NoTracking`. `NoTrackingWithIdentityResolution` queries receive real principal keys so the standalone state manager can deduplicate correctly.

## Commit structure

The PR is split into four commits to make review easier:

1. **Refactor** — widen `bool trackQueryResults` to `QueryTrackingBehavior` enum throughout the visitor chain (no behavior change; prerequisite for commit 4's scoping logic)
2. **Refactor** — rename `ProjectionBindings` → `_projectionBindings` and `_ordinalParameterBindings` → `_ordinalMappings` (no behavior change; reduces noise in commit 3's diff)
3. **Fix** — core EF-313 projection fix: `TryResolveFieldAccess`, new `BsonBinding` overload, mixed-path `StripPushedDownSelect`, tests for aliased owned and root properties
4. **Fix** — restrict synthetic owned-entity keys to `NoTracking` only; regression test covering `NoTrackingWithIdentityResolution`