### PR TITLE
EF-313: Rewrite binding for robustness with non-trivial shapes

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -40,7 +40,8 @@ namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 internal sealed class MongoEFToLinqTranslatingExpressionVisitor : System.Linq.Expressions.ExpressionVisitor
 {
     private static readonly MethodInfo MqlFieldMethodInfo =
-        typeof(Mql).GetMethod(nameof(Mql.Field), BindingFlags.Public | BindingFlags.Static)!;
+        typeof(Mql).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(Mql.Field) && m.GetParameters().Length == 3);
 
     private readonly QueryContext _queryContext;
     private readonly Expression _source;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -19,7 +19,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
-using MongoDB.Bson;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 using MongoDB.EntityFrameworkCore.Storage;
 
@@ -28,14 +27,13 @@ namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 /// <summary>
 /// Extends <see cref="MongoProjectionBindingRemovingExpressionVisitor"/> to handle mixed projections
 /// (containing both entity references and scalar properties). In this path, the LINQ V3 query
-/// returns full BsonDocuments (Select is stripped), and scalars are read from the root document
-/// using the property's actual serialization info rather than the projection alias.
+/// returns full BsonDocuments (Select is stripped), and scalars are read from the document that
+/// owns the mapped property using the property's actual serialization info.
 /// </summary>
 internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
     : MongoProjectionBindingRemovingExpressionVisitor
 {
     private readonly MongoQueryExpression _queryExpression;
-    private readonly IEntityType _rootEntityType;
     private readonly ParameterExpression _docParameter;
 
     public MongoMixedProjectionBindingRemovingExpressionVisitor(
@@ -46,7 +44,6 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
         : base(rootEntityType, queryExpression, docParameter, trackingBehavior)
     {
         _queryExpression = queryExpression;
-        _rootEntityType = rootEntityType;
         _docParameter = docParameter;
     }
 
@@ -54,86 +51,66 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
     {
         if (extensionExpression is ProjectionBindingExpression projectionBindingExpression)
         {
-            // Scalar projections in the mixed path use ProjectionMember (not Index) because
-            // ApplyProjection() early-returns when entity projections already populated _projection.
             if (projectionBindingExpression.ProjectionMember != null)
             {
                 var mappedExpression = _queryExpression.GetMappedProjection(
                     projectionBindingExpression.ProjectionMember);
 
-                // If ApplyProjection already converted this to an index, use the standard path.
+                // Resolve the source expression: after ApplyProjection it's wrapped as Constant(index),
+                // so we unwrap to get the actual stored expression; otherwise use it directly.
+                Expression? sourceExpression;
+                string? alias;
                 if (mappedExpression is ConstantExpression { Value: int })
                 {
-                    return base.VisitExtension(extensionExpression);
+                    var projection = GetProjection(projectionBindingExpression);
+                    alias = projection.Alias;
+                    if (alias is null)
+                        return _docParameter;
+                    sourceExpression = projection.Expression;
                 }
-
-                // Resolve the IProperty from the mapped expression and read from the full document.
-                var (property, fieldName) = TryResolveFieldAccess(mappedExpression);
-                if (property != null)
+                else
                 {
-                    return CreateGetValueExpression(_docParameter, property, projectionBindingExpression.Type);
+                    alias = projectionBindingExpression.ProjectionMember.Last?.Name;
+                    sourceExpression = mappedExpression;
                 }
 
-                if (fieldName != null)
+                var fieldAccess = TryResolveFieldAccess(sourceExpression);
+                if (fieldAccess.Property != null)
                 {
-                    // Non-model field (e.g., __score from $addFields) — read directly by name.
-                    return BsonBinding.CreateGetElementValue(_docParameter, fieldName, projectionBindingExpression.Type);
+                    if (fieldAccess.DocumentExpression is ParameterExpression parameterExpression
+                        && fieldAccess.MemberInfo != null
+                        && fieldAccess.MemberInfo.DeclaringType?.IsAssignableFrom(parameterExpression.Type) == true)
+                    {
+                        var memberAccess = Expression.MakeMemberAccess(parameterExpression, fieldAccess.MemberInfo);
+                        return memberAccess.Type == projectionBindingExpression.Type
+                            ? memberAccess
+                            : Expression.Convert(memberAccess, projectionBindingExpression.Type);
+                    }
+
+                    return CreateGetValueExpression(
+                        fieldAccess.DocumentExpression ?? _docParameter,
+                        fieldAccess.Property,
+                        projectionBindingExpression.Type);
                 }
 
-                // Fallback: read by projection member name from the root document.
+                if (fieldAccess.FieldName != null)
+                {
+                    return BsonBinding.CreateGetElementValue(
+                        fieldAccess.DocumentExpression ?? _docParameter,
+                        fieldAccess.FieldName,
+                        projectionBindingExpression.Type);
+                }
+
                 return CreateGetValueExpression(
                     _docParameter,
-                    projectionBindingExpression.ProjectionMember.Last?.Name,
+                    alias,
                     !projectionBindingExpression.Type.IsNullableType(),
                     projectionBindingExpression.Type);
             }
 
-            // Index-based bindings are used for entity projections (set by MongoProjectionBindingExpressionVisitor).
-            // Delegate to the base visitor which handles entity materialization.
             return base.VisitExtension(extensionExpression);
         }
 
         return base.VisitExtension(extensionExpression);
-    }
-
-    /// <summary>
-    /// Attempts to resolve an <see cref="IProperty"/> and/or field name from a projection expression that
-    /// represents a scalar property access on the entity (e.g., <c>p.name</c>) or a non-model field
-    /// access (e.g., <c>Mql.Field(e, "__score", null)</c>).
-    /// </summary>
-    private (IProperty? property, string? fieldName) TryResolveFieldAccess(Expression expression)
-    {
-        // Unwrap converts
-        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
-        {
-            expression = unary.Operand;
-        }
-
-        if (expression is MemberExpression memberExpression)
-        {
-            var property = _rootEntityType.FindProperty(memberExpression.Member);
-            return (property, property != null ? null : memberExpression.Member.Name);
-        }
-
-        if (expression is MethodCallExpression methodCall)
-        {
-            // Handle EF.Property<T>(entity, "propertyName") method calls
-            if (methodCall.Method.IsEFPropertyMethod()
-                && methodCall.Arguments[1] is ConstantExpression { Value: string propertyName })
-            {
-                var property = _rootEntityType.FindProperty(propertyName);
-                return (property, property != null ? null : propertyName);
-            }
-
-            // Handle Mql.Field<TDoc, TField>(entity, "fieldName", serializer) calls
-            if (methodCall.Method is { Name: "Field", DeclaringType.FullName: "MongoDB.Driver.Mql" }
-                && methodCall.Arguments[1] is ConstantExpression { Value: string fieldName })
-            {
-                var property = _rootEntityType.FindProperty(fieldName);
-                return (property, property != null ? null : fieldName);
-            }
-        }
-
-        return (null, null);
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
@@ -41,8 +42,8 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
         IEntityType rootEntityType,
         MongoQueryExpression queryExpression,
         ParameterExpression docParameter,
-        bool trackQueryResults)
-        : base(rootEntityType, queryExpression, docParameter, trackQueryResults)
+        QueryTrackingBehavior trackingBehavior)
+        : base(rootEntityType, queryExpression, docParameter, trackingBehavior)
     {
         _queryExpression = queryExpression;
         _rootEntityType = rootEntityType;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -43,9 +43,9 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     private readonly ParameterExpression DocParameter;
     private readonly bool _trackQueryResults;
     private readonly Dictionary<ParameterExpression, Expression> _materializationContextBindings = new();
-    private readonly Dictionary<Expression, ParameterExpression> ProjectionBindings = new();
+    private readonly Dictionary<Expression, ParameterExpression> _projectionBindings = new();
     private readonly Dictionary<Expression, (IEntityType EntityType, Expression BsonDocExpression)> _ownerMappings = new();
-    private readonly Dictionary<Expression, Expression> _ordinalParameterBindings = new();
+    private readonly Dictionary<Expression, Expression> _ordinalMappings = new();
     private List<IncludeExpression> _pendingIncludes = [];
 
     /// <summary>
@@ -98,15 +98,15 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                             throw new InvalidOperationException(CoreStrings.TranslationFailed(extensionExpression.Print()));
                     }
 
-                    var bsonArray = ProjectionBindings[objectArrayProjection];
+                    var bsonArray = _projectionBindings[objectArrayProjection];
                     var jObjectParameter = Expression.Parameter(typeof(BsonDocument), bsonArray.Name + "Object");
                     var ordinalParameter = Expression.Parameter(typeof(int), bsonArray.Name + "Ordinal");
 
                     var accessExpression = objectArrayProjection.InnerProjection.ParentAccessExpression;
-                    ProjectionBindings[accessExpression] = jObjectParameter;
+                    _projectionBindings[accessExpression] = jObjectParameter;
                     _ownerMappings[accessExpression] =
                         (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
-                    _ordinalParameterBindings[accessExpression] = Expression.Add(
+                    _ordinalMappings[accessExpression] = Expression.Add(
                         ordinalParameter, Expression.Constant(1, typeof(int)));
 
                     var innerShaper = (BlockExpression)Visit(collectionShaperExpression.InnerShaper);
@@ -200,14 +200,14 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     if (projectionExpression is ObjectArrayProjectionExpression objectArrayProjectionExpression)
                     {
                         innerAccessExpression = objectArrayProjectionExpression.AccessExpression;
-                        ProjectionBindings[objectArrayProjectionExpression] = parameterExpression;
+                        _projectionBindings[objectArrayProjectionExpression] = parameterExpression;
                         fieldName ??= objectArrayProjectionExpression.Name;
                     }
                     else
                     {
                         var entityProjectionExpression = (EntityProjectionExpression)projectionExpression;
                         var accessExpression = entityProjectionExpression.ParentAccessExpression;
-                        ProjectionBindings[accessExpression] = parameterExpression;
+                        _projectionBindings[accessExpression] = parameterExpression;
                         fieldName ??= entityProjectionExpression.Name;
 
                         switch (accessExpression)
@@ -340,7 +340,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 var ownership = entityType.FindOwnership();
                 if (ownership?.IsUnique == false && property.IsOwnedTypeOrdinalKey())
                 {
-                    var readExpression = _ordinalParameterBindings[docExpression];
+                    var readExpression = _ordinalMappings[docExpression];
                     if (readExpression.Type != type)
                     {
                         readExpression = Expression.Convert(readExpression, type);
@@ -417,7 +417,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         };
 
         var innerExpression = docExpression;
-        if (ProjectionBindings.TryGetValue(docExpression, out var innerVariable))
+        if (_projectionBindings.TryGetValue(docExpression, out var innerVariable))
         {
             innerExpression = innerVariable;
         }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -54,20 +54,17 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     /// <param name="rootEntityType">The <see cref="IEntityType"/> this projection relates to.</param>
     /// <param name="queryExpression">The <see cref="MongoQueryExpression"/> this visitor should use.</param>
     /// <param name="docParameter">The parameter that will hold the <see cref="BsonDocument"/> input parameter to the shaper.</param>
-    /// <param name="trackQueryResults">
-    /// <see langword="true"/> if the results from this query are being tracked for changes,
-    /// <see langword="false"/> if they are not.
-    /// </param>
+    /// <param name="trackingBehavior">The <see cref="QueryTrackingBehavior"/> for this query.</param>
     public MongoProjectionBindingRemovingExpressionVisitor(
         IEntityType rootEntityType,
         MongoQueryExpression queryExpression,
         ParameterExpression docParameter,
-        bool trackQueryResults)
+        QueryTrackingBehavior trackingBehavior)
     {
         _queryExpression = queryExpression;
         _rootEntityType = rootEntityType;
         DocParameter = docParameter;
-        _trackQueryResults = trackQueryResults;
+        _trackQueryResults = trackingBehavior == QueryTrackingBehavior.TrackAll;
     }
 
     protected override Expression VisitExtension(Expression extensionExpression)

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -26,6 +26,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using MongoDB.Bson;
+using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 using MongoDB.EntityFrameworkCore.Storage;
@@ -75,6 +76,39 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 {
                     var projection = GetProjection(projectionBindingExpression);
 
+                    // Alias is null when the projection's expression has no natural name —
+                    // the BsonDoc itself is the value.
+                    if (projection.Alias is null)
+                    {
+                        return DocParameter;
+                    }
+
+                    // Resolve the source IProperty so we apply its serializer / nullability —
+                    // not whatever EF property happens to share the alias name on the root entity.
+                    var fieldAccess = TryResolveFieldAccess(projection.Expression);
+                    if (fieldAccess.Property != null)
+                    {
+                        return BsonBinding.CreateGetValueExpression(
+                            DocParameter,
+                            projection.Alias,
+                            fieldAccess.Property,
+                            projectionBindingExpression.Type);
+                    }
+
+                    // For genuinely non-property expressions (arithmetic, constants, Mql.Field) the
+                    // push-down result document has the alias as its BSON element name — read it raw.
+                    // When projection.Expression is null (EF key-property binding via BindProperty)
+                    // there is no source expression to inspect; fall through to the property-lookup
+                    // path so the alias is resolved against the declared entity type, which gives us
+                    // the correct BSON element name (e.g. OrderID → _id).
+                    if (projection.Expression != null)
+                    {
+                        return BsonBinding.CreateGetElementValue(
+                            DocParameter,
+                            projection.Alias,
+                            projectionBindingExpression.Type);
+                    }
+
                     return CreateGetValueExpression(
                         DocParameter,
                         projection.Alias,
@@ -104,11 +138,9 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
 
                     var accessExpression = objectArrayProjection.InnerProjection.ParentAccessExpression;
                     _projectionBindings[accessExpression] = jObjectParameter;
-                    _ownerMappings[accessExpression] =
-                        (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
-                    _ordinalMappings[accessExpression] = Expression.Add(
-                        ordinalParameter, Expression.Constant(1, typeof(int)));
-
+                    _ownerMappings[accessExpression] = (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
+                    _ownerMappings[jObjectParameter] = (objectArrayProjection.Navigation.DeclaringEntityType, objectArrayProjection.AccessExpression);
+                    _ordinalMappings[accessExpression] = Expression.Add(ordinalParameter, Expression.Constant(1, typeof(int)));
                     var innerShaper = (BlockExpression)Visit(collectionShaperExpression.InnerShaper);
 
                     innerShaper = AddIncludes(innerShaper);
@@ -201,7 +233,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     {
                         innerAccessExpression = objectArrayProjectionExpression.AccessExpression;
                         _projectionBindings[objectArrayProjectionExpression] = parameterExpression;
-                        fieldName ??= objectArrayProjectionExpression.Name;
+                        fieldName ??= FindProjectionAlias(objectArrayProjectionExpression) ?? objectArrayProjectionExpression.Name;
                     }
                     else
                     {
@@ -214,12 +246,21 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                         {
                             case ObjectAccessExpression innerObjectAccessExpression:
                                 innerAccessExpression = innerObjectAccessExpression.AccessExpression;
-                                _ownerMappings[accessExpression] =
-                                    (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
+                                _ownerMappings[accessExpression] = (innerObjectAccessExpression.Navigation.DeclaringEntityType, innerAccessExpression);
                                 fieldRequired = innerObjectAccessExpression.Required;
                                 break;
                             case RootReferenceExpression:
                                 innerAccessExpression = DocParameter;
+                                if (_ownerMappings.TryGetValue(accessExpression, out var ownerInfo))
+                                {
+                                    _ownerMappings[parameterExpression] = (ownerInfo.EntityType, ownerInfo.BsonDocExpression);
+                                }
+
+                                if (_ordinalMappings.TryGetValue(accessExpression, out var ordinalExpression))
+                                {
+                                    _ordinalMappings[parameterExpression] = ordinalExpression;
+                                }
+
                                 break;
                             default:
                                 throw new InvalidOperationException(
@@ -353,8 +394,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 if (principalProperty != null)
                 {
                     Expression? ownerBsonDocExpression = null;
-                    if (_ownerMappings.TryGetValue(docExpression,
-                            out var ownerInfo))
+                    if (_ownerMappings.TryGetValue(docExpression, out var ownerInfo))
                     {
                         ownerBsonDocExpression = ownerInfo.BsonDocExpression;
                     }
@@ -435,6 +475,107 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         var elementType = typeMapping?.ClrType ?? type;
         return BsonBinding.CreateGetValueExpression(innerExpression, propertyName, required, elementType, entityType);
     }
+
+    protected ResolvedFieldAccess TryResolveFieldAccess(Expression expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        if (expression is MemberExpression memberExpression)
+        {
+            var source = TryResolveFieldAccessSource(memberExpression.Expression);
+            var property = source.EntityType?.FindProperty(memberExpression.Member);
+            return property != null
+                ? new ResolvedFieldAccess(property, source.DocumentExpression, null, memberExpression.Member)
+                : new ResolvedFieldAccess(null, source.DocumentExpression, memberExpression.Member.Name, memberExpression.Member);
+        }
+
+        if (expression is MethodCallExpression methodCall)
+        {
+            if (methodCall.Method.IsEFPropertyMethod()
+                && methodCall.Arguments[1] is ConstantExpression { Value: string propertyName })
+            {
+                var source = TryResolveFieldAccessSource(methodCall.Arguments[0]);
+                var property = source.EntityType?.FindProperty(propertyName);
+                return property != null
+                    ? new ResolvedFieldAccess(property, source.DocumentExpression, null, null)
+                    : new ResolvedFieldAccess(null, source.DocumentExpression, propertyName, null);
+            }
+
+            if (methodCall.Method.IsGenericMethod
+                && methodCall.Method.GetGenericMethodDefinition() == MqlFieldMethodInfo
+                && methodCall.Arguments[1] is ConstantExpression { Value: string fieldName })
+            {
+                var source = TryResolveFieldAccessSource(methodCall.Arguments[0]);
+                return new ResolvedFieldAccess(null, source.DocumentExpression, fieldName, null);
+            }
+        }
+
+        return new ResolvedFieldAccess(null, null, null, null);
+    }
+
+    private (IEntityType? EntityType, Expression? DocumentExpression) TryResolveFieldAccessSource(Expression? expression)
+    {
+        while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+        {
+            expression = unary.Operand;
+        }
+
+        if (expression is EntityTypedExpression entityTypedExpression)
+        {
+            return (entityTypedExpression.EntityType, entityTypedExpression);
+        }
+
+        if (expression is RootReferenceExpression rootReferenceExpression)
+        {
+            return (rootReferenceExpression.EntityType, rootReferenceExpression);
+        }
+
+        if (expression is ObjectAccessExpression objectAccessExpression)
+        {
+            return (objectAccessExpression.Navigation.TargetEntityType, objectAccessExpression);
+        }
+
+        // When a projection lambda does `new { o.Prop }`, EF stores MemberExpr(STS_root, "Prop")
+        // in the projection mapping. Recognise the root entity's shaper here so we can resolve
+        // the property and use its own BSON element name instead of the projected alias.
+        if (expression is StructuralTypeShaperExpression { StructuralType: IEntityType shaperEntityType }
+            && shaperEntityType == _rootEntityType)
+        {
+            return (shaperEntityType, DocParameter);
+        }
+
+        if (expression is ParameterExpression parameterExpression)
+        {
+            var entityType = _rootEntityType.Model.GetEntityTypes()
+                .FirstOrDefault(e => e.ClrType == parameterExpression.Type);
+            if (entityType != null)
+            {
+                return (entityType, parameterExpression);
+            }
+        }
+
+        if (expression != null && _ownerMappings.TryGetValue(expression, out var ownerInfo))
+        {
+            return (ownerInfo.EntityType, ownerInfo.BsonDocExpression);
+        }
+
+        return (null, null);
+    }
+
+    private static readonly MethodInfo MqlFieldMethodInfo =
+        typeof(Mql).GetMethod(nameof(Mql.Field), BindingFlags.Public | BindingFlags.Static)!;
+
+    protected readonly record struct ResolvedFieldAccess(
+        IProperty? Property,
+        Expression? DocumentExpression,
+        string? FieldName,
+        MemberInfo? MemberInfo);
+
+    private string? FindProjectionAlias(Expression expression)
+        => _queryExpression.Projection.FirstOrDefault(p => p.Expression.Equals(expression))?.Alias;
 
     private BlockExpression AddIncludes(BlockExpression shaperBlock)
     {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -119,24 +119,14 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                             : Expression.Convert(valueExpression, projectionBindingExpression.Type);
                     }
 
-                    // For genuinely non-property expressions (arithmetic, constants, Mql.Field) the
-                    // push-down result document has the alias as its BSON element name — read it raw.
-                    // When projection.Expression is null (EF key-property binding via BindProperty)
-                    // there is no source expression to inspect; fall through to the property-lookup
-                    // path so the alias is resolved against the declared entity type, which gives us
-                    // the correct BSON element name (e.g. OrderID → _id).
-                    if (projection.Expression != null)
-                    {
-                        return BsonBinding.CreateGetElementValue(
-                            DocParameter,
-                            projection.Alias,
-                            projectionBindingExpression.Type);
-                    }
-
-                    return CreateGetValueExpression(
+                    // For non-property expressions (arithmetic, constants, Mql.Field) — and for
+                    // key-property bindings — the push-down result document carries the value under
+                    // the projection alias as its BSON element name (e.g. `{ OrderID: "$_id" }`), so
+                    // read it raw by that alias. projection.Expression is non-nullable (see
+                    // ProjectionExpression), so there is no null-source path to handle here.
+                    return BsonBinding.CreateGetElementValue(
                         DocParameter,
                         projection.Alias,
-                        !projectionBindingExpression.Type.IsNullableType(),
                         projectionBindingExpression.Type);
                 }
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -85,9 +85,22 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
 
                     // Resolve the source IProperty so we apply its serializer / nullability —
                     // not whatever EF property happens to share the alias name on the root entity.
+                    // TryResolveFieldAccess unwraps Convert nodes, so in principle the binding's
+                    // outer type could differ from the property's CLR type. In practice it never
+                    // does at this call site: aliased projections that introduce a Convert (e.g.
+                    // `new { X = (long)p.intProp }`) go through the LINQ V3 push-down path and
+                    // never reach this visitor — see ProjectionAnalyzer.CanPushDown. The assert
+                    // below pins the invariant so a future change that violates it fails loudly
+                    // rather than mis-deserialising via the wrong property's serializer.
                     var fieldAccess = TryResolveFieldAccess(projection.Expression);
                     if (fieldAccess.Property != null)
                     {
+                        System.Diagnostics.Debug.Assert(
+                            fieldAccess.Property.ClrType == projectionBindingExpression.Type
+                            || fieldAccess.Property.ClrType == projectionBindingExpression.Type.UnwrapNullableType(),
+                            $"Aliased projection type {projectionBindingExpression.Type} does not match source property '{
+                                fieldAccess.Property.Name}' of type {fieldAccess.Property.ClrType}; the property's serializer "
+                            + "may produce values that cannot be cast to the binding's outer type.");
                         return BsonBinding.CreateGetValueExpression(
                             DocParameter,
                             projection.Alias,
@@ -476,8 +489,10 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         return BsonBinding.CreateGetValueExpression(innerExpression, propertyName, required, elementType, entityType);
     }
 
-    protected ResolvedFieldAccess TryResolveFieldAccess(Expression expression)
+    protected ResolvedFieldAccess TryResolveFieldAccess(Expression? expression)
     {
+        if (expression == null) return default;
+
         while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
         {
             expression = unary.Operand;
@@ -575,7 +590,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         MemberInfo? MemberInfo);
 
     private string? FindProjectionAlias(Expression expression)
-        => _queryExpression.Projection.FirstOrDefault(p => p.Expression.Equals(expression))?.Alias;
+        => _queryExpression.Projection.FirstOrDefault(p => p.Expression != null && p.Expression.Equals(expression))?.Alias;
 
     private BlockExpression AddIncludes(BlockExpression shaperBlock)
     {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -95,12 +95,15 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                     var fieldAccess = TryResolveFieldAccess(projection.Expression);
                     if (fieldAccess.Property != null)
                     {
-                        System.Diagnostics.Debug.Assert(
-                            fieldAccess.Property.ClrType == projectionBindingExpression.Type
-                            || fieldAccess.Property.ClrType == projectionBindingExpression.Type.UnwrapNullableType(),
-                            $"Aliased projection type {projectionBindingExpression.Type} does not match source property '{
-                                fieldAccess.Property.Name}' of type {fieldAccess.Property.ClrType}; the property's serializer "
-                            + "may produce values that cannot be cast to the binding's outer type.");
+                        if (fieldAccess.Property.ClrType != projectionBindingExpression.Type
+                            && fieldAccess.Property.ClrType != projectionBindingExpression.Type.UnwrapNullableType())
+                        {
+                            throw new InvalidOperationException(
+                                $"Aliased projection type '{projectionBindingExpression.Type}' does not match source property " +
+                                $"'{fieldAccess.Property.Name}' of type '{fieldAccess.Property.ClrType}'; the property's serializer " +
+                                "may produce values that cannot be cast to the binding's outer type.");
+                        }
+
                         return BsonBinding.CreateGetValueExpression(
                             DocParameter,
                             projection.Alias,
@@ -581,7 +584,8 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     }
 
     private static readonly MethodInfo MqlFieldMethodInfo =
-        typeof(Mql).GetMethod(nameof(Mql.Field), BindingFlags.Public | BindingFlags.Static)!;
+        typeof(Mql).GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == nameof(Mql.Field) && m.GetParameters().Length == 3);
 
     protected readonly record struct ResolvedFieldAccess(
         IProperty? Property,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -104,11 +104,19 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                                 "may produce values that cannot be cast to the binding's outer type.");
                         }
 
-                        return BsonBinding.CreateGetValueExpression(
+                        var valueExpression = BsonBinding.CreateGetValueExpression(
                             DocParameter,
                             projection.Alias,
                             fieldAccess.Property,
                             projectionBindingExpression.Type);
+
+                        // The read expression's type is the property's CLR type widened to nullable when
+                        // the property is nullable; the assert above permits the binding type to be the
+                        // non-nullable form, so convert to the exact binding type to keep the shaper's
+                        // expression tree well-typed.
+                        return valueExpression.Type == projectionBindingExpression.Type
+                            ? valueExpression
+                            : Expression.Convert(valueExpression, projectionBindingExpression.Type);
                     }
 
                     // For genuinely non-property expressions (arithmetic, constants, Mql.Field) the

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -77,8 +77,8 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
 
         // Entity path: full BsonDocuments shaped into tracked/untracked entity instances
         return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
-            (bsonDoc, track) => new MongoProjectionBindingRemovingExpressionVisitor(
-                rootEntityType, mongoQueryExpression, bsonDoc, track));
+            (bsonDoc, behavior) => new MongoProjectionBindingRemovingExpressionVisitor(
+                rootEntityType, mongoQueryExpression, bsonDoc, behavior));
     }
 
     private MethodCallExpression VisitProjectedQuery(
@@ -112,18 +112,18 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         }
 
         return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
-            (bsonDoc, track) => new MongoMixedProjectionBindingRemovingExpressionVisitor(
-                rootEntityType, mongoQueryExpression, bsonDoc, track));
+            (bsonDoc, behavior) => new MongoMixedProjectionBindingRemovingExpressionVisitor(
+                rootEntityType, mongoQueryExpression, bsonDoc, behavior));
     }
 
     private MethodCallExpression CompileShapedQuery(
         ShapedQueryExpression shapedQueryExpression,
         MongoQueryExpression mongoQueryExpression,
         IEntityType rootEntityType,
-        Func<ParameterExpression, bool, System.Linq.Expressions.ExpressionVisitor> createBindingRemover)
+        Func<ParameterExpression, QueryTrackingBehavior, System.Linq.Expressions.ExpressionVisitor> createBindingRemover)
     {
         var bsonDocParameter = Expression.Parameter(typeof(BsonDocument), "bsonDoc");
-        var trackQueryResults = QueryCompilationContext.QueryTrackingBehavior == QueryTrackingBehavior.TrackAll;
+        var trackingBehavior = QueryCompilationContext.QueryTrackingBehavior;
 
         var shaperBody = shapedQueryExpression.ShaperExpression;
         shaperBody = new BsonDocumentInjectingExpressionVisitor().Visit(shaperBody);
@@ -132,7 +132,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
 #else
         shaperBody = InjectStructuralTypeMaterializers(shaperBody);
 #endif
-        shaperBody = createBindingRemover(bsonDocParameter, trackQueryResults).Visit(shaperBody);
+        shaperBody = createBindingRemover(bsonDocParameter, trackingBehavior).Visit(shaperBody);
 
         var shaperLambda = Expression.Lambda(
             shaperBody,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -104,12 +104,11 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
         }
 
         // Mixed path: projection contains entity references that LINQ V3 can't handle.
-        // Strip the Select, return full BsonDocuments, and build a client-side shaper.
-        if (mongoQueryExpression.CapturedExpression is MethodCallExpression
-                { Method: { Name: "Select", DeclaringType.Name: "Queryable" } } selectCall)
-        {
-            mongoQueryExpression.CapturedExpression = selectCall.Arguments[0];
-        }
+        // Strip the Select so the driver returns full BsonDocuments keyed by EF-configured
+        // element names; the client-side shaper handles the projection. The Select may sit
+        // directly on the captured expression, or under a no-arg cardinality terminator
+        // (Single/First/etc.) which we also need to rebind to the un-projected source type.
+        mongoQueryExpression.CapturedExpression = StripPushedDownSelect(mongoQueryExpression.CapturedExpression);
 
         return CompileShapedQuery(shapedQueryExpression, mongoQueryExpression, rootEntityType,
             (bsonDoc, behavior) => new MongoMixedProjectionBindingRemovingExpressionVisitor(
@@ -155,6 +154,35 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             Expression.Constant(standAloneStateManager),
             Expression.Constant(_threadSafetyChecksEnabled),
             Expression.Constant(shapedQueryExpression.ResultCardinality));
+    }
+
+    private static Expression? StripPushedDownSelect(Expression? captured)
+    {
+        if (captured is not MethodCallExpression call || call.Method.DeclaringType != typeof(Queryable))
+        {
+            return captured;
+        }
+
+        if (call.Method.Name == nameof(Queryable.Select) && call.Arguments.Count == 2)
+        {
+            return call.Arguments[0];
+        }
+
+        if (call.Method.IsGenericMethod
+            && call.Method.GetParameters().Length == 1
+            && call.Method.Name is nameof(Queryable.Single) or nameof(Queryable.SingleOrDefault)
+                or nameof(Queryable.First) or nameof(Queryable.FirstOrDefault)
+                or nameof(Queryable.Last) or nameof(Queryable.LastOrDefault)
+            && call.Arguments is [MethodCallExpression { Method: { Name: nameof(Queryable.Select), DeclaringType: var st } } innerSelect]
+            && st == typeof(Queryable))
+        {
+            var newSource = innerSelect.Arguments[0];
+            var newSourceType = newSource.Type.GetGenericArguments()[0];
+            var rebound = call.Method.GetGenericMethodDefinition().MakeGenericMethod(newSourceType);
+            return Expression.Call(rebound, newSource);
+        }
+
+        return captured;
     }
 
     private static (MongoQueryContext, MongoExecutableQuery) TranslateQuery<TSource>(

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -86,6 +86,43 @@ internal static class BsonBinding
         throw new InvalidOperationException(CoreStrings.PropertyNotFound(name, declaredType.DisplayName()));
     }
 
+    /// <summary>
+    /// Create the expression which will obtain a projected element using the serializer metadata
+    /// from the source property rather than resolving metadata from the projected alias.
+    /// </summary>
+    /// <param name="bsonDocExpression">The expression to obtain the current <see cref="BsonDocument"/>.</param>
+    /// <param name="name">The projected element name in the current document.</param>
+    /// <param name="property">The source model property that defines serializer/nullability metadata.</param>
+    /// <param name="mappedType">What <see cref="Type"/> the value is to be treated as.</param>
+    /// <returns>A compilable expression the shaper can use to obtain this value.</returns>
+    public static Expression CreateGetValueExpression(
+        Expression bsonDocExpression,
+        string? name,
+        IProperty property,
+        Type mappedType)
+    {
+        if (name is null)
+        {
+            return bsonDocExpression;
+        }
+
+        if (mappedType == typeof(BsonArray))
+        {
+            return CreateGetBsonArray(bsonDocExpression, name);
+        }
+
+        if (mappedType == typeof(BsonDocument))
+        {
+            return CreateGetBsonDocument(bsonDocExpression, name, !property.IsNullable, property.DeclaringType);
+        }
+
+        return CreateGetPropertyValueAtElement(
+            bsonDocExpression,
+            Expression.Constant(name),
+            Expression.Constant(property),
+            property.IsNullable ? mappedType.MakeNullable() : mappedType);
+    }
+
     private static MethodCallExpression CreateGetBsonArray(Expression bsonDocExpression, string name)
         => Expression.Call(null, GetBsonArrayMethodInfo, bsonDocExpression, Expression.Constant(name));
 
@@ -132,12 +169,28 @@ internal static class BsonBinding
         CreateGetPropertyValue(Expression bsonDocExpression, Expression propertyExpression, Type resultType) =>
         Expression.Call(null, GetPropertyValueMethodInfo.MakeGenericMethod(resultType), bsonDocExpression, propertyExpression);
 
+    private static MethodCallExpression CreateGetPropertyValueAtElement(
+        Expression bsonDocExpression,
+        Expression elementNameExpression,
+        Expression propertyExpression,
+        Type resultType)
+        => Expression.Call(
+            null,
+            GetPropertyValueAtElementMethodInfo.MakeGenericMethod(resultType),
+            bsonDocExpression,
+            elementNameExpression,
+            propertyExpression);
+
     internal static MethodCallExpression CreateGetElementValue(Expression bsonDocExpression, string name, Type type) =>
         Expression.Call(null, GetElementValueMethodInfo.MakeGenericMethod(type), bsonDocExpression, Expression.Constant(name));
 
     private static readonly MethodInfo GetPropertyValueMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
             .Single(mi => mi.Name == nameof(GetPropertyValue));
+
+    private static readonly MethodInfo GetPropertyValueAtElementMethodInfo
+        = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+            .Single(mi => mi.Name == nameof(GetPropertyValueAtElement));
 
     private static readonly MethodInfo GetElementValueMethodInfo
         = typeof(BsonBinding).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
@@ -160,6 +213,31 @@ internal static class BsonBinding
         if (property.IsNullable) return default;
 
         throw new InvalidOperationException($"Document element is missing for required non-nullable property '{property.Name}'.");
+    }
+
+    internal static T? GetPropertyValueAtElement<T>(BsonDocument document, string elementName, IReadOnlyProperty property)
+    {
+        var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+        var projectedSerializationInfo = new BsonSerializationInfo(
+            elementName,
+            serializationInfo.Serializer,
+            serializationInfo.NominalType);
+
+        if (TryReadElementValue(document, projectedSerializationInfo, out T? value))
+        {
+            if (value == null && !property.IsNullable)
+            {
+                throw new InvalidOperationException($"Document element is null for required non-nullable property '{property.Name
+                }'.");
+            }
+
+            return value;
+        }
+
+        if (property.IsNullable) return default;
+
+        throw new InvalidOperationException($"Document element '{elementName}' is missing for required non-nullable property '{
+            property.Name}'.");
     }
 
     internal static T? GetElementValue<T>(BsonDocument document, string elementName)

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -223,6 +223,11 @@ internal static class BsonBinding
     internal static T? GetPropertyValueAtElement<T>(BsonDocument document, string elementName, IReadOnlyProperty property)
     {
         var serializationInfo = BsonSerializerFactory.GetPropertySerializationInfo(property);
+
+        // Intentionally drop any ElementPath from the source serialization info: in a projection the
+        // value lives at the flat alias name in the projected document, not at the property's original
+        // (possibly nested, e.g. ["_id", name] for a composite key) path. Re-introducing the path here
+        // would break aliased projections of composite-key parts.
         var projectedSerializationInfo = new BsonSerializationInfo(
             elementName,
             serializationInfo.Serializer,

--- a/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/BsonBinding.cs
@@ -94,6 +94,12 @@ internal static class BsonBinding
     /// <param name="name">The projected element name in the current document.</param>
     /// <param name="property">The source model property that defines serializer/nullability metadata.</param>
     /// <param name="mappedType">What <see cref="Type"/> the value is to be treated as.</param>
+    /// <remarks>
+    /// Callers must ensure <paramref name="mappedType"/> matches <paramref name="property"/>'s CLR
+    /// type (modulo nullability). The generated call casts the deserialized value to
+    /// <paramref name="mappedType"/>; if it differs from the property's CLR type the cast can
+    /// throw because the property's serializer produces values of its own type.
+    /// </remarks>
     /// <returns>A compilable expression the shaper can use to obtain this value.</returns>
     public static Expression CreateGetValueExpression(
         Expression bsonDocExpression,
@@ -203,8 +209,7 @@ internal static class BsonBinding
         {
             if (value == null && !property.IsNullable)
             {
-                throw new InvalidOperationException($"Document element is null for required non-nullable property '{property.Name
-                }'.");
+                throw new InvalidOperationException($"Document element is null for required non-nullable property '{property.Name}'.");
             }
 
             return value;
@@ -227,8 +232,7 @@ internal static class BsonBinding
         {
             if (value == null && !property.IsNullable)
             {
-                throw new InvalidOperationException($"Document element is null for required non-nullable property '{property.Name
-                }'.");
+                throw new InvalidOperationException($"Document element is null for required non-nullable property '{property.Name}'.");
             }
 
             return value;
@@ -236,8 +240,7 @@ internal static class BsonBinding
 
         if (property.IsNullable) return default;
 
-        throw new InvalidOperationException($"Document element '{elementName}' is missing for required non-nullable property '{
-            property.Name}'.");
+        throw new InvalidOperationException($"Document element '{elementName}' is missing for required non-nullable property '{property.Name}'.");
     }
 
     internal static T? GetElementValue<T>(BsonDocument document, string elementName)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -414,6 +414,108 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         }
     }
 
+    [Fact]
+    public void OwnedEntity_projection_alias_with_bson_representation_uses_owned_property_serializer()
+    {
+        var collection = database.CreateCollection<PersonWithLocation>();
+
+        var id = ObjectId.GenerateNewId();
+        var expectedLocation = new Location { latitude = 1.234m, longitude = 1.567m };
+
+        var modelBuilder = (ModelBuilder mb) =>
+        {
+            mb.Entity<PersonWithLocation>(p =>
+            {
+                p.OwnsOne(e => e.location, f =>
+                {
+                    f.HasElementName("Location");
+                    f.Property(g => g.longitude)
+                        .HasElementName("Longitude")
+                        .HasBsonRepresentation(BsonType.String);
+                });
+            });
+        };
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            dbContext.Entities.Add(new PersonWithLocation
+            {
+                _id = id,
+                name = Guid.NewGuid().ToString(),
+                location = expectedLocation
+            });
+            dbContext.SaveChanges();
+        }
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            var found = dbContext.Entities.AsNoTracking()
+                .Where(e => e._id == id)
+                .Select(e => new { Alias = e.location.longitude })
+                .Single();
+
+            Assert.Equal(expectedLocation.longitude, found.Alias);
+        }
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_projection_alias_with_bson_representation_uses_owned_property_serializer()
+    {
+        var collection = database.CreateCollection<PersonWithMultipleLocations>();
+
+        var id = ObjectId.GenerateNewId();
+        var expectedLocations = new[]
+        {
+            new Location { latitude = 1.234m, longitude = 1.567m },
+            new Location { latitude = 2.345m, longitude = 2.678m }
+        };
+
+        var modelBuilder = (ModelBuilder mb) =>
+        {
+            mb.Entity<PersonWithMultipleLocations>(p =>
+            {
+                p.OwnsMany(e => e.locations, f =>
+                {
+                    f.HasElementName("Locations");
+                    f.Property(g => g.longitude)
+                        .HasElementName("Longitude")
+                        .HasBsonRepresentation(BsonType.String);
+                });
+            });
+        };
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            dbContext.Entities.Add(new PersonWithMultipleLocations
+            {
+                _id = id,
+                name = "A",
+                locations = [.. expectedLocations]
+            });
+            dbContext.SaveChanges();
+        }
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            var actual = dbContext.Entities
+                .AsNoTracking()
+                .Where(e => e._id == id)
+                .Select(e => new
+                {
+                    e.name,
+                    e.locations,
+                    Longitudes = e.locations
+                        .Select(l => new { Alias = l.longitude })
+                        .ToList()
+                })
+                .Single();
+
+            Assert.Equal("A", actual.name);
+            Assert.Equal(expectedLocations.Length, actual.locations.Count);
+            Assert.Equal(expectedLocations.Select(l => l.longitude), actual.Longitudes.Select(l => l.Alias));
+        }
+    }
+
     class SimpleNonNullableCollection
     {
         public ObjectId _id { get; set; }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -536,6 +536,63 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
             mb.Entity<PlanetWithLongOrder>().Property(e => e.orderFromSun).HasConversion<int>());
     }
 
+    private class PlanetWithStringOrder
+    {
+        public ObjectId _id { get; set; }
+        public string name { get; set; } = null!;
+        public int orderFromSun { get; set; }
+    }
+
+    private SingleEntityDbContext<PlanetWithStringOrder> CreateStringOrderContext(string collectionName)
+    {
+        database.MongoDatabase.CreateCollection(collectionName);
+        var collection = database.MongoDatabase.GetCollection<PlanetWithStringOrder>(collectionName);
+        var configureModel = (ModelBuilder mb) =>
+        {
+            mb.Entity<PlanetWithStringOrder>().Property(e => e.orderFromSun).HasBsonRepresentation(BsonType.String);
+        };
+
+        using (var db = SingleEntityDbContext.Create(collection, configureModel))
+        {
+            db.Entities.AddRange(
+                new PlanetWithStringOrder { _id = ObjectId.GenerateNewId(), name = "Mercury", orderFromSun = 1 },
+                new PlanetWithStringOrder { _id = ObjectId.GenerateNewId(), name = "Venus", orderFromSun = 2 });
+            db.SaveChanges();
+        }
+
+        return SingleEntityDbContext.Create(collection, configureModel);
+    }
+
+    [Fact]
+    public void Select_projection_alias_with_bson_representation_uses_source_property_serializer()
+    {
+        using var db = CreateStringOrderContext(
+            nameof(Select_projection_alias_with_bson_representation_uses_source_property_serializer));
+        var results = db.Entities
+            .OrderBy(p => p.orderFromSun)
+            .Select(p => new { Position = p.orderFromSun })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results[0].Position);
+        Assert.Equal(2, results[1].Position);
+    }
+
+    [Fact]
+    public void Select_projection_alias_with_bson_representation_ef_property_uses_source_property_serializer()
+    {
+        using var db = CreateStringOrderContext(
+            nameof(Select_projection_alias_with_bson_representation_ef_property_uses_source_property_serializer));
+        var results = db.Entities
+            .OrderBy(p => p.orderFromSun)
+            .Select(p => new { Position = EF.Property<int>(p, nameof(PlanetWithStringOrder.orderFromSun)) })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results[0].Position);
+        Assert.Equal(2, results[1].Position);
+    }
+
     [Fact]
     public void Sum_with_value_converter()
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -594,6 +594,49 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
     }
 
     [Fact]
