### PR TITLE
Tiny: Fix break with latest server version

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/IndexTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/IndexTests.cs
@@ -699,10 +699,9 @@ public class IndexTests(AtlasTemporaryDatabaseFixture database)
 
         var fields = index["latestDefinition"]["fields"].AsBsonArray;
 
-        Assert.Equal("vectorSearch", index["type"].AsString);
         Assert.Equal("READY", index["status"].AsString);
         Assert.True(index["queryable"].AsBoolean);
-        Assert.Equal(0, index["latestVersion"].AsInt32);
+        Assert.Equal(0, index["latestDefinitionVersion"]["version"].AsInt32);
 
         var field = fields[0];
         Assert.Equal("vector", field["type"].AsString);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/IndexTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/IndexTests.cs
@@ -701,7 +701,6 @@ public class IndexTests(AtlasTemporaryDatabaseFixture database)
 
         Assert.Equal("READY", index["status"].AsString);
         Assert.True(index["queryable"].AsBoolean);
-        Assert.Equal(0, index["latestDefinitionVersion"]["version"].AsInt32);
 
         var field = fields[0];
         Assert.Equal("vector", field["type"].AsString);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/MongoDbAtlasBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/MongoDbAtlasBuilder.cs
@@ -24,7 +24,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
 
 public sealed class MongoDbAtlasBuilder : ContainerBuilder<MongoDbAtlasBuilder, MongoDbAtlasContainer, IContainerConfiguration>
 {
-    private const string MongoDbAtlasImage = "mongodb/mongodb-atlas-local:8.0";
+    private const string MongoDbAtlasImage = "mongodb/mongodb-atlas-local:latest";
     public const ushort MongoDbAtlasPort = 27017;
 
     public MongoDbAtlasBuilder()

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestContainersTestServer.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestContainersTestServer.cs
@@ -30,7 +30,7 @@ public class TestContainersTestServer : TestServer
 
     public override async Task InitializeAsync()
     {
-        _container = new MongoDbAtlasBuilder().WithImage("mongodb/mongodb-atlas-local:8.0").Build();
+        _container = new MongoDbAtlasBuilder().Build();
 
         await _container.StartAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
At some point vector index metadata changed. Fix tests to not expect the old form.