### PR TITLE
CSHARP-5671: Replace Artifactory with ECR for container image pulls

### DIFF
--- a/evergreen/download-augmented-sbom.sh
+++ b/evergreen/download-augmented-sbom.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
+set -o errexit
+set -o pipefail
 
 # Environment variables used as input:
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
 # AWS_SESSION_TOKEN
+#
+# Prerequisite: kondukto_credentials.env must already exist (written by fetch-kondukto-token.sh).
 
 declare -r SSDLC_PATH="./artifacts/ssdlc"
 mkdir -p "${SSDLC_PATH}"
 
 echo "Downloading augmented sbom from Kondukto"
 
-# use AWS CLI to get the Kondukto API token from AWS Secrets Manager
-kondukto_token=$(aws secretsmanager get-secret-value --secret-id "kondukto-token" --region "us-east-1" --query 'SecretString' --output text)
-if [ $? -ne 0 ]; then
-    exit 1
-fi
-# set the KONDUKTO_TOKEN environment variable
-echo "KONDUKTO_TOKEN=$kondukto_token" > ${PWD}/kondukto_credentials.env
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
 docker run --platform="linux/amd64" --rm -v ${PWD}:/pwd \
   --env-file ${PWD}/kondukto_credentials.env \
-  artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:2.0 \
+  901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
   augment --repo mongodb/mongo-efcore-provider --branch main --sbom-in /pwd/sbom.json --sbom-out /pwd/${SSDLC_PATH}/augmented-sbom.json

--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -262,13 +262,17 @@ functions:
           . ./evergreen/pack-packages.sh
 
   sign-packages:
+    - command: ec2.assume_role
+      params:
+        role_arn: ${ecr-evergreen-role}
     - command: shell.exec
       params:
         shell: bash
         working_dir: mongo-efcore-provider
         include_expansions_in_env:
-          - "ARTIFACTORY_PASSWORD"
-          - "ARTIFACTORY_USERNAME"
+          - "AWS_ACCESS_KEY_ID"
+          - "AWS_SECRET_ACCESS_KEY"
+          - "AWS_SESSION_TOKEN"
           - "GRS_USERNAME"
           - "GRS_PASSWORD"
           - "AUTHENTICODE_KEY_NAME"
@@ -378,6 +382,19 @@ functions:
     - command: ec2.assume_role
       params:
         role_arn: ${kondukto_role_arn}
+    - command: shell.exec
+      params:
+        working_dir: mongo-efcore-provider
+        include_expansions_in_env:
+          - "AWS_ACCESS_KEY_ID"
+          - "AWS_SECRET_ACCESS_KEY"
+          - "AWS_SESSION_TOKEN"
+        script: |
+          ${PREPARE_SHELL}
+          ./evergreen/fetch-kondukto-token.sh
+    - command: ec2.assume_role
+      params:
+        role_arn: ${ecr-evergreen-role}
     - command: shell.exec
       params:
         working_dir: mongo-efcore-provider

--- a/evergreen/fetch-kondukto-token.sh
+++ b/evergreen/fetch-kondukto-token.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit  # Exit the script with error if any of the commands fail
+
+# Environment variables used as input:
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+# AWS_SESSION_TOKEN
+
+kondukto_token=$(aws secretsmanager get-secret-value --secret-id "kondukto-token" --region "us-east-1" --query 'SecretString' --output text)
+echo "KONDUKTO_TOKEN=$kondukto_token" > ${PWD}/kondukto_credentials.env

--- a/evergreen/sign-packages.sh
+++ b/evergreen/sign-packages.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
-set -o errexit  # Exit the script with error if any of the commands fail
+set -o errexit
+set -o pipefail
 
 # Environment variables used as input:
-# ARTIFACTORY_PASSWORD
-# ARTIFACTORY_USERNAME
+# AUTHENTICODE_KEY_NAME
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+# AWS_SESSION_TOKEN
 # GRS_USERNAME
 # GRS_PASSWORD
 # PACKAGE_VERSION
 
-echo "${ARTIFACTORY_PASSWORD}" | docker login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 901841024863.dkr.ecr.us-east-1.amazonaws.com
 
 echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}" >> "signing-envfile"
 echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}" >> "signing-envfile"
 
 docker run --platform="linux/amd64" --env-file=signing-envfile --rm -v $(pwd):/workdir -w /workdir \
-  artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-jsign \
+  901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-jsign \
   /bin/bash -c "jsign --tsaurl "http://timestamp.digicert.com" -a ${AUTHENTICODE_KEY_NAME} "./artifacts/nuget/*.$PACKAGE_VERSION.nupkg""


### PR DESCRIPTION
[CSHARP-5671](https://jira.mongodb.org/browse/CSHARP-5671)

## Summary
- Replaces `artifactory.corp.mongodb.com/release-tools-container-registry-*` image pulls with `901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure` across the signing and SSDLC pipelines
- Splits `download-augmented-sbom.sh` into two scripts to accommodate the two IAM roles required: `${kondukto_role_arn}` for Secrets Manager access and `${ecr-evergreen-role}` for ECR authentication
- Adds `set -o pipefail` to all shell scripts that use pipelines for docker authentication

## Changes
- `evergreen/fetch-kondukto-token.sh` *(new)* — fetches the Kondukto API token from AWS Secrets Manager under `${kondukto_role_arn}`
- `evergreen/download-augmented-sbom.sh` — removed Secrets Manager call (moved to above); added ECR login; updated `silkbomb` image URL to ECR
- `evergreen/sign-packages.sh` — replaced Artifactory login with ECR login; updated `garasign-jsign` image URL to ECR
- `evergreen/evergreen.yml` — restructured `download-and-promote-augmented-sbom-to-s3-bucket` to assume kondukto role then ECR role as separate steps; added ECR role assumption to `sign-packages` function

## Test plan
[EG Run](https://spruce.corp.mongodb.com/version/6a0b8aa5154ee9000724ec60)