+    public void Select_projection_alias_with_bson_representation_widening_cast()
+    {
+        using var db = CreateStringOrderContext(
+            nameof(Select_projection_alias_with_bson_representation_widening_cast));
+        var results = db.Entities
+            .OrderBy(p => p.orderFromSun)
+            .Select(p => new { Position = (long)p.orderFromSun })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1L, results[0].Position);
+        Assert.Equal(2L, results[1].Position);
+    }
+
+    [Fact]
+    public void Select_projection_alias_with_bson_representation_nullable_lift()
+    {
+        using var db = CreateStringOrderContext(
+            nameof(Select_projection_alias_with_bson_representation_nullable_lift));
+        var results = db.Entities
+            .OrderBy(p => p.orderFromSun)
+            .Select(p => new { Position = (int?)p.orderFromSun })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(1, results[0].Position);
+        Assert.Equal(2, results[1].Position);
+    }
+
+    [Fact]
+    public void Select_projection_alias_with_value_converter_cast_throws()
+    {
+        // Driver's NumericConversionSerializer requires IHasRepresentationSerializer, which
+        // ValueConverterSerializer does not implement — so widening/narrowing casts on a
+        // value-converted property fail at LINQ translation time. Documents the limitation.
+        using var db = CreateLongOrderContext();
+        Assert.ThrowsAny<Exception>(
+            () => db.Entities.Select(p => new { Position = (decimal)p.orderFromSun }).ToList());
+        Assert.ThrowsAny<Exception>(
+            () => db.Entities.Select(p => new { Position = (int)p.orderFromSun }).ToList());
+    }
+
+    [Fact]
     public void Sum_with_value_converter()
     {
         using var db = CreateLongOrderContext();

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SharedClrTypeProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SharedClrTypeProjectionTests.cs
@@ -1,0 +1,277 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// Proves the behaviour of aliased scalar projections when two owned entity types share the
+/// same CLR type but map a property to a different BsonRepresentation. The collection-projection
+/// inner-lambda parameter (<c>e.coll.Select(l =&gt; l.prop)</c>) resolves through the
+/// <c>ParameterExpression</c> branch in <c>TryResolveFieldAccessSource</c>, which must resolve the
+/// owned entity type that actually owns the projected element — not an arbitrary same-CLR-type one.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class SharedClrTypeProjectionTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private record GeoPoint
+    {
+        public decimal lat { get; set; }
+        public decimal lng { get; set; }
+    }
+
+    private record MultiSameTypeOwner
+    {
+        public ObjectId _id { get; set; }
+        public string name { get; set; } = null!;
+
+        // Two owned collections of the SAME CLR type, but `lng` is stored with a different
+        // BsonRepresentation in each: primary as a string, secondary as the default decimal.
+        public List<GeoPoint> primary { get; set; } = null!;
+        public List<GeoPoint> secondary { get; set; } = null!;
+    }
+
+    private static readonly Action<ModelBuilder> ConfigureModel = mb =>
+    {
+        mb.Entity<MultiSameTypeOwner>(b =>
+        {
+            // Configured first → first in Model.GetEntityTypes() for CLR type GeoPoint.
+            b.OwnsMany(e => e.primary, o =>
+            {
+                o.HasElementName("primary");
+                o.Property(p => p.lng).HasElementName("lng").HasBsonRepresentation(BsonType.String);
+            });
+            // Configured second → the projected value below comes from here.
+            b.OwnsMany(e => e.secondary, o =>
+            {
+                o.HasElementName("secondary");
+                o.Property(p => p.lng).HasElementName("lng"); // default (decimal128)
+            });
+        });
+    };
+
+    private (ObjectId Id, string Collection) Seed()
+    {
+        var collectionName = nameof(SharedClrTypeProjectionTests) + Guid.NewGuid().ToString("N");
+        var collection = database.MongoDatabase.GetCollection<MultiSameTypeOwner>(collectionName);
+        var id = ObjectId.GenerateNewId();
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+        db.Entities.Add(new MultiSameTypeOwner
+        {
+            _id = id,
+            name = "X",
+            primary = [new GeoPoint { lat = 1.1m, lng = 10.5m }],
+            secondary = [new GeoPoint { lat = 2.2m, lng = 20.5m }]
+        });
+        db.SaveChanges();
+        return (id, collectionName);
+    }
+
+    [Fact]
+    public void Collection_alias_projection_from_secondary_uses_its_own_serializer_member_access()
+    {
+        var (id, collectionName) = Seed();
+        var collection = database.MongoDatabase.GetCollection<MultiSameTypeOwner>(collectionName);
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+
+        var found = db.Entities.AsNoTracking()
+            .Where(e => e._id == id)
+            .Select(e => new
+            {
+                e.secondary,
+                Lngs = e.secondary.Select(l => new { Alias = l.lng }).ToList()
+            })
+            .Single();
+
+        Assert.Equal(20.5m, found.Lngs.Single().Alias);
+    }
+
+    [Fact]
+    public void Collection_alias_projection_from_secondary_uses_its_own_serializer_bare_scalar()
+    {
+        var (id, collectionName) = Seed();
+        var collection = database.MongoDatabase.GetCollection<MultiSameTypeOwner>(collectionName);
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+
+        var found = db.Entities.AsNoTracking()
+            .Where(e => e._id == id)
+            .Select(e => new
+            {
+                e.secondary,
+                Lngs = e.secondary.Select(l => l.lng).ToList()
+            })
+            .Single();
+
+        Assert.Equal(20.5m, found.Lngs.Single());
+    }
+
+    private record SingleOwner
+    {
+        public ObjectId _id { get; set; }
+        public List<GeoPoint> points { get; set; } = null!;
+    }
+
+    // Control: nested EF.Property inside a collection Select is an unrelated, pre-existing
+    // translation limitation (crashes in MongoProjectionBindingExpressionVisitor) — it has
+    // nothing to do with shared CLR types. This documents that the EF.Property crash is not
+    // the shared-CLR-type serializer concern.
+    [Fact]
+    public void Control_nested_ef_property_in_collection_select_is_unsupported_even_single_owned()
+    {
+        var collectionName = nameof(Control_nested_ef_property_in_collection_select_is_unsupported_even_single_owned)
+            + Guid.NewGuid().ToString("N");
+        var collection = database.MongoDatabase.GetCollection<SingleOwner>(collectionName);
+        var id = ObjectId.GenerateNewId();
+        Action<ModelBuilder> configure = mb =>
+            mb.Entity<SingleOwner>().OwnsMany(e => e.points, o => o.Property(p => p.lng).HasElementName("lng"));
+
+        using (var db = SingleEntityDbContext.Create(collection, configure))
+        {
+            db.Entities.Add(new SingleOwner { _id = id, points = [new GeoPoint { lat = 1m, lng = 2m }] });
+            db.SaveChanges();
+        }
+
+        using var db2 = SingleEntityDbContext.Create(collection, configure);
+        Assert.ThrowsAny<Exception>(() => db2.Entities.AsNoTracking()
+            .Where(e => e._id == id)
+            .Select(e => new { e.points, Lngs = e.points.Select(l => new { Alias = EF.Property<decimal>(l, "lng") }).ToList() })
+            .Single());
+    }
+
+    [Fact]
+    public void Collection_alias_projection_from_primary_uses_its_own_serializer_member_access()
+    {
+        var (id, collectionName) = Seed();
+        var collection = database.MongoDatabase.GetCollection<MultiSameTypeOwner>(collectionName);
+        using var db = SingleEntityDbContext.Create(collection, ConfigureModel);
+
+        var found = db.Entities.AsNoTracking()
+            .Where(e => e._id == id)
+            .Select(e => new
+            {
+                e.primary,
+                Lngs = e.primary.Select(l => new { Alias = l.lng }).ToList()
+            })
+            .Single();
+
+        Assert.Equal(10.5m, found.Lngs.Single().Alias);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Top-level shared-type entities: two DbSets of the SAME CLR type, each mapping `lng` to a
+    // different BsonRepresentation. Routes through the base (non-mixed) projection visitor, which
+    // resolves the source entity type via TryResolveFieldAccessSource — including the loose
+    // FirstOrDefault(e => e.ClrType == parameterExpression.Type) branch.
+    // ---------------------------------------------------------------------------------------
+
+    private record SharedDoc
+    {
+        public ObjectId _id { get; set; }
+        public decimal lng { get; set; }
+    }
+
+    private class TwoSetContext(IMongoClient client, string dbName, string collA, string collB) : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseMongoDB(client, dbName)
+                .ConfigureWarnings(w =>
+                    w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        protected override void OnModelCreating(ModelBuilder mb)
+        {
+            // "A" registered first → stored as STRING. Element name shared ("lng") to isolate serializer.
+            mb.SharedTypeEntity<SharedDoc>("A", b =>
+            {
+                b.ToCollection(collA);
+                b.Property(p => p.lng).HasElementName("lng").HasBsonRepresentation(BsonType.String);
+            });
+            // "B" registered second → stored as default decimal128.
+            mb.SharedTypeEntity<SharedDoc>("B", b =>
+            {
+                b.ToCollection(collB);
+                b.Property(p => p.lng).HasElementName("lng");
+            });
+        }
+
+        public IQueryable<SharedDoc> A => Set<SharedDoc>("A");
+        public IQueryable<SharedDoc> B => Set<SharedDoc>("B");
+        public void AddToB(SharedDoc d) => Set<SharedDoc>("B").Add(d);
+        public void AddToA(SharedDoc d) => Set<SharedDoc>("A").Add(d);
+    }
+
+    private (ObjectId Id, string CollA, string CollB) SeedTwoSets()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var collA = "SharedA" + suffix;
+        var collB = "SharedB" + suffix;
+        var client = database.MongoDatabase.Client;
+        var dbName = database.MongoDatabase.DatabaseNamespace.DatabaseName;
+        var id = ObjectId.GenerateNewId();
+        using var db = new TwoSetContext(client, dbName, collA, collB);
+        db.AddToA(new SharedDoc { _id = ObjectId.GenerateNewId(), lng = 10.5m });
+        db.AddToB(new SharedDoc { _id = id, lng = 20.5m });
+        db.SaveChanges();
+        return (id, collA, collB);
+    }
+
+    [Fact]
+    public void TopLevel_shared_type_alias_projection_from_B_member_access()
+    {
+        var (id, collA, collB) = SeedTwoSets();
+        using var db = new TwoSetContext(database.MongoDatabase.Client,
+            database.MongoDatabase.DatabaseNamespace.DatabaseName, collA, collB);
+
+        var found = db.B.AsNoTracking().Where(e => e._id == id)
+            .Select(e => new { Alias = e.lng })
+            .Single();
+
+        Assert.Equal(20.5m, found.Alias);
+    }
+
+    [Fact]
+    public void TopLevel_shared_type_alias_projection_from_B_ef_property()
+    {
+        var (id, collA, collB) = SeedTwoSets();
+        using var db = new TwoSetContext(database.MongoDatabase.Client,
+            database.MongoDatabase.DatabaseNamespace.DatabaseName, collA, collB);
+
+        var found = db.B.AsNoTracking().Where(e => e._id == id)
+            .Select(e => new { Alias = EF.Property<decimal>(e, "lng") })
+            .Single();
+
+        Assert.Equal(20.5m, found.Alias);
+    }
+
+    [Fact]
+    public void TopLevel_shared_type_mixed_projection_from_B_ef_property()
+    {
+        var (id, collA, collB) = SeedTwoSets();
+        using var db = new TwoSetContext(database.MongoDatabase.Client,
+            database.MongoDatabase.DatabaseNamespace.DatabaseName, collA, collB);
+
+        var found = db.B.AsNoTracking().Where(e => e._id == id)
+            .Select(e => new { Entity = e, Alias = EF.Property<decimal>(e, "lng") })
+            .Single();
+
+        Assert.Equal(20.5m, found.Alias);
+        Assert.Equal(20.5m, found.Entity.lng);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -2445,139 +2445,51 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
     }
 
     public override async Task Select_expression_long_to_string(bool async)
-    {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_long_to_string(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Select_expression_long_to_string(async);
 
     public override async Task Select_expression_int_to_string(bool async)
-    {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_int_to_string(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Select_expression_int_to_string(async);
 
     public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool async)
     {
-        // Fails: Client eval in final projection EF-250
         Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            "Expression not supported: o.OrderID.ToString(",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
                 base.ToString_with_formatter_is_evaluated_on_the_client(async))).Message);
-
-        AssertMql(
-        );
     }
 
     public override async Task Select_expression_other_to_string(bool async)
-    {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "The property 'Order.ShipName' could not be found.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.Select_expression_other_to_string(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Select_expression_other_to_string(async);
 
     public override async Task Select_expression_date_add_year(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_year(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_date_add_year(async));
 
     public override async Task Select_expression_datetime_add_month(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_month(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_month(async));
 
     public override async Task Select_expression_datetime_add_hour(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_hour(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_hour(async));
 
     public override async Task Select_expression_datetime_add_minute(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_minute(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_minute(async));
 
     public override async Task Select_expression_datetime_add_second(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_second(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_second(async));
 
     public override async Task Select_expression_date_add_milliseconds_above_the_range(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_above_the_range(async)))
-            .Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+            () => base.Select_expression_date_add_milliseconds_above_the_range(async));
 
     public override async Task Select_expression_date_add_milliseconds_below_the_range(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_date_add_milliseconds_below_the_range(async)))
-            .Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+            () => base.Select_expression_date_add_milliseconds_below_the_range(async));
 
     public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
     {
-        // Fails: Unsupported by driver
         Assert.Contains(
-            "Rewriting child expression",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            "Cannot deserialize a 'Int32' from BsonType 'DateTime'",
+            (await Assert.ThrowsAsync<FormatException>(() =>
                 base.Select_expression_date_add_milliseconds_large_number_divided(async))).Message);
-
-        AssertMql(
-        );
     }
 
     public override async Task Add_minutes_on_constant_value(bool async)
@@ -3524,16 +3436,7 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
     }
 
     public override async Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
-    {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws
-        Assert.Contains(
-            "Rewriting child expression",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                base.Convert_to_nullable_on_nullable_value_is_ignored(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Convert_to_nullable_on_nullable_value_is_ignored(async);
 
     public override async Task Navigation_inside_interpolated_string_is_expanded(bool async)
     {
@@ -4280,15 +4183,7 @@ Customers.
     }
 
     public override async Task Select_expression_datetime_add_ticks(bool async)
-    {
-        // Fails: Unsupported by driver
-        Assert.Contains(
-            "DateTime",
-            (await Assert.ThrowsAsync<ArgumentException>(() => base.Select_expression_datetime_add_ticks(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_ticks(async));
 
     public override async Task Where_subquery_expression_same_parametername(bool async)
     {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -3566,16 +3566,7 @@ Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "Orde
     }
 
     public override async Task Convert_to_nullable_on_nullable_value_is_ignored(bool async)
-    {
-        // Fails: Not throwing expected translation failed exception from EF, but still throws EF-X002
-        Assert.Contains(
-            "Rewriting child expression",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                base.Convert_to_nullable_on_nullable_value_is_ignored(async))).Message);
-
-        AssertMql(
-        );
-    }
+        => await base.Convert_to_nullable_on_nullable_value_is_ignored(async);
 
     public override async Task Navigation_inside_interpolated_string_is_expanded(bool async)
     {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -2461,28 +2461,52 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
     public override async Task Select_expression_other_to_string(bool async)
         => await base.Select_expression_other_to_string(async);
 
+    // The driver translates DateAdd/Sub but the resulting Bson DateTime loses the .NET
+    // DateTimeKind (returned as UTC) so the base test's exact-value comparison fails. The
+    // assertions below pin the failure type and a stable message portion so unrelated
+    // regressions surface as a different exception rather than silently passing.
+
     public override async Task Select_expression_date_add_year(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_date_add_year(async));
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_date_add_year(async))).Message);
 
     public override async Task Select_expression_datetime_add_month(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_month(async));
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_datetime_add_month(async))).Message);
 
     public override async Task Select_expression_datetime_add_hour(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_hour(async));
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_datetime_add_hour(async))).Message);
 
     public override async Task Select_expression_datetime_add_minute(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_minute(async));
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_datetime_add_minute(async))).Message);
 
     public override async Task Select_expression_datetime_add_second(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_second(async));
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_datetime_add_second(async))).Message);
 
     public override async Task Select_expression_date_add_milliseconds_above_the_range(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
-            () => base.Select_expression_date_add_milliseconds_above_the_range(async));
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_date_add_milliseconds_above_the_range(async))).Message);
 
     public override async Task Select_expression_date_add_milliseconds_below_the_range(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
-            () => base.Select_expression_date_add_milliseconds_below_the_range(async));
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_date_add_milliseconds_below_the_range(async))).Message);
 
     public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
     {
@@ -4183,7 +4207,12 @@ Customers.
     }
 
     public override async Task Select_expression_datetime_add_ticks(bool async)
