### PR TITLE
EF-27: Add compliance test, annotate failing spec tests with ticket IDs, and document known failures

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -1,0 +1,202 @@
+# Failing specification tests — Jira inventory
+
+EF Core ships a "specification tests" suite that providers consume from the
+`Microsoft.EntityFrameworkCore.Specification.Tests` NuGet package and override
+to assert the provider's actual behavior. When the MongoDB provider does not
+yet support the functionality exercised by a test, the override is updated to
+**assert the current failure** rather than be skipped — so the test stays green,
+and any change in behavior (different exception type, different error message,
+or the feature beginning to work) is detected immediately.
+
+Each such override is annotated with a `// Fails: <description> <ticket-id>`
+comment. This document enumerates every ticket referenced by such comments
+together with a one-line description, plus a section listing failure modes
+that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrameworkCore.SpecificationTests/**/*.cs`.
+
+> If you fix one of these bugs, search for the ticket id in the spec-tests
+> project — the corresponding overrides need to be updated (drop the
+> `AssertTranslationFailed` wrapper or the throws-asserting `Assert.Contains`,
+> assert the new MQL baseline, and remove the `// Fails:` line).
+
+---
+
+## MongoDB EF Core provider tickets — `EF-NNN`
+
+| Ticket | Comment subject | Description | Count |
+| --- | --- | --- | --- |
+| [EF-117](https://jira.mongodb.org/browse/EF-117) | `Include issue EF-117` / `Include (joins) issue EF-117` | `Include`/`ThenInclude` across DbSets is not supported — joins between collections cannot be translated. | 499 |
+| [EF-149](https://jira.mongodb.org/browse/EF-149) | `GroupBy issue EF-149` | `GroupBy` translation is severely limited; most non-trivial group-by shapes fail to translate. | 246 |
+| [EF-153](https://jira.mongodb.org/browse/EF-153) | `TagWith EF-153` | `TagWith(...)` content is silently dropped — does not appear in the emitted MQL. | 9 |
+| [EF-164](https://jira.mongodb.org/browse/EF-164) | `Missing property values issue EF-164` / `Projections issue EF-164` | BSON documents that omit a required scalar (or required navigation) throw on materialization — `Project_root_with_missing_scalars`, `Project_root_entity_with_missing_required_navigation`, etc. | 3 |
+| [EF-202](https://jira.mongodb.org/browse/EF-202) | `Entity equality issue EF-202` | Comparing two entities (`entity1 == entity2` / `Contains(entity)`) is not lowered to a key-equality comparison. | 4 |
+| [EF-216](https://jira.mongodb.org/browse/EF-216) | `Cross-document navigation access issue EF-216` / `Navigations issue EF-216` | Navigations that cross collection boundaries cannot be translated; surfaces as `Unsupported cross-DbSet query between ...`. Documented at the helper `AssertNoMultiCollectionQuerySupport`. | 263 |
+| [EF-217](https://jira.mongodb.org/browse/EF-217) | `Call ToString on DateTimeOffset EF-217` | `DateTimeOffset.ToString()` cannot be translated. | 2 |
+| [EF-218](https://jira.mongodb.org/browse/EF-218) | `Projecting DateTimeOffset members EF-218` | Projecting individual members of a `DateTimeOffset` (e.g. `.Year`, `.Hour`) is not supported. | 2 |
+| [EF-220](https://jira.mongodb.org/browse/EF-220) | `Multiple query roots issue EF-220` | Queries that reference more than one `DbSet<>` (Cartesian product / cross-join) are not translatable. | 2 |
+| [EF-221](https://jira.mongodb.org/browse/EF-221) | `Equals with different types issue EF-221` | `==` / `Equals` with operands of mismatched CLR types (e.g. `int == long`) is not translated correctly. | 4 |
+| [EF-222](https://jira.mongodb.org/browse/EF-222) | `translation of Like issue EF-222` | `EF.Functions.Like(...)` is not translated. | 9 |
+| [EF-227](https://jira.mongodb.org/browse/EF-227) | `Max over empty nullables issue EF-227` | `Min` / `Max` over an empty nullable sequence does not produce the EF-expected `null`. | 4 |
+| [EF-228](https://jira.mongodb.org/browse/EF-228) | `Truncation data loss issue EF-228` | `Sum`/`Average` over `float` columns suffers precision/truncation loss when accumulated server-side. | 2 |
+| [EF-229](https://jira.mongodb.org/browse/EF-229) | `Incorrect results issue EF-229` | `Contains` at the top of the query tree returns wrong results in at least one shape. | 1 |
+| [EF-231](https://jira.mongodb.org/browse/EF-231) | `String.FirstOrDefault issue EF-231` | `String.FirstOrDefault()` in a projection forces a client-evaluation path that is not supported. | 1 |
+| [EF-232](https://jira.mongodb.org/browse/EF-232) | `Sum of empty set cast to nullable issue EF-232` | `Sum_with_no_data_cast_to_nullable` does not produce the EF-expected `null`. (The `Compiled_query_when_does_not_end_in_query_operator` failure that previously also cited EF-232 has been re-tagged as `EF-X011`.) | 1 |
+| [EF-234](https://jira.mongodb.org/browse/EF-234) | `translation of Random issue EF-234` | `EF.Functions.Random()` is not translated. | 2 |
+| [EF-235](https://jira.mongodb.org/browse/EF-235) | `Translate Convert methods issue EF-235` | `Convert.ToBoolean/Byte/Int*/Decimal/Double/String/...` calls are not translated. | 8 |
+| [EF-237](https://jira.mongodb.org/browse/EF-237) | `MathF mapping issue EF-237` | `MathF.*` overloads (the `float` Math API) are not translated. | 25 |
+| [EF-238](https://jira.mongodb.org/browse/EF-238) | `Math.Min/Math.Max mapping issue EF-238` | `Math.Min` / `Math.Max` are not translated. | 6 |
+| [EF-239](https://jira.mongodb.org/browse/EF-239) | `Math.Sign mapping issue EF-239` | `Math.Sign` is not translated. | 1 |
+| [EF-240](https://jira.mongodb.org/browse/EF-240) | `Double.RadiansToDegrees and Double.DegreesToRadians mapping issue EF-240` | `Double.RadiansToDegrees` / `Double.DegreesToRadians` are not translated. | 2 |
+| [EF-241](https://jira.mongodb.org/browse/EF-241) | `Translate string.Trim methods issue EF-241` | `String.TrimStart(...)` / `String.TrimEnd(...)` with a `char[]` argument are not translated. | 6 |
+| [EF-242](https://jira.mongodb.org/browse/EF-242) | `DateOnly support issue EF-242` | `DateOnly.FromDateTime(...)` (and related `DateOnly` conversions) are not translated. | 1 |
+| [EF-243](https://jira.mongodb.org/browse/EF-243) | `StartsWith/Contains/EndsWith Ordinal/OrdinalIgnoreCase issue EF-243` | `string.StartsWith/Contains/EndsWith` with `StringComparison.Ordinal` or `OrdinalIgnoreCase` is not translated. | 9 |
+| [EF-245](https://jira.mongodb.org/browse/EF-245) | `String.Join issue EF-245` | `String.Join(separator, source.Select(...))` is not translated. | 5 |
+| [EF-246](https://jira.mongodb.org/browse/EF-246) | `DateTime subtraction issue EF-246` | `(dateA - dateB).TotalDays / TotalHours / TotalSeconds / TotalMilliseconds` is not translated. | 1 |
+| [EF-247](https://jira.mongodb.org/browse/EF-247) | `Regex with non-constant pattern issue EF-247` | `Regex.IsMatch` with a non-constant pattern is not translated. | 1 |
+| [EF-248](https://jira.mongodb.org/browse/EF-248) | `Translate String.FirstOrDefault and String.LastOrDefault issue EF-248` | `String.FirstOrDefault()` / `LastOrDefault()` (LINQ-on-string) is not translated. | 2 |
+| [EF-249](https://jira.mongodb.org/browse/EF-249) | `checked issue EF-249` | `checked { ... }` arithmetic is not honored — the `Checked_context_with_arithmetic_does_not_fail` test sees a different exception than EF expects. | 1 |
+| [EF-250](https://jira.mongodb.org/browse/EF-250) | `Client eval in final projection EF-250` | `Select(...)` with a client-evaluated expression in the final projection (e.g. `i.ToString()` on a server value) is not supported. | 7 |
+| [EF-252](https://jira.mongodb.org/browse/EF-252) | `Concurrency detector tests broken EF-252` | `Throws_on_concurrent_query_first/list` — the concurrency detector does not fire as the EF base test expects. | 2 |
+| [EF-253](https://jira.mongodb.org/browse/EF-253) | `Multiple ordering issue EF-253` | `OrderBy(x).ThenBy(x)` on the same column with different directions does not emit the expected MQL. | 1 |
+| [EF-254](https://jira.mongodb.org/browse/EF-254) | `Take zero EF-254` | `.Skip(0).Take(0)` with a parameter does not produce the expected empty result. | 1 |
+
+## MongoDB C# Driver tickets — `CSHARP-NNNN`
+
+| Ticket | Comment subject | Description | Count |
+| --- | --- | --- | --- |
+| [CSHARP-5296](https://jira.mongodb.org/browse/CSHARP-5296) | `DateTimeOffset issue CSHARP-5296` | Driver-level: `DateTimeOffset.Now / UtcNow` component access (`.Year`, `.Hour`, etc.) is not translated by the LINQ provider. | 2 |
+| [CSHARP-5836](https://jira.mongodb.org/browse/CSHARP-5836) | `Reverse not supported CSHARP-5836` | Driver-level: `Queryable.Reverse()` is not implemented in the driver's LINQ provider. | 14 |
+
+## Upstream EF Core tickets — `dotnet/efcore#NNNNN`
+
+| Ticket | Comment subject | Description | Count |
+| --- | --- | --- | --- |
+| [dotnet/efcore#36412](https://github.com/dotnet/efcore/issues/36412) | `EF upstream issue--see https://github.com/dotnet/efcore/issues/36412` | Upstream EF Core test bug — provider-side override compensates while the upstream is fixed. | 1 |
+
+Two further GitHub references appear in the codebase but are not `// Fails:`-tagged (they are TODOs / notes, not failure annotations): [dotnet/efcore#36488](https://github.com/dotnet/efcore/issues/36488) (`NorthwindSetOperationsQueryMongoTest.cs:149`, upstream test has a bug), [dotnet/efcore#36521](https://github.com/dotnet/efcore/issues/36521) (`MongoApiConsistencyTest.cs:91`), [dotnet/efcore#36413](https://github.com/dotnet/efcore/issues/36413) (`Utilities/TestMqlLoggerFactory.cs:6`).
+
+---
+
+## Failure modes lacking a Jira ticket — proposed new tickets
+
+These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` reference, or in test bodies as un-commented failure assertions. Each entry is assigned a **temporary** ticket id of the form `EF-X###` to be replaced with a real Jira number once filed; the `X` makes it obvious in `grep` results that the id is a placeholder.
+
+| Temp ticket | Subject | Count |
+| --- | --- | --- |
+| EF-X001 | Sub-query selection across DbSets is not translated | 125 |
+| EF-X002 | Provider throws a different exception than the EF translation-failure message | 44 |
+| EF-X003 | Driver-level feature gaps surfaced as test failures | 17 |
+| EF-X004 | Float `Sum`/`Average` truncation (likely duplicate of EF-228) | 1 |
+| EF-X005 | BSON document missing nested required reference (AdHoc JSON) | 2 |
+| EF-X006 | MongoDB `DateTimeKind` round-trip handling | 1 |
+| EF-X007 | Views / `HasDefiningQuery` semantics for MongoDB collections | 2 |
+| EF-X008 | No support for nested JSON in AdHoc JSON tests | 2 |
+| EF-X009 | Single uncategorized failure — needs triage | 1 |
+| EF-X010 | Provider-specific Include error message differs from EF baseline | 4 |
+| EF-X011 | Compiled query with non-query operator — wrong exception | 1 |
+| EF-X012 | `OfType` translation unsupported | 2 |
+| EF-X013 | MongoDB has no `$xor` operator (`Where_bitwise_xor`) | 1 |
+| EF-X014 | Server-side projection conflict with cast-to-nullable | 1 |
+| EF-X015 | Sub-second `DateTime` component translation (nanosecond/microsecond) | 1 |
+
+### EF-X001 — Sub-query selection across DbSets is not translated
+Comment patterns: `// Fails: Subquery selection EF-X001`, `// Fails: Subqueries not supported EF-X001`, `// Fails: No subquery support EF-X001`.
+Test-body patterns: `AssertTranslationFailed(() => base.X(...))`, `AssertNoMultiCollectionQuerySupport(() => base.X(...))`.
+Affected: ~125 tests across `NorthwindAggregateOperators`, `NorthwindMiscellaneous`, `NorthwindWhere`, `NorthwindNavigations`, `NorthwindSetOperations`, etc. Many overlap with [EF-216](https://jira.mongodb.org/browse/EF-216); a separate ticket lets cross-collection subquery support be tracked independently from raw navigation access.
+
+### EF-X002 — Provider throws a different exception than the EF translation-failure message
+Comment patterns: `// Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002`, `// Fails: Not throwing expected translation failed exception from EF. EF-X002`, `// Fails: Does not throw expected unable to translate exception EF-X002`, `// Fails: Does not use translation failed message EF-X002`, `// Fails: Throws different exception, but still throws EF-X002`.
+Affected: ~34 tests. EF's base tests expect `InvalidOperationException` with EF's "could not be translated" message; the provider currently throws `ExpressionNotSupportedException` / `MongoCommandException` / `NotSupportedException` instead. Aligning the messages would let EF-level diagnostics work without provider-specific overrides.
+
+### EF-X003 — Driver-level feature gaps surfaced as test failures
+Comment patterns: `// Fails: Unsupported by driver EF-X003`, `// Fails: Reverse not supported by driver EF-X003`, `// Fails: Limited support on client evaluation EF-X003`.
+Affected: ~17 tests. These are MongoDB C# Driver gaps (the driver does not implement a particular LINQ-to-MQL translation). Many likely fold into existing `CSHARP-*` tickets; a single umbrella issue would let the provider track its dependency on driver work.
+
+### EF-X004 — Float `Sum`/`Average` truncation (likely duplicate of EF-228)
+Comment pattern: `// Fails: Truncation resulted in data loss EF-X004`.
+Affected: 1 test (`NorthwindAggregateOperatorsQueryMongoTest.cs`). Almost certainly the same failure mode as [EF-228](https://jira.mongodb.org/browse/EF-228); recommend re-tagging with `EF-228` and dropping this ticket once confirmed.
+
+### EF-X005 — BSON document missing nested required reference (AdHoc JSON)
+Comment patterns: `// Fails: NestedRequiredReference is null in BsonDocument for entity id=6 EF-X005`, `// Fails: Entity id=5 has no RequiredReference field EF-X005`.
+Affected: 2 tests in `AdHocJsonQueryMongoTest.cs`. Same family as [EF-164](https://jira.mongodb.org/browse/EF-164) but more specific — failure occurs when an owned navigation (rather than a scalar) is missing from the seeded BSON.
+
+### EF-X006 — MongoDB `DateTimeKind` round-trip handling
+Comment pattern: `// Fails: MongoDB DateTimeKind handling EF-X006`.
+Affected: 1 test. BSON cannot represent `DateTimeKind.Unspecified`, so the provider normalizes to UTC; tests that compare original vs round-tripped `DateTime.Kind` diverge.
+
+### EF-X007 — Views / `HasDefiningQuery` semantics for MongoDB collections
+Comment patterns: `// Fails: Views are not supported, so this returns all entities from mapped collection. EF-X007`, `// Fails: Defining queries are not supported. EF-X007`.
+Affected: 2 tests in `NorthwindKeylessEntitiesQueryMongoTest.cs`. The EF "view" / `HasDefiningQuery` notion doesn't map onto MongoDB; the provider returns the full collection instead of the view-filtered subset.
+
+### EF-X008 — No support for nested JSON in AdHoc JSON tests
+Comment pattern: `// Fails: No support for nested JSON EF-X008`.
+Affected: 2 tests in `AdHocJsonQueryMongoTest.cs`. The provider's JSON-column emulation does not nest deeply enough for these EF Core AdHoc cases.
+
+### EF-X009 — Single uncategorized failure — needs triage
+Comment pattern: `// Fails: Unknown reasons EF-X009`.
+Affected: 1 test. Author was unsure of root cause when adding the override.
+
+### EF-X010 — Provider-specific Include error message differs from EF baseline
+Pattern: tests for `Include_collection_with_client_filter` across all four Include variants use `Assert.ThrowsAsync<ContainsException>` and assert that `Assert.Contains` fails because the provider's error message differs from the generic EF message. The override carries an explanatory comment ("Throws with Mongo-specific message rather than the generic EF message.") but no `// Fails:` tag in the current codebase.
+Affected: 4 tests (`NorthwindEFPropertyIncludeQueryMongoTest.cs`, `NorthwindIncludeNoTrackingQueryMongoTest.cs`, `NorthwindIncludeQueryMongoTest.cs`, `NorthwindStringIncludeQueryMongoTest.cs`).
+
+### EF-X011 — Compiled query with non-query operator — wrong exception
+Comment pattern: `// Fails: Compiled query with non-query operator issue EF-X011`.
+Affected: 1 test (`NorthwindCompiledQueryMongoTest.Compiled_query_when_does_not_end_in_query_operator`). Previously cited the same `EF-232` as `Sum_with_no_data_cast_to_nullable`, but the two are clearly distinct bugs — split out into this temp ticket. The provider throws `ArgumentException("No ultimate source found")` instead of the EF-expected error.
+
+### EF-X012 — `OfType` translation unsupported
+Comment pattern: `// Fails: OfType translation EF-X012`.
+Affected: 2 tests in `NorthwindAggregateOperatorsQueryMongoTest.cs` (`OfType_Select`, `OfType_Select_OfType_Select`). `Queryable.OfType<T>()` is not translated; the failure surfaces as a generic `AssertTranslationFailed`.
+
+### EF-X013 — MongoDB has no `$xor` operator
+Comment pattern: `// Fails: MongoDB does not have an xor operator EF-X013`.
+Affected: 1 test (`NorthwindWhereQueryMongoTest.Where_bitwise_xor`). The provider throws `ExpressionNotSupportedException` with message `"because MongoDB does not have a boolean $xor operator"`.
+
+### EF-X014 — Server-side projection conflict with cast-to-nullable
+Comment pattern: `// Fails: Server-side projection conflict with cast-to-nullable EF-X014`.
+Affected: 1 test (`NorthwindSelectQueryMongoTest.Select_bool_closure_with_order_by_property_with_cast_to_nullable`). Server rejects the generated `$project` stage with `"Cannot do exclusion on field _key1 in inclusion projection"` — likely a translator bug where the projection stage mixes inclusion and exclusion.
+
+### EF-X015 — Sub-second `DateTime` component translation (nanosecond/microsecond)
+Comment pattern: `// Fails: Sub-second DateTime component translation EF-X015`.
+Affected: 1 test (`NorthwindMiscellaneousQueryMongoTest.Where_nanosecond_and_microsecond_component`). `DateTime.Nanosecond` and `DateTime.Microsecond` (added in .NET 7) are not translated; the provider throws `ExpressionNotSupportedException`.
+
+---
+
+## Audit findings — tagging hygiene
+
+The following inconsistencies were observed while building this inventory and have since been resolved.
+
+### 1. `EF-232` was reused for two distinct failure modes — **fixed**
+
+`Sum_with_no_data_cast_to_nullable` keeps `EF-232`; `Compiled_query_when_does_not_end_in_query_operator` was re-tagged with the new temp ticket `EF-X011`.
+
+### 2. Sibling `#if` branches missing the `// Fails:` tag — **fixed**
+
+Both branches of `Any_on_distinct`, `Contains_on_distinct`, `All_on_distinct`, `IQueryable_captured_variable`, and `Where_Order_First` in `NorthwindMiscellaneousQueryMongoTest.cs` now carry the `EF-216` tag. (`Filtered_include_with_multiple_ordering` in `NorthwindStringIncludeQueryMongoTest.cs` was verified to pass — it does not need a tag despite the sibling-file convention; the audit's flag was a false positive there.)
+
+### 3. Duplicate `EF-243` references on the same method — **fixed**
+
+The duplicate inline `// ... See EF-243.` mentions in the three StartsWith/Contains/EndsWith overrides were dropped; the `// Fails: ... EF-243` lines remain.
+
+### 4. Single-mode helpers tag at the helper, not at each call site — **fixed**
+
+The convention: when a helper method wraps a single failure mode, the `// Fails:` line goes above the helper declaration, not at every call site. Applied to:
+
+- `AssertNoMultiCollectionQuerySupport` (single mode: `EF-216`) — definition now tagged in every file that declares it; call sites left untagged. This was already the dominant pattern in 8 of 9 files; the one missing tag in `NorthwindGroupByQueryMongoTest.cs` was added.
+- `AssertGroupByUnsupported` (single mode: `EF-149`) — already tagged at the helper.
+
+The generic `AssertTranslationFailed` helper is **not** single-mode (it's used for many distinct failure causes) and is therefore tagged per call site.
+
+### 5. Untagged `AssertTranslationFailed` and Throws callers — **fixed**
+
+All ~70 `AssertTranslationFailed` call sites now carry a `// Fails:` tag — categorized as `EF-117` (joins/Include), `EF-149` (GroupBy), `EF-216` (cross-document), `EF-X001` (sub-query selection), or one of the new EF-X011–EF-X015 tickets. Three additional `Assert.Throws*` blocks (`Type_casting_inside_sum`, `Late_subquery_pushdown`, `Where_nanosecond_and_microsecond_component`) were also tagged. Two malformed tags (`// Fails ` without colon) were corrected. `Assert.Throws<...>` blocks that preserve EF Core's own expected throws (`Max_on_empty_sequence_throws`, `Client_code_using_instance_*_throws`, `VectorSearch_throws_if_num_candidates_set_for_exact_search`) intentionally remain untagged — they assert the provider matches EF behavior, not that it fails.
+
+### Verification
+
+After all edits:
+
+```
+grep -rEho "(EF-X?[0-9]+|CSHARP-[0-9]+)" tests/.../SpecificationTests --include="*.cs" \
+  | sort | uniq -c | sort -rn
+```
+
+returns 49 distinct ticket ids, including 15 temporary `EF-X###` placeholders. The static audit (lookback-5 search for `// Fails:` above any `AssertTranslationFailed` / `Assert.Throws*` / `AssertGroupByUnsupported` callsite, excluding helper definitions and single-mode helper callers) reports zero remaining holes among Mongo-failure cases.

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoComplianceTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/MongoComplianceTest.cs
@@ -1,0 +1,197 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace MongoDB.EntityFrameworkCore.SpecificationTests;
+
+public class MongoComplianceTest : ComplianceTestBase
+{
+    // Test bases from Microsoft.EntityFrameworkCore.Specification.Tests that have not yet been
+    // overridden for the MongoDB provider. As tests are implemented they should be removed from
+    // this list so that the compliance test enforces continued coverage of newly added
+    // specification tests.
+    protected override ICollection<Type> IgnoredTestBases { get; } =
+    [
+        // Provider-wide non-query test bases (present across EF8/EF9/EF10).
+        typeof(BadDataJsonDeserializationTestBase),
+        typeof(ComplexTypesTrackingTestBase<>),
+        typeof(CompositeKeyEndToEndTestBase<>),
+        typeof(ConcurrencyDetectorDisabledTestBase<>),
+        typeof(ConcurrencyDetectorEnabledTestBase<>),
+        typeof(ConcurrencyDetectorTestBase<>),
+        typeof(ConferencePlannerTestBase<>),
+        typeof(ConvertToProviderTypesTestBase<>),
+        typeof(CustomConvertersTestBase<>),
+        typeof(DataAnnotationTestBase<>),
+        typeof(DataBindingTestBase<>),
+        typeof(EntityFrameworkServiceCollectionExtensionsTestBase),
+        typeof(FieldMappingTestBase<>),
+        typeof(FieldsOnlyLoadTestBase<>),
+        typeof(FindTestBase<>),
+        typeof(GraphUpdatesTestBase<>),
+        typeof(InterceptionTestBase),
+        typeof(JsonTypesTestBase),
+        typeof(KeysWithConvertersTestBase<>),
+        typeof(LazyLoadProxyTestBase<>),
+        typeof(LoadTestBase<>),
+        typeof(LoggingTestBase),
+        typeof(ManyToManyFieldsLoadTestBase<>),
+        typeof(ManyToManyLoadTestBase<>),
+        typeof(ManyToManyTrackingTestBase<>),
+        typeof(MaterializationInterceptionTestBase<>),
+        typeof(ModelBuilding101TestBase),
+        typeof(MonsterFixupTestBase<>),
+        typeof(MusicStoreTestBase<>),
+        typeof(NotificationEntitiesTestBase<>),
+        typeof(OptimisticConcurrencyTestBase<,>),
+        typeof(OverzealousInitializationTestBase<>),
+        typeof(OwnedEntityQueryTestBase),
+        typeof(PropertyValuesTestBase<>),
+        typeof(ProxyGraphUpdatesTestBase<>),
+        typeof(QueryExpressionInterceptionTestBase),
+        typeof(SaveChangesInterceptionTestBase),
+        typeof(SeedingTestBase),
+        typeof(SerializationTestBase<>),
+        typeof(SharedTypeQueryTestBase),
+        typeof(SingletonInterceptorsTestBase<>),
+        typeof(SpatialTestBase<>),
+        typeof(StoreGeneratedFixupTestBase<>),
+        typeof(StoreGeneratedTestBase<>),
+        typeof(ValueConvertersEndToEndTestBase<>),
+        typeof(WithConstructorsTestBase<>),
+
+        // Query test bases (present across EF8/EF9/EF10).
+        typeof(ComplexNavigationsCollectionsQueryTestBase<>),
+        typeof(ComplexNavigationsCollectionsSharedTypeQueryTestBase<>),
+        typeof(ComplexNavigationsQueryTestBase<>),
+        typeof(ComplexNavigationsSharedTypeQueryTestBase<>),
+        typeof(ComplexTypeQueryTestBase<>),
+        typeof(CompositeKeysQueryTestBase<>),
+        typeof(Ef6GroupByTestBase<>),
+        typeof(FilteredQueryTestBase<>),
+        typeof(FiltersInheritanceQueryTestBase<>),
+        typeof(FunkyDataQueryTestBase<>),
+        typeof(GearsOfWarQueryTestBase<>),
+        typeof(IncludeOneToOneTestBase<>),
+        typeof(InheritanceQueryTestBase<>),
+        typeof(InheritanceRelationshipsQueryTestBase<>),
+        typeof(ManyToManyNoTrackingQueryTestBase<>),
+        typeof(ManyToManyQueryTestBase<>),
+        typeof(NonSharedPrimitiveCollectionsQueryTestBase),
+        typeof(NullKeysTestBase<>),
+        typeof(OwnedQueryTestBase<>),
+        typeof(PrimitiveCollectionsQueryTestBase<>),
+        typeof(QueryFilterFuncletizationTestBase<>),
+        typeof(QueryTestBase<>),
+        typeof(SpatialQueryTestBase<>),
+        typeof(AdHocAdvancedMappingsQueryTestBase),
+        typeof(AdHocComplexTypeQueryTestBase),
+
+#if EF8
+        // EF8-only test bases.
+        typeof(ManyToManyHeterogeneousQueryTestBase),
+        typeof(SimpleQueryTestBase),
+        typeof(UpdatesTestBase<>),
+#endif
+
+#if !EF8
+        // Test bases added in EF9+.
+        typeof(AdHocManyToManyQueryTestBase),
+        typeof(AdHocMiscellaneousQueryTestBase),
+        typeof(AdHocNavigationsQueryTestBase),
+        typeof(AdHocQueryFiltersQueryTestBase),
+        typeof(Microsoft.EntityFrameworkCore.BulkUpdates.BulkUpdatesTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.BulkUpdates.FiltersInheritanceBulkUpdatesTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.BulkUpdates.InheritanceBulkUpdatesTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.BulkUpdates.NonSharedModelBulkUpdatesTestBase),
+        typeof(Microsoft.EntityFrameworkCore.BulkUpdates.NorthwindBulkUpdatesTestBase<>),
+        typeof(JsonQueryTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.ComplexTypeTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.InheritanceTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.ManyToManyTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.ManyToOneTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.ModelBuilderTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.NonRelationshipTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.OneToManyTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.OneToOneTestBase),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.OwnedTypesTestBase),
+        typeof(Microsoft.EntityFrameworkCore.Scaffolding.CompiledModelTestBase),
+        typeof(Microsoft.EntityFrameworkCore.Update.UpdatesTestBase<>),
+#endif
+
+#if EF9
+        // Test bases that existed only in EF9.
+        typeof(Microsoft.EntityFrameworkCore.BulkUpdates.ComplexTypeBulkUpdatesTestBase<>),
+#endif
+
+#if !EF8 && !EF9
+        // Test bases added in EF10+.
+        typeof(AdHocJsonQueryTestBase),
+        // NorthwindFunctionsQueryMongoTest exists only for EF8 and EF9 — the EF10 build deliberately omits it.
+        typeof(NorthwindFunctionsQueryTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.ModelBuilding.ModelBuilderTest.ComplexCollectionTestBase),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.AssociationsBulkUpdateTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.AssociationsCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.AssociationsMiscellaneousTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.AssociationsPrimitiveCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.AssociationsProjectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.AssociationsSetOperationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.AssociationsStructuralEqualityTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties.ComplexPropertiesBulkUpdateTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties.ComplexPropertiesCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties.ComplexPropertiesMiscellaneousTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties.ComplexPropertiesPrimitiveCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties.ComplexPropertiesProjectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties.ComplexPropertiesSetOperationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.ComplexProperties.ComplexPropertiesStructuralEqualityTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.Navigations.NavigationsCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.Navigations.NavigationsIncludeTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.Navigations.NavigationsMiscellaneousTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.Navigations.NavigationsPrimitiveCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.Navigations.NavigationsProjectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.Navigations.NavigationsSetOperationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.Navigations.NavigationsStructuralEqualityTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations.OwnedNavigationsCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations.OwnedNavigationsMiscellaneousTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations.OwnedNavigationsPrimitiveCollectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations.OwnedNavigationsProjectionTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations.OwnedNavigationsSetOperationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations.OwnedNavigationsStructuralEqualityTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.ByteArrayTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.EnumTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.GuidTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.MathTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.MiscellaneousTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Operators.ArithmeticOperatorTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Operators.BitwiseOperatorTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Operators.ComparisonOperatorTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Operators.LogicalOperatorTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Operators.MiscellaneousOperatorTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.StringTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Temporal.DateOnlyTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Temporal.DateTimeOffsetTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Temporal.DateTimeTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Temporal.TimeOnlyTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Query.Translations.Temporal.TimeSpanTranslationsTestBase<>),
+        typeof(Microsoft.EntityFrameworkCore.Types.TypeTestBase<,>),
+#endif
+    ];
+
+    protected override Assembly TargetAssembly
+        => typeof(MongoComplianceTest).Assembly;
+}

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
@@ -49,7 +49,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_top_level_json_entity_with_missing_scalars(bool async)
     {
-        // Fails: No support for nested JSON
+        // Fails: No support for nested JSON EF-X008
         Assert.Contains(
             "Argument type 'System.Collections.Generic.IEnumerable`1[Microsoft.EntityFrameworkCore.Query.AdHocJsonQueryTestBase+Context21006+JsonEntity]' does not match",
             (await Assert.ThrowsAsync<ArgumentException>(
@@ -61,7 +61,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_nested_json_entity_with_missing_scalars(bool async)
     {
-        // Fails: No support for nested JSON
+        // Fails: No support for nested JSON EF-X008
         Assert.Contains(
             "An item with the same key has already been added.",
             (await Assert.ThrowsAsync<ArgumentException>(() =>
@@ -98,7 +98,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_missing_required_navigation(bool async)
     {
-        // Fails: Entity id=5 has no RequiredReference field
+        // Fails: Entity id=5 has no RequiredReference field EF-X005
         Assert.Contains(
             "Field 'RequiredReference' required but not present",
             (await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -128,7 +128,7 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
 
     public override async Task Project_null_required_navigation(bool async)
     {
-        // Fails: NestedRequiredReference is null in BsonDocument for entity id=6
+        // Fails: NestedRequiredReference is null in BsonDocument for entity id=6 EF-X005
         Assert.Contains(
             "Field 'NestedRequiredReference' required but not present",
             (await Assert.ThrowsAsync<InvalidOperationException>(

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -97,7 +97,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Enumerable_min_is_mapped_to_Queryable_1(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Enumerable_min_is_mapped_to_Queryable_1(async));
 
         AssertMql(
@@ -106,7 +106,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Enumerable_min_is_mapped_to_Queryable_2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Enumerable_min_is_mapped_to_Queryable_2(async));
 
         AssertMql(
@@ -115,7 +115,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_with_unmapped_property_access_throws_meaningful_exception(bool async)
     {
-        // Fails: Does not use translation failed message
+        // Fails: Does not use translation failed message EF-X002
         Assert.Contains(
             "a",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -171,16 +171,19 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_after_default_if_empty_does_not_throw(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Average_after_default_if_empty_does_not_throw(async));
     }
 
     public override async Task Max_after_default_if_empty_does_not_throw(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Max_after_default_if_empty_does_not_throw(async));
     }
 
     public override async Task Min_after_default_if_empty_does_not_throw(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Min_after_default_if_empty_does_not_throw(async));
     }
 
@@ -260,7 +263,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Min_no_data_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Min_no_data_subquery(async));
 
         AssertMql(
@@ -307,7 +310,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Max_no_data_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Max_no_data_subquery(async));
 
         AssertMql(
@@ -346,7 +349,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_no_data_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Average_no_data_subquery(async));
 
         AssertMql(
@@ -375,7 +378,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Where_OrderBy_Count_client_eval(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -389,7 +392,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OrderBy_Where_Count_client_eval(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -403,7 +406,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OrderBy_Where_Count_client_eval_mixed(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -417,7 +420,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OrderBy_Count_with_predicate_client_eval(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -431,7 +434,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OrderBy_Count_with_predicate_client_eval_mixed(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -445,7 +448,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OrderBy_Where_Count_with_predicate_client_eval(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -459,7 +462,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OrderBy_Where_Count_with_predicate_client_eval_mixed(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() =>
@@ -736,7 +739,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Sum_on_float_column_in_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Sum_on_float_column_in_subquery(async));
 
         AssertMql(
@@ -863,7 +866,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_on_float_column_in_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Average_on_float_column_in_subquery(async));
 
         AssertMql(
@@ -872,7 +875,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_on_float_column_in_subquery_with_cast(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Average_on_float_column_in_subquery_with_cast(async));
 
         AssertMql(
@@ -1157,13 +1160,13 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Multiple_collection_navigation_with_FirstOrDefault_chained(async));
     }
 
     public override async Task Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Multiple_collection_navigation_with_FirstOrDefault_chained_projecting_scalar(async));
     }
 
@@ -1234,7 +1237,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_with_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertNoMultiCollectionQuerySupport(() => base.Contains_with_subquery(async));
     }
 
@@ -1254,7 +1257,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_with_subquery_and_local_array_closure(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1654,6 +1657,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OfType_Select(bool async)
     {
+        // Fails: OfType translation EF-X012
         await AssertTranslationFailed(() => base.OfType_Select(async));
 
         AssertMql(
@@ -1662,6 +1666,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task OfType_Select_OfType_Select(bool async)
     {
+        // Fails: OfType translation EF-X012
         await AssertTranslationFailed(() => base.OfType_Select_OfType_Select(async));
 
         AssertMql(
@@ -1830,7 +1835,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1844,7 +1849,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_entityType_with_null_in_projection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1857,7 +1862,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_scalar_with_null_should_rewrite_to_identity_equality_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1871,7 +1876,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_negated(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1885,7 +1890,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_entityType_with_null_should_rewrite_to_identity_equality_subquery_complex(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1899,7 +1904,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Contains_over_nullable_scalar_with_null_in_subquery_translated_correctly(async));
 
         AssertMql(
@@ -1908,7 +1913,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Contains_over_non_nullable_scalar_with_null_in_subquery_simplifies_to_false(async));
 
@@ -1918,7 +1923,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_entityType_should_materialize_when_composite(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1932,7 +1937,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_over_entityType_should_materialize_when_composite2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -2068,7 +2073,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Cast_before_aggregate_is_preserved(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Cast_before_aggregate_is_preserved(async));
 
         AssertMql(
@@ -2116,7 +2121,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Average_on_nav_subquery_in_projection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Average_on_nav_subquery_in_projection(async));
 
         AssertMql(
@@ -2150,6 +2155,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Contains_inside_aggregate_function_with_GroupBy(bool async)
     {
+        // Fails: GroupBy issue EF-149
         await AssertTranslationFailed(() => base.Contains_inside_aggregate_function_with_GroupBy(async));
     }
 
@@ -2216,27 +2222,32 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 #if EF8 || EF9
     public override async Task DefaultIfEmpty_selects_only_required_columns(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_selects_only_required_columns(async));
     }
 
 #else
     public override async Task Average_after_DefaultIfEmpty_does_not_throw(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Average_after_DefaultIfEmpty_does_not_throw(async));
     }
 
     public override async Task Max_after_DefaultIfEmpty_does_not_throw(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Max_after_DefaultIfEmpty_does_not_throw(async));
     }
 
     public override async Task Min_after_DefaultIfEmpty_does_not_throw(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Min_after_DefaultIfEmpty_does_not_throw(async));
     }
 
     public override async Task DefaultIfEmpty_selects_only_required_columns(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_selects_only_required_columns(async));
 
         AssertMql(
@@ -2279,6 +2290,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Type_casting_inside_sum(bool async)
     {
+        // Fails: Truncation data loss issue EF-228
         // Returns 121.04000180587159838 instead of 121.040 because of conversion errors.
         Assert.Contains(
             "Actual:   121.04000180587159838",

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindCompiledQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindCompiledQueryMongoTest.cs
@@ -169,7 +169,7 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
 
     public override void Compiled_query_when_does_not_end_in_query_operator()
     {
-         // Fails: Compiled query with non-query operator issue EF-232
+         // Fails: Compiled query with non-query operator issue EF-X011
          Assert.Contains(
              "No ultimate source found",
              Assert.Throws<ArgumentException>(() => base.Compiled_query_when_does_not_end_in_query_operator()).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindEFPropertyIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindEFPropertyIncludeQueryMongoTest.cs
@@ -34,6 +34,7 @@ public class NorthwindEFPropertyIncludeQueryMongoTest : NorthwindEFPropertyInclu
 
     public override async Task Include_collection_with_right_join_clause_with_filter(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.Include_collection_with_right_join_clause_with_filter(async));
 
         AssertMql();
@@ -1168,7 +1169,7 @@ Customers.{ "$limit" : 1 }, { "$project" : { "_id" : 0, "_v" : null } }
 
     public override async Task Include_collection_with_client_filter(bool async)
     {
-        // Throws with Mongo-specific message rather than the generic EF message.
+        // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
         Assert.Contains(
             "Including navigation 'Navigation' is not",
             (await Assert.ThrowsAsync<ContainsException>(() => base.Include_collection_with_client_filter(async))).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
@@ -195,7 +195,7 @@ Customers.
 
     public override async Task String_StartsWith_with_StringComparison_unsupported(bool async)
     {
-        // These are translated by the Mongo provider. See EF-243.
+        // These are translated by the Mongo provider.
         await AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.CompanyName.StartsWith("Qu", StringComparison.CurrentCulture)));
         await AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.StartsWith("m", StringComparison.CurrentCultureIgnoreCase)));
 
@@ -205,6 +205,7 @@ Customers.
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
                 AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.StartsWith("M", StringComparison.InvariantCulture))))).Message);
 
+        // Fails: StartsWith/Contains/EndsWith Ordinal/OrdinalIgnoreCase issue EF-243
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -311,7 +312,7 @@ Customers.
 
     public override async Task String_EndsWith_with_StringComparison_unsupported(bool async)
     {
-        // These are translated by the Mongo provider. See EF-243.
+        // These are translated by the Mongo provider.
         await AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith("e", StringComparison.CurrentCulture)));
         await AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith("m", StringComparison.CurrentCultureIgnoreCase)));
 
@@ -321,6 +322,7 @@ Customers.
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
                 AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.EndsWith("M", StringComparison.InvariantCulture))))).Message);
 
+        // Fails: StartsWith/Contains/EndsWith Ordinal/OrdinalIgnoreCase issue EF-243
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1031,7 +1033,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_round_works_correctly_in_projection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Sum_over_round_works_correctly_in_projection(async));
 
         AssertMql(
@@ -1040,7 +1042,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_round_works_correctly_in_projection_2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Sum_over_round_works_correctly_in_projection_2(async));
 
         AssertMql(
@@ -1049,7 +1051,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_truncate_works_correctly_in_projection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Sum_over_truncate_works_correctly_in_projection(async));
 
         AssertMql(
@@ -1058,7 +1060,7 @@ Orders.{ "$match" : { "OrderDate" : { "$lte" : { "$date" : "1998-05-04T00:00:00Z
 
     public override async Task Sum_over_truncate_works_correctly_in_projection_2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Sum_over_truncate_works_correctly_in_projection_2(async));
 
         AssertMql(
@@ -2201,6 +2203,7 @@ Customers.{ "$match" : { "Region" : { "$regularExpression" : { "pattern" : "$", 
 
     public override async Task Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertTranslationFailed(() =>
             base.Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(async));
 
@@ -2220,7 +2223,7 @@ Customers.{ "$match" : { "Region" : { "$regularExpression" : { "pattern" : "$", 
 
     public override async Task Static_equals_nullable_datetime_compared_to_non_nullable(bool async)
     {
-        // Fails: MongoDB DateTimeKind handling
+        // Fails: MongoDB DateTimeKind handling EF-X006
         var arg = new DateTime(1996, 7, 4, 0, 0, 0, DateTimeKind.Utc);
 
         await AssertQuery(
@@ -2302,7 +2305,7 @@ Customers.{ "$match" : { "Region" : { "$regularExpression" : { "pattern" : "$", 
 
     public override async Task Regex_IsMatch_MethodCall_constant_input(bool async)
     {
-        // Fails Regex with non-constant pattern issue EF-247
+        // Fails: Regex with non-constant pattern issue EF-247
         Assert.Contains(
             "Expression not supported: IsMatch",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -2409,7 +2412,7 @@ Customers.
 
     public override async Task String_Contains_with_StringComparison_unsupported(bool async)
     {
-        // These are translated by the Mongo provider. See EF-243.
+        // These are translated by the Mongo provider.
         await AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.CurrentCulture)));
         await AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("m", StringComparison.CurrentCultureIgnoreCase)));
 
@@ -2419,6 +2422,7 @@ Customers.
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
                 AssertQuery(async, ss => ss.Set<Customer>().Where(c => c.ContactName.Contains("M", StringComparison.InvariantCulture))))).Message);
 
+        // Fails: StartsWith/Contains/EndsWith Ordinal/OrdinalIgnoreCase issue EF-243
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindGroupByQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindGroupByQueryMongoTest.cs
@@ -41,6 +41,7 @@ public class NorthwindGroupByQueryMongoTest : NorthwindGroupByQueryTestBase<
 
     public override async Task Final_GroupBy_TagWith(bool async)
     {
+        // Fails: GroupBy issue EF-149
         await AssertTranslationFailed(() => base.Final_GroupBy_TagWith(async));
     }
 
@@ -2353,6 +2354,7 @@ public class NorthwindGroupByQueryMongoTest : NorthwindGroupByQueryTestBase<
     protected override void ClearLog()
         => Fixture.TestMqlLoggerFactory.Clear();
 
+    // Fails: Cross-document navigation access issue EF-216
     private static async Task AssertNoMultiCollectionQuerySupport(Func<Task> query)
         =>  Assert.Contains("Unsupported cross-DbSet query between",
             (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeNoTrackingQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeNoTrackingQueryMongoTest.cs
@@ -34,6 +34,7 @@ public class NorthwindIncludeNoTrackingQueryMongoTest : NorthwindIncludeNoTracki
 
     public override async Task Include_collection_with_right_join_clause_with_filter(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.Include_collection_with_right_join_clause_with_filter(async));
     }
 
@@ -1170,7 +1171,7 @@ public class NorthwindIncludeNoTrackingQueryMongoTest : NorthwindIncludeNoTracki
 
     public override async Task Include_collection_with_client_filter(bool async)
     {
-        // Throws with Mongo-specific message rather than the generic EF message.
+        // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
         Assert.Contains(
             "Including navigation 'Navigation' is not",
             (await Assert.ThrowsAsync<ContainsException>(() => base.Include_collection_with_client_filter(async))).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeQueryMongoTest.cs
@@ -34,6 +34,7 @@ public class NorthwindIncludeQueryMongoTest : NorthwindIncludeQueryTestBase<
 
     public override async Task Include_collection_with_right_join_clause_with_filter(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.Include_collection_with_right_join_clause_with_filter(async));
     }
 
@@ -1185,7 +1186,7 @@ public class NorthwindIncludeQueryMongoTest : NorthwindIncludeQueryTestBase<
 
     public override async Task Include_collection_with_client_filter(bool async)
     {
-        // Throws with Mongo-specific message rather than the generic EF message.
+        // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
         Assert.Contains(
             "Including navigation 'Navigation' is not",
             (await Assert.ThrowsAsync<ContainsException>(() => base.Include_collection_with_client_filter(async))).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
@@ -38,6 +38,7 @@ public class NorthwindJoinQueryMongoTest : NorthwindJoinQueryTestBase<NorthwindQ
 
     public override async Task LeftJoin(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.LeftJoin(async));
 
         AssertMql(
@@ -46,6 +47,7 @@ public class NorthwindJoinQueryMongoTest : NorthwindJoinQueryTestBase<NorthwindQ
 
     public override async Task RightJoin(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.RightJoin(async));
 
         AssertMql(
@@ -54,6 +56,7 @@ public class NorthwindJoinQueryMongoTest : NorthwindJoinQueryTestBase<NorthwindQ
 
     public override async Task GroupJoin_aggregate_anonymous_key_selectors(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.GroupJoin_aggregate_anonymous_key_selectors(async));
 
         AssertMql(
@@ -62,6 +65,7 @@ public class NorthwindJoinQueryMongoTest : NorthwindJoinQueryTestBase<NorthwindQ
 
     public override async Task GroupJoin_aggregate_anonymous_key_selectors2(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.GroupJoin_aggregate_anonymous_key_selectors2(async));
 
         AssertMql(
@@ -70,6 +74,7 @@ public class NorthwindJoinQueryMongoTest : NorthwindJoinQueryTestBase<NorthwindQ
 
     public override async Task GroupJoin_aggregate_anonymous_key_selectors_one_argument(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.GroupJoin_aggregate_anonymous_key_selectors_one_argument(async));
 
         AssertMql(
@@ -78,6 +83,7 @@ public class NorthwindJoinQueryMongoTest : NorthwindJoinQueryTestBase<NorthwindQ
 
     public override async Task GroupJoin_aggregate_nested_anonymous_key_selectors(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.GroupJoin_aggregate_nested_anonymous_key_selectors(async));
 
         AssertMql(
@@ -86,6 +92,7 @@ public class NorthwindJoinQueryMongoTest : NorthwindJoinQueryTestBase<NorthwindQ
 
     public override async Task Join_with_key_selectors_being_nested_anonymous_objects(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.Join_with_key_selectors_being_nested_anonymous_objects(async));
 
         AssertMql(

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindKeylessEntitiesQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindKeylessEntitiesQueryMongoTest.cs
@@ -43,7 +43,7 @@ Customers.{ "$match" : { "City" : "London" } }
 
     public override async Task KeylessEntity_by_database_view(bool async)
     {
-        // Fails: Views are not supported, so this returns all entities from mapped collection.
+        // Fails: Views are not supported, so this returns all entities from mapped collection. EF-X007
         await Assert.ThrowsAsync<EqualException>(() => base.KeylessEntity_by_database_view(async));
 
         AssertMql(
@@ -62,7 +62,7 @@ Customers.{ "$match" : { "City" : "London" } }
 
     public override async Task KeylessEntity_with_nav_defining_query(bool async)
     {
-        // Fails: Defining queries are not supported.
+        // Fails: Defining queries are not supported. EF-X007
         await Assert.ThrowsAsync<EqualException>(() => base.KeylessEntity_with_nav_defining_query(async));
 
         AssertMql(

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -45,22 +45,26 @@ public class NorthwindMiscellaneousQueryMongoTest
 #if EF8 || EF9
     public override async Task DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_over_empty_collection_followed_by_projecting_constant(async));
     }
 
     public override async Task DefaultIfEmpty_without_group_join(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_without_group_join(async));
     }
 
 #else
     public override async Task DefaultIfEmpty_top_level(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level(async));
     }
 
     public override async Task DefaultIfEmpty_without_group_join(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_without_group_join(async));
     }
 
@@ -89,6 +93,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task DefaultIfEmpty_top_level_followed_by_constant_Select(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level_followed_by_constant_Select(async));
 
         AssertMql(
@@ -97,6 +102,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task DefaultIfEmpty_top_level_preceded_by_constant_Select(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.DefaultIfEmpty_top_level_preceded_by_constant_Select(async));
 
         AssertMql(
@@ -105,6 +111,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task SelectMany_correlated_with_Select_value_type_and_DefaultIfEmpty_in_selector(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.SelectMany_correlated_with_Select_value_type_and_DefaultIfEmpty_in_selector(async));
 
@@ -114,6 +121,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Late_subquery_pushdown(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await Assert.ThrowsAnyAsync<ExpressionNotSupportedException>(() => base.Late_subquery_pushdown(async));
 
         AssertMql("Orders."
@@ -122,6 +130,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Where_nanosecond_and_microsecond_component(bool async)
     {
+        // Fails: Sub-second DateTime component translation EF-X015
         await Assert.ThrowsAnyAsync<ExpressionNotSupportedException>(() => base.Where_nanosecond_and_microsecond_component(async));
 
         AssertMql("Orders."
@@ -140,6 +149,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Any_on_distinct(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await Assert.ThrowsAsync<InvalidOperationException>(() => base.Any_on_distinct(async));
     }
 
@@ -196,7 +206,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Skip_1_Take_0_works_when_constant(bool async)
     {
-        // Fails: Subqueries not supported
+        // Fails: Subqueries not supported EF-X001
         await AssertTranslationFailed(() => base.Skip_1_Take_0_works_when_constant(async));
 
         AssertMql();
@@ -204,7 +214,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Take_0_works_when_constant(bool async)
     {
-        // Fails: Subqueries not supported
+        // Fails: Subqueries not supported EF-X001
         await AssertTranslationFailed(() => base.Take_0_works_when_constant(async));
 
         AssertMql();
@@ -290,7 +300,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Subquery_DefaultIfEmpty_Any(bool async)
     {
-        // Fails: No subquery support
+        // Fails: No subquery support EF-X001
         await AssertTranslationFailed(() => base.Subquery_DefaultIfEmpty_Any(async));
     }
 
@@ -534,21 +544,25 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Join_with_default_if_empty_on_both_sources(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.Join_with_default_if_empty_on_both_sources(async));
     }
 
     public override async Task Default_if_empty_top_level_followed_by_projecting_constant(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Default_if_empty_top_level_followed_by_projecting_constant(async));
     }
 
     public override async Task Default_if_empty_top_level_positive(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Default_if_empty_top_level_positive(async));
     }
 
     public override async Task Default_if_empty_top_level_projection(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Default_if_empty_top_level_projection(async));
     }
 
@@ -1238,16 +1252,19 @@ public class NorthwindMiscellaneousQueryMongoTest
 #if EF9
     public override async Task Any_on_distinct(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertNoMultiCollectionQuerySupport(() => base.Any_on_distinct(async));
     }
 
     public override async Task Contains_on_distinct(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertNoMultiCollectionQuerySupport(() => base.Contains_on_distinct(async));
     }
 
     public override async Task All_on_distinct(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertNoMultiCollectionQuerySupport(() => base.All_on_distinct(async));
     }
 
@@ -1275,7 +1292,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task All_top_level_subquery(bool async)
     {
-        // Fails: Subqueries not supported
+        // Fails: Subqueries not supported EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1289,7 +1306,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task All_top_level_subquery_ef_property(bool async)
     {
-        // Fails: Subqueries not supported
+        // Fails: Subqueries not supported EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1303,76 +1320,91 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Where_select_many_or(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Where_select_many_or(async));
     }
 
     public override async Task Where_select_many_or2(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Where_select_many_or2(async));
     }
 
     public override async Task Where_select_many_or3(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Where_select_many_or3(async));
     }
 
     public override async Task Where_select_many_or4(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Where_select_many_or4(async));
     }
 
     public override async Task Where_select_many_or_with_parameter(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Where_select_many_or_with_parameter(async));
     }
 
     public override async Task SelectMany_simple_subquery(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_simple_subquery(async));
     }
 
     public override async Task SelectMany_simple1(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_simple1(async));
     }
 
     public override async Task SelectMany_simple2(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_simple2(async));
     }
 
     public override async Task SelectMany_entity_deep(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_entity_deep(async));
     }
 
     public override async Task SelectMany_projection1(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_projection1(async));
     }
 
     public override async Task SelectMany_projection2(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_projection2(async));
     }
 
     public override async Task SelectMany_Count(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_Count(async));
     }
 
     public override async Task SelectMany_LongCount(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_LongCount(async));
     }
 
     public override async Task SelectMany_OrderBy_ThenBy_Any(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_OrderBy_ThenBy_Any(async));
     }
 
     public override async Task Join_Where_Count(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.Join_Where_Count(async));
     }
 
@@ -1383,7 +1415,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Where_Join_Exists(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         await AssertNoMultiCollectionQuerySupport(() => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c =>
@@ -1392,7 +1424,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Where_Join_Exists_Inequality(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         await AssertNoMultiCollectionQuerySupport(() => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c =>
@@ -1401,7 +1433,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Where_Join_Exists_Constant(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         await AssertNoMultiCollectionQuerySupport(() => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" && c.Orders.Exists(o => false))));
@@ -1411,7 +1443,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task Where_Join_Not_Exists(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         await AssertNoMultiCollectionQuerySupport(() => AssertQuery(
             async,
             ss => ss.Set<Customer>().Where(c => c.CustomerID == "ALFKI" && !c.Orders.Exists(o => false))));
@@ -1748,7 +1780,7 @@ public class NorthwindMiscellaneousQueryMongoTest
 
     public override async Task OrderBy_correlated_subquery1(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.OrderBy_correlated_subquery1(async))).Message);
@@ -2491,7 +2523,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_year(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_year(async))).Message);
@@ -2502,7 +2534,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_month(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_month(async))).Message);
@@ -2513,7 +2545,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_hour(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_hour(async))).Message);
@@ -2524,7 +2556,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_minute(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_minute(async))).Message);
@@ -2535,7 +2567,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_datetime_add_second(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_second(async))).Message);
@@ -2546,7 +2578,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_milliseconds_above_the_range(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_above_the_range(async)))
@@ -2558,7 +2590,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_milliseconds_below_the_range(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_below_the_range(async)))
@@ -2570,7 +2602,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "Rewriting child expression",
             (await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -2814,7 +2846,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Complex_query_with_repeated_query_model_compiles_correctly(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -2828,7 +2860,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Complex_query_with_repeated_nested_query_model_compiles_correctly(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -2912,7 +2944,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_subquery_orderby(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Anonymous_projection_skip_take_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -3525,7 +3557,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "Rewriting child expression",
             (await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -3645,7 +3677,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_projection_skip_empty_collection_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Anonymous_projection_skip_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -3654,7 +3686,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_projection_take_empty_collection_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Anonymous_projection_take_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -3663,7 +3695,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Anonymous_projection_skip_take_empty_collection_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Anonymous_projection_skip_take_empty_collection_FirstOrDefault(async));
 
         AssertMql(
@@ -3963,7 +3995,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
 
     public override async Task Non_nullable_property_through_optional_navigation(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "MongoCommandException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Non_nullable_property_through_optional_navigation(async)))
@@ -4281,7 +4313,7 @@ Customers.
 
     public override async Task Select_expression_datetime_add_ticks(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "DateTime",
             (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_ticks(async))).Message);
@@ -4390,7 +4422,7 @@ Customers.
 
     public override async Task Using_static_string_Equals_with_StringComparison_throws_informative_error(bool async)
     {
-        // Fails: Throws different exception, but still throws
+        // Fails: Throws different exception, but still throws EF-X002
         Assert.Contains(
             "Expression not supported: Equals",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -4404,7 +4436,7 @@ Customers.
 
     public override async Task Using_string_Equals_with_StringComparison_throws_informative_error(bool async)
     {
-        // Fails: Throws different exception, but still throws
+        // Fails: Throws different exception, but still throws EF-X002
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -4545,7 +4577,7 @@ Customers.
 
     public override async Task Client_code_unknown_method(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Client_code_unknown_method(async))).Message);
@@ -4602,7 +4634,7 @@ Customers.
 
     public override async Task Where_query_composition3(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_query_composition3(async))).Message);
@@ -4615,7 +4647,7 @@ Customers.
 
     public override async Task Where_query_composition4(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_query_composition4(async))).Message);
@@ -4628,7 +4660,7 @@ Customers.
 
     public override async Task Where_query_composition5(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_query_composition5(async))).Message);
@@ -4641,7 +4673,7 @@ Customers.
 
     public override async Task Where_query_composition6(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_query_composition6(async))).Message);
@@ -4703,7 +4735,7 @@ Customers.
 
     public override async Task OrderBy_client_mixed(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.OrderBy_client_mixed(async))).Message);
@@ -4731,6 +4763,7 @@ Customers.
 #if EF9
     public override async Task IQueryable_captured_variable()
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertNoMultiCollectionQuerySupport(() => base.IQueryable_captured_variable());
     }
 
@@ -4773,7 +4806,7 @@ Customers.
 
     public override async Task Queryable_reprojection(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Queryable_reprojection(async))).Message);
@@ -4786,7 +4819,7 @@ Customers.
 
     public override async Task All_client(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.All_client(async))).Message);
@@ -4798,7 +4831,7 @@ Customers.
 
     public override async Task All_client_and_server_top_level(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.All_client_and_server_top_level(async))).Message);
@@ -4811,7 +4844,7 @@ Customers.
 
     public override async Task All_client_or_server_top_level(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.All_client_or_server_top_level(async))).Message);
@@ -4824,7 +4857,7 @@ Customers.
 
     public override async Task First_client_predicate(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
+        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.First_client_predicate(async))).Message);
@@ -4902,6 +4935,7 @@ Customers.
 
     public override async Task Parameter_collection_Contains_with_projection_and_ordering(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Parameter_collection_Contains_with_projection_and_ordering(async));
     }
 
@@ -4997,6 +5031,7 @@ Customers.{ "$sort" : { "_id" : -1 } }, { "$project" : { "_v" : "$_id", "_id" : 
 
     public override async Task Where_Order_First(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertNoMultiCollectionQuerySupport(() => base.Where_Order_First(async));
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindNavigationsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindNavigationsQueryMongoTest.cs
@@ -328,6 +328,7 @@ public class NorthwindNavigationsQueryMongoTest : NorthwindNavigationsQueryTestB
 
     public override async Task Collection_select_nav_prop_all(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertTranslationFailed(() => base.Collection_select_nav_prop_all(async));
     }
 
@@ -338,6 +339,7 @@ public class NorthwindNavigationsQueryMongoTest : NorthwindNavigationsQueryTestB
 
     public override async Task Collection_select_nav_prop_count(bool async)
     {
+        // Fails: Cross-document navigation access issue EF-216
         await AssertTranslationFailed(() => base.Collection_select_nav_prop_count(async));
     }
 
@@ -491,7 +493,7 @@ public class NorthwindNavigationsQueryMongoTest : NorthwindNavigationsQueryTestB
 
     public override async Task Where_subquery_on_navigation(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         await AssertNoMultiCollectionQuerySupport(() => AssertQuery(
             async,
             ss => from p in ss.Set<Product>()
@@ -503,7 +505,7 @@ public class NorthwindNavigationsQueryMongoTest : NorthwindNavigationsQueryTestB
 
     public override async Task Where_subquery_on_navigation2(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         await AssertNoMultiCollectionQuerySupport(() => AssertQuery(
             async,
             ss => from p in ss.Set<Product>()
@@ -632,7 +634,7 @@ public class NorthwindNavigationsQueryMongoTest : NorthwindNavigationsQueryTestB
 
     public override async Task Select_Where_Navigation_Client(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "The LINQ expression",
             (await Assert.ThrowsAsync<ContainsException>(() => base.Select_Where_Navigation_Client(async))).Message);
@@ -642,7 +644,7 @@ public class NorthwindNavigationsQueryMongoTest : NorthwindNavigationsQueryTestB
 
     public override async Task Collection_select_nav_prop_all_client(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "The LINQ expression",
             (await Assert.ThrowsAsync<ContainsException>(() => base.Collection_select_nav_prop_all_client(async))).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindQueryFiltersQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindQueryFiltersQueryMongoTest.cs
@@ -184,7 +184,7 @@ Customers.{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : 
 
     public override async Task Client_eval(bool async)
     {
-        // Fails: Does not throw expected unable to translate exception
+        // Fails: Does not throw expected unable to translate exception EF-X002
         Assert.Contains(
             "Actual:   typeof(MongoDB.Driver.Linq.ExpressionNotSupportedException)",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Client_eval(async))).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
@@ -42,6 +42,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 #if !EF8 && !EF9
     public override async Task SelectMany_with_nested_DefaultIfEmpty(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_with_nested_DefaultIfEmpty(async));
 
         AssertMql(
@@ -50,6 +51,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
     public override async Task SelectMany_with_multiple_Take(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_with_multiple_Take(async));
 
         AssertMql(
@@ -58,6 +60,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_OrderBy_and_FirstOrDefault(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Take_OrderBy_and_FirstOrDefault(async));
 
@@ -128,6 +131,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
     public override async Task Set_operation_in_pending_collection(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Set_operation_in_pending_collection(async));
     }
 
@@ -135,7 +139,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
     public override async Task Projection_when_arithmetic_expression_precedence(bool async)
     {
-        // Fails: Truncation resulted in data loss
+        // Fails: Truncation resulted in data loss EF-X004
         Assert.Contains(
             "An error occurred while deserializing the B property",
             (await Assert.ThrowsAsync<FormatException>(() =>
@@ -159,7 +163,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
     public override async Task Projection_when_arithmetic_mixed(bool async)
     {
-        // Fails: Subqueries not supported
+        // Fails: Subqueries not supported EF-X001
         await AssertTranslationFailed(() => base.Projection_when_arithmetic_mixed(async));
 
         AssertMql();
@@ -177,7 +181,7 @@ public class NorthwindSelectQueryMongoTest : NorthwindSelectQueryTestBase<Northw
 
     public override async Task Projection_when_client_evald_subquery(bool async)
     {
-        // Fails: Subqueries not supported
+        // Fails: Subqueries not supported EF-X001
         await AssertTranslationFailed(() => base.Projection_when_client_evald_subquery(async));
 
         AssertMql();
@@ -205,6 +209,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projection_of_multiple_entity_types_into_object_array(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(
             () => base.Projection_of_multiple_entity_types_into_object_array(async));
     }
@@ -231,7 +236,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool async)
     {
-        // Fails: Unknown reasons
+        // Fails: Unknown reasons EF-X009
         Assert.Contains(
             "Command aggregate failed: Invalid $project :: caused by :: Cannot do exclusion on field _key1 in inclusion projection.",
             (await Assert.ThrowsAsync<MongoCommandException>(() =>
@@ -375,7 +380,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection(async));
 
         AssertMql();
@@ -383,7 +388,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level(async));
 
         AssertMql();
@@ -391,7 +396,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level2(async));
 
         AssertMql();
@@ -399,7 +404,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level3(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level3(async));
 
         AssertMql();
@@ -407,7 +412,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level4(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level4(async));
 
         AssertMql();
@@ -415,7 +420,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level5(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level5(async));
 
         AssertMql();
@@ -423,7 +428,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_multi_level6(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_multi_level6(async));
 
         AssertMql();
@@ -431,7 +436,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_count_using_anonymous_type(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_count_using_anonymous_type(async));
 
         AssertMql();
@@ -500,7 +505,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(
         bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "Expression not supported: Convert((Convert(o.OrderID, Int64) + Convert(o.OrderID, Int64)), Int16) because conversion to System.Int16 is not supported.",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -555,7 +560,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "Expression not supported: Convert(o.OrderID, Int16) because conversion to System.Int16 is not supported.",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -632,7 +637,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projection_in_a_subquery_should_be_liftable(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported: Format(\"{0}\", Convert(e.EmployeeID, Object))",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -646,7 +651,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projection_containing_DateTime_subtraction(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "Expression not supported: (o.OrderDate.Value",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -660,7 +665,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(async));
 
@@ -669,7 +674,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(async));
 
@@ -678,7 +683,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(async));
 
@@ -688,7 +693,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task
         Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(
                 async));
@@ -698,7 +703,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(async));
 
@@ -708,7 +713,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task
         Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(async));
 
@@ -717,7 +722,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(async));
 
@@ -728,7 +733,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
         Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
             bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base
                 .Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(
@@ -739,7 +744,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(async));
 
@@ -749,7 +754,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task
         Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(async));
 
@@ -759,7 +764,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(
         bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(async));
 
@@ -898,7 +903,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Anonymous_projection_with_repeated_property_being_ordered_2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Anonymous_projection_with_repeated_property_being_ordered_2(async));
 
         AssertMql();
@@ -906,7 +911,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_GetValueOrDefault_on_DateTime(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "Expression not supported: o.OrderDate.GetValueOrDefault()",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -920,7 +925,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         await AssertTranslationFailed(() => base.Select_GetValueOrDefault_on_DateTime_with_null_values(async));
 
         AssertMql();
@@ -948,7 +953,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Multiple_select_many_with_predicate(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Multiple_select_many_with_predicate(async));
 
         AssertMql();
@@ -956,7 +961,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_without_result_selector_naked_collection_navigation(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_without_result_selector_naked_collection_navigation(async));
 
         AssertMql();
@@ -964,7 +969,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_without_result_selector_collection_navigation_composed(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_without_result_selector_collection_navigation_composed(async));
 
         AssertMql();
@@ -972,7 +977,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_correlated_with_outer_1(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_1(async));
 
         AssertMql();
@@ -980,7 +985,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_correlated_with_outer_2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_2(async));
 
         AssertMql();
@@ -988,7 +993,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_correlated_with_outer_3(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_3(async));
 
         AssertMql();
@@ -996,7 +1001,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_correlated_with_outer_4(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_4(async));
 
         AssertMql();
@@ -1004,7 +1009,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_correlated_with_outer_5(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_5(async));
 
         AssertMql();
@@ -1012,7 +1017,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_correlated_with_outer_6(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_6(async));
 
         AssertMql();
@@ -1020,7 +1025,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_correlated_with_outer_7(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_correlated_with_outer_7(async));
 
         AssertMql();
@@ -1028,7 +1033,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.FirstOrDefault_over_empty_collection_of_value_type_returns_correct_results(async));
 
         AssertMql();
@@ -1036,7 +1041,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Project_non_nullable_value_after_FirstOrDefault_on_empty_collection(async));
 
         AssertMql();
@@ -1058,7 +1063,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Filtered_collection_projection_is_tracked(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Filtered_collection_projection_is_tracked(async));
 
         AssertMql();
@@ -1066,7 +1071,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Filtered_collection_projection_with_to_list_is_tracked(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Filtered_collection_projection_with_to_list_is_tracked(async));
 
         AssertMql();
@@ -1075,7 +1080,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(
         bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.SelectMany_with_collection_being_correlated_subquery_which_references_inner_and_outer_entity(async));
 
@@ -1086,7 +1091,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
         SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
             bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base
                 .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
@@ -1115,7 +1120,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_chained_entity_navigation_doesnt_materialize_intermittent_entities(async));
 
         AssertMql();
@@ -1123,7 +1128,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_entity_compared_to_null(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_entity_compared_to_null(async));
 
         AssertMql();
@@ -1141,7 +1146,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task SelectMany_whose_selector_references_outer_source(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.SelectMany_whose_selector_references_outer_source(async));
 
         AssertMql();
@@ -1149,7 +1154,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Collection_FirstOrDefault_with_entity_equality_check_in_projection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Collection_FirstOrDefault_with_entity_equality_check_in_projection(async));
 
         AssertMql();
@@ -1157,7 +1162,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Collection_FirstOrDefault_with_nullable_unsigned_int_column(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Collection_FirstOrDefault_with_nullable_unsigned_int_column(async));
 
         AssertMql();
@@ -1165,7 +1170,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task ToList_Count_in_projection_works(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.ToList_Count_in_projection_works(async));
 
         AssertMql();
@@ -1173,7 +1178,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task LastOrDefault_member_access_in_projection_translates_to_server(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.LastOrDefault_member_access_in_projection_translates_to_server(async));
 
         AssertMql();
@@ -1201,7 +1206,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Collection_projection_AsNoTracking_OrderBy(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Collection_projection_AsNoTracking_OrderBy(async));
 
         AssertMql();
@@ -1219,7 +1224,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_uint_through_collection_FirstOrDefault(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Project_uint_through_collection_FirstOrDefault(async));
 
         AssertMql();
@@ -1227,7 +1232,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Project_keyless_entity_FirstOrDefault_without_orderby(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Project_keyless_entity_FirstOrDefault_without_orderby(async));
 
         AssertMql();
@@ -1235,7 +1240,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Reverse_changes_asc_order_to_desc(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1390,7 +1395,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projection_AsEnumerable_projection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Projection_AsEnumerable_projection(async));
 
         AssertMql();
@@ -1408,7 +1413,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projecting_multiple_collection_with_same_constant_works(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Projecting_multiple_collection_with_same_constant_works(async));
 
         AssertMql();
@@ -1416,7 +1421,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Custom_projection_reference_navigation_PK_to_FK_optimization(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Custom_projection_reference_navigation_PK_to_FK_optimization(async));
 
         AssertMql();
@@ -1424,7 +1429,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Projecting_Length_of_a_string_property_after_FirstOrDefault_on_correlated_collection(async));
 
@@ -1433,7 +1438,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projecting_count_of_navigation_which_is_generic_list(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Projecting_count_of_navigation_which_is_generic_list(async));
 
         AssertMql();
@@ -1441,7 +1446,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projecting_count_of_navigation_which_is_generic_collection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Projecting_count_of_navigation_which_is_generic_collection(async));
 
         AssertMql();
@@ -1449,7 +1454,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projecting_count_of_navigation_which_is_generic_collection_using_convert(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertNoMultiCollectionQuerySupport(() => base.Projecting_count_of_navigation_which_is_generic_collection_using_convert(async));
     }
 
@@ -1475,7 +1480,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Projection_Distinct_projection_preserves_columns_used_for_distinct_in_subquery(async));
 
@@ -1505,7 +1510,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Ternary_in_client_eval_assigns_correct_types(bool async)
     {
-        // Fails: Limited support on client evaluation
+        // Fails: Limited support on client evaluation EF-X003
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1519,7 +1524,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projecting_after_navigation_and_distinct(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Projecting_after_navigation_and_distinct(async));
 
         AssertMql();
@@ -1528,7 +1533,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task
         Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_distinct_with_complex_projection_containing_original_identifier(async));
 
@@ -1537,7 +1542,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Correlated_collection_after_distinct_not_containing_original_identifier(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Correlated_collection_after_distinct_not_containing_original_identifier(async));
 
         AssertMql();
@@ -1546,7 +1551,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task
         Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_distinct_with_complex_projection_not_containing_original_identifier(async));
 
@@ -1556,7 +1561,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task
         Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_groupby_with_complex_projection_containing_original_identifier(async));
 
@@ -1565,7 +1570,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_deep(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_deep(async));
 
         AssertMql();
@@ -1573,7 +1578,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_nested_collection_deep_distinct_no_identifiers(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_nested_collection_deep_distinct_no_identifiers(async));
 
         AssertMql();
@@ -1592,7 +1597,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Collection_projection_selecting_outer_element_followed_by_take(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Collection_projection_selecting_outer_element_followed_by_take(async));
 
         AssertMql();
@@ -1600,7 +1605,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Take_on_top_level_and_on_collection_projection_with_outer_apply(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Take_on_top_level_and_on_collection_projection_with_outer_apply(async));
 
         AssertMql();
@@ -1608,7 +1613,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Take_on_correlated_collection_in_first(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Take_on_correlated_collection_in_first(async));
 
         AssertMql();
@@ -1616,7 +1621,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Client_projection_via_ctor_arguments(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Client_projection_via_ctor_arguments(async));
 
         AssertMql();
@@ -1624,7 +1629,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Client_projection_with_string_initialization_with_scalar_subquery(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Client_projection_with_string_initialization_with_scalar_subquery(async));
 
         AssertMql();
@@ -1632,7 +1637,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task MemberInit_in_projection_without_arguments(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.MemberInit_in_projection_without_arguments(async));
 
         AssertMql();
@@ -1670,7 +1675,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Projection_when_arithmetic_mixed_subqueries(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Projection_when_arithmetic_mixed_subqueries(async));
 
         AssertMql();
@@ -1678,7 +1683,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_datetime_Ticks_component(bool async)
     {
-        // Fails: Unsupported by driver
+        // Fails: Unsupported by driver EF-X003
         Assert.Contains(
             "Expression not supported: o.OrderDate.Value.Ticks.",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1807,7 +1812,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
     public override async Task
         Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() =>
             base.Correlated_collection_after_groupby_with_complex_projection_not_containing_original_identifier(async));
 
@@ -1816,7 +1821,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
     {
-        // Fails unknown issue
+        // Fails: Server-side projection conflict with cast-to-nullable EF-X014
         Assert.Contains(
             "Command aggregate failed: Invalid $project :: caused by :: Cannot do exclusion on field _key1 in inclusion projection.",
             (await Assert.ThrowsAsync<MongoCommandException>(() =>
@@ -1830,7 +1835,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Reverse_without_explicit_ordering(bool async)
     {
-        // Fails: Reverse not supported by driver
+        // Fails: Reverse not supported by driver EF-X003
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
@@ -1844,7 +1849,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task List_of_list_of_anonymous_type(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.List_of_list_of_anonymous_type(async));
 
         AssertMql();
@@ -1852,7 +1857,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task List_from_result_of_single_result(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.List_from_result_of_single_result(async));
 
         AssertMql();
@@ -1860,7 +1865,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task List_from_result_of_single_result_2(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.List_from_result_of_single_result_2(async));
 
         AssertMql();
@@ -1868,7 +1873,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task List_from_result_of_single_result_3(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.List_from_result_of_single_result_3(async));
 
         AssertMql();
@@ -1897,7 +1902,7 @@ Customers.{ "$sort" : { "_id" : 1 } }, { "$match" : { "_id" : { "$regularExpress
 
     public override async Task Set_operation_in_pending_collection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Set_operation_in_pending_collection(async));
 
         AssertMql();

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSetOperationsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSetOperationsQueryMongoTest.cs
@@ -41,25 +41,25 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Union_Intersect(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Union_Intersect(async));
     }
 
     public override async Task Intersect_non_entity(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Intersect_non_entity(async));
     }
 
     public override async Task Intersect_nested(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Intersect_nested(async));
     }
 
     public override async Task Intersect(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Intersect(async));
     }
 
@@ -213,6 +213,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Select_Union_different_fields_in_anonymous_with_subquery(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Select_Union_different_fields_in_anonymous_with_subquery(async));
     }
 
@@ -550,16 +551,19 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Union_over_scalarsubquery_column(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Union_over_scalarsubquery_column(async));
     }
 
     public override async Task Union_over_scalarsubquery_function(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Union_over_scalarsubquery_function(async));
     }
 
     public override async Task Union_over_scalarsubquery_constant(bool async)
     {
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Union_over_scalarsubquery_constant(async));
     }
 
@@ -642,7 +646,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Collection_projection_after_set_operation(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Collection_projection_after_set_operation(async));
 
         AssertMql(
@@ -651,7 +655,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Concat_with_one_side_being_GroupBy_aggregate(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Concat_with_one_side_being_GroupBy_aggregate(async));
 
         AssertMql(
@@ -660,7 +664,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Union_on_entity_with_correlated_collection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Union_on_entity_with_correlated_collection(async));
 
         AssertMql(
@@ -669,7 +673,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Union_on_entity_plus_other_column_with_correlated_collection(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Union_on_entity_plus_other_column_with_correlated_collection(async));
 
         AssertMql(
@@ -752,7 +756,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Collection_projection_after_set_operation_fails_if_distinct(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Collection_projection_after_set_operation_fails_if_distinct(async));
 
         AssertMql();
@@ -760,7 +764,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Collection_projection_before_set_operation_fails(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Collection_projection_before_set_operation_fails(async));
 
         AssertMql();
@@ -770,7 +774,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Intersect_on_distinct(bool async)
     {
-        // Fails: Subquery selection
+        // Fails: Subquery selection EF-X001
         await AssertTranslationFailed(() => base.Intersect_on_distinct(async));
     }
 
@@ -861,7 +865,7 @@ public class NorthwindSetOperationsQueryMongoTest : NorthwindSetOperationsQueryT
 
     public override async Task Client_eval_Union_FirstOrDefault(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws.
+        // Fails: Not throwing expected translation failed exception from EF, but still throws. EF-X002
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Client_eval_Union_FirstOrDefault(async)))

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindStringIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindStringIncludeQueryMongoTest.cs
@@ -34,6 +34,7 @@ public class NorthwindStringIncludeQueryMongoTest : NorthwindStringIncludeQueryT
 
     public override async Task Include_collection_with_right_join_clause_with_filter(bool async)
     {
+        // Fails: Include (joins) issue EF-117
         await AssertTranslationFailed(() => base.Include_collection_with_right_join_clause_with_filter(async));
 
         AssertMql(
@@ -1191,7 +1192,7 @@ public class NorthwindStringIncludeQueryMongoTest : NorthwindStringIncludeQueryT
 
     public override async Task Include_collection_with_client_filter(bool async)
     {
-        // Throws with Mongo-specific message rather than the generic EF message.
+        // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
         Assert.Contains(
             "Including navigation 'Navigation' is not",
             (await Assert.ThrowsAsync<ContainsException>(() => base.Include_collection_with_client_filter(async))).Message);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
@@ -404,7 +404,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_client(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client(async))).Message);
@@ -417,7 +417,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_subquery_correlated(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "Expression not supported",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Where_subquery_correlated(async)))
@@ -431,7 +431,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_subquery_correlated_client_eval(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         await Assert.ThrowsAsync<ThrowsException>(() => base.Where_subquery_correlated_client_eval(async));
 
         AssertMql(
@@ -442,7 +442,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_client_and_server_top_level(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_and_server_top_level(async))).Message);
@@ -455,7 +455,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_client_or_server_top_level(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_or_server_top_level(async))).Message);
@@ -468,7 +468,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_client_and_server_non_top_level(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_and_server_non_top_level(async)))
@@ -482,7 +482,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_client_deep_inside_predicate_and_server_top_level(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "ExpressionNotSupportedException",
             (await Assert.ThrowsAsync<ThrowsException>(() => base.Where_client_deep_inside_predicate_and_server_top_level(async)))
@@ -778,7 +778,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_bool_client_side_negated(bool async)
     {
-        // Fails: Not throwing expected translation failed exception from EF.
+        // Fails: Not throwing expected translation failed exception from EF. EF-X002
         Assert.Contains(
             "Expression not supported: ClientFunc(p.ProductID)",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Where_bool_client_side_negated(async))).Message);
@@ -2160,7 +2160,7 @@ Customers.{ "$match" : { "_id" : "ANATR" } }, { "$project" : { "_v" : "$_id", "_
 
     public override async Task Where_bitwise_xor(bool async)
     {
-        // Fails MongoDB does not have an xor operator
+        // Fails: MongoDB does not have an xor operator EF-X013
         Assert.Contains(
             "because MongoDB does not have a boolean $xor operator",
             (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.Where_bitwise_xor(async))).Message);


### PR DESCRIPTION
- Add MongoComplianceTest.cs — a ComplianceTestBase subclass that enforces coverage of all EF specification test bases, listing the ones not yet implemented for the MongoDB provider so any newly-added test base is detected immediately.

- Annotate every spec-test override that asserts a current failure with a structured '// Fails: <description> <ticket-id>' comment.  Previously many overrides had no comment or an incomplete description with no ticket reference; now every override is tagged with one of:
    - an existing EF-NNN / CSHARP-NNNN / upstream efcore#NNNNN ticket, or
    - a temporary EF-XNNN placeholder for failure modes that lack a real ticket (so they are still searchable and can be replaced once filed).

- Add docs/failing-spec-tests.md — a Jira-style inventory that lists every referenced ticket, a one-line description, and an occurrence count, plus a section for the EF-X placeholder entries that need real tickets filed.