-        => await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(() => base.Select_expression_datetime_add_ticks(async));
+        // Same root cause as the DateAdd family above: driver translates the arithmetic but the
+        // result's DateTimeKind round-trips as UTC, failing the base test's exact equality.
+        => Assert.Contains(
+            "Assert.Equal() Failure",
+            (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
+                () => base.Select_expression_datetime_add_ticks(async))).Message);
 
     public override async Task Where_subquery_expression_same_parametername(bool async)
     {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -2479,46 +2479,95 @@ Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "Ship
     // regressions surface as a different exception rather than silently passing.
 
     public override async Task Select_expression_date_add_year(bool async)
-        => Assert.Contains(
+    {
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_date_add_year(async))).Message);
 
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "year", "amount" : 1 } }, "_id" : 0 } }
+""");
+    }
+
     public override async Task Select_expression_datetime_add_month(bool async)
-        => Assert.Contains(
+    {
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_datetime_add_month(async))).Message);
 
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "month", "amount" : 1 } }, "_id" : 0 } }
+""");
+    }
+
     public override async Task Select_expression_datetime_add_hour(bool async)
-        => Assert.Contains(
+    {
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_datetime_add_hour(async))).Message);
 
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "hour", "amount" : 1.0 } }, "_id" : 0 } }
+""");
+    }
+
     public override async Task Select_expression_datetime_add_minute(bool async)
-        => Assert.Contains(
+    {
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_datetime_add_minute(async))).Message);
 
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "minute", "amount" : 1.0 } }, "_id" : 0 } }
+""");
+    }
+
     public override async Task Select_expression_datetime_add_second(bool async)
-        => Assert.Contains(
+    {
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_datetime_add_second(async))).Message);
 
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "second", "amount" : 1.0 } }, "_id" : 0 } }
+""");
+    }
+
     public override async Task Select_expression_date_add_milliseconds_above_the_range(bool async)
-        => Assert.Contains(
+    {
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_date_add_milliseconds_above_the_range(async))).Message);
 
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "millisecond", "amount" : 1000000000000.0 } }, "_id" : 0 } }
+""");
+    }
+
     public override async Task Select_expression_date_add_milliseconds_below_the_range(bool async)
-        => Assert.Contains(
+    {
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_date_add_milliseconds_below_the_range(async))).Message);
+
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "millisecond", "amount" : -1000000000000.0 } }, "_id" : 0 } }
+""");
+    }
 
     public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool async)
     {
@@ -2526,6 +2575,11 @@ Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "Ship
             "Cannot deserialize a 'Int32' from BsonType 'DateTime'",
             (await Assert.ThrowsAsync<FormatException>(() =>
                 base.Select_expression_date_add_milliseconds_large_number_divided(async))).Message);
+
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "day", "amount" : { "$divide" : [{ "$millisecond" : "$OrderDate" }, 86400000] } } }, "unit" : "millisecond", "amount" : { "$mod" : [{ "$millisecond" : "$OrderDate" }, 86400000] } } }, "_id" : 0 } }
+""");
     }
 
     public override async Task Add_minutes_on_constant_value(bool async)
@@ -4219,12 +4273,19 @@ Customers.
     }
 
     public override async Task Select_expression_datetime_add_ticks(bool async)
+    {
         // Same root cause as the DateAdd family above: driver translates the arithmetic but the
         // result's DateTimeKind round-trips as UTC, failing the base test's exact equality.
-        => Assert.Contains(
+        Assert.Contains(
             "Assert.Equal() Failure",
             (await Assert.ThrowsAsync<Xunit.Sdk.EqualException>(
                 () => base.Select_expression_datetime_add_ticks(async))).Message);
+
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "OrderDate" : { "$dateAdd" : { "startDate" : "$OrderDate", "unit" : "millisecond", "amount" : 1.0 } }, "_id" : 0 } }
+""");
+    }
 
     public override async Task Where_subquery_expression_same_parametername(bool async)
     {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -2445,10 +2445,22 @@ Orders.{ "$match" : { "$expr" : { "$eq" : [{ "$bitXor" : ["$_id", 1] }, 10249] }
     }
 
     public override async Task Select_expression_long_to_string(bool async)
-        => await base.Select_expression_long_to_string(async);
+    {
+        await base.Select_expression_long_to_string(async);
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "ShipName" : { "$toString" : { "$toLong" : "$_id" } }, "_id" : 0 } }
+""");
+    }
 
     public override async Task Select_expression_int_to_string(bool async)
-        => await base.Select_expression_int_to_string(async);
+    {
+        await base.Select_expression_int_to_string(async);
+        AssertMql(
+            """
+Orders.{ "$match" : { "OrderDate" : { "$ne" : null } } }, { "$project" : { "ShipName" : { "$toString" : "$_id" }, "_id" : 0 } }
+""");
+    }
 
     public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool async)
     {


### PR DESCRIPTION
## Problem

A projection like `new { Alias = e.Prop }` pushes a `$project` stage to MongoDB that emits the field under the alias key. When the shaper reads it back, it looked up `Alias` as a *property name* on the root entity type in order to find a serializer. Three failure modes depending on what `Alias` happens to collide with:

| Alias collides with… | Outcome |
|---|---|
| no EF property at all | `InvalidOperationException: The property '<Root>.Alias' could not be found` |
| a different EF property with incompatible nullability | `ArgumentException` — Expression.Call rejects a `Nullable<T>` where `T` is expected |
| a different EF property with compatible type | query runs but uses the **wrong** serializer — silent data corruption |

The same bug affects properties on owned entities and owned collections.

## Fix

`VisitExtension` now walks the projection's source expression (via `TryResolveFieldAccess`, promoted from the mixed visitor to the base class) to find the originating `IProperty`. It then reads the BSON element by alias key but deserializes using that property's own serializer and nullability metadata.

A new `BsonBinding.CreateGetValueExpression(doc, elementKey, sourceProperty, type)` overload separates the lookup key from the property metadata so the two concerns can no longer collide.

The mixed-projection path (a `Select` that contains both entity references and scalar properties, which LINQ V3 cannot push down) is also corrected: the pushed-down `Select` is now stripped from the LINQ expression before execution so the driver returns full entity `BsonDocument`s; the client-side shaper then handles the projection.

## Commit structure

The PR is split into four commits to make review easier:

1. **Refactor** — widen `bool trackQueryResults` to `QueryTrackingBehavior` enum throughout the visitor chain (no behavior change)
2. **Refactor** — rename `ProjectionBindings` → `_projectionBindings` and `_ordinalParameterBindings` → `_ordinalMappings` (no behavior change; reduces noise in commit 3's diff)
3. **Fix** — core EF-313 projection fix: `TryResolveFieldAccess`, new `BsonBinding` overload, mixed-path `StripPushedDownSelect`, tests for aliased owned and root properties