### PR TITLE
EF-308: Refine /review-ef-core-provider and /test-all skills

### DIFF
--- a/.claude/agents/api-stability-reviewer.md
+++ b/.claude/agents/api-stability-reviewer.md
@@ -24,7 +24,17 @@ What counts as the public surface:
 - Default values for parameters and options (`AutoTransactionBehavior`, `QueryableEncryptionSchemaMode`, etc.) — silent defaults flow into user code.
 - Behavior of unchanged signatures — silent semantic shifts are particularly bad here because there's no `[Obsolete]` mitigation for them.
 
-`InternalsVisibleTo` grants visibility to `MongoDB.EntityFrameworkCore.UnitTests` and `MongoDB.EntityFrameworkCore.SpecificationTests` only (see `MongoDB.EntityFrameworkCore.csproj`). Internal types stay internal for the SemVer surface regardless.
+`InternalsVisibleTo` grants visibility to `MongoDB.EntityFrameworkCore.UnitTests` and `MongoDB.EntityFrameworkCore.SpecificationTests` only (see `MongoDB.EntityFrameworkCore.csproj`). **Changes to anything `internal` are never breaking — regardless of `InternalsVisibleTo`.** That a test assembly can see an internal type does not make it part of the public surface; do not flag internal signature, behavior, or visibility changes as breaks. The public surface is strictly what an external consumer can reference without `InternalsVisibleTo`.
+
+## Baseline: the latest released version, not `main`
+
+Breaking changes are measured against the **latest released version of the assembly** (the most recent published NuGet package), **not** against the current state of `main`. The practical consequence: a public API that was added, then changed or removed, *within the current unreleased development cycle* (i.e. it does not exist in the last release) is **not** a break — it never shipped, so no consumer depends on it. Only differences observable to someone upgrading from the last released version count.
+
+**Finding the baseline.** Releases are tagged `v<major>.<minor>.<patch>` (optional `-preview.N`), one line per EF major (`v8.*`, `v9.*`, `v10.*` ship in parallel). Do **not** rely on local `git tag` — a clone's tags are frequently stale and miss recent releases. Use the GitHub release list:
+- Absolute latest: `gh release list --limit 1 --json tagName,isLatest`.
+- Latest on the EF-major line relevant to the change: the highest non-preview `v<major>.*` from `gh release list --limit 100 --json tagName` (e.g. assess an EF8-only change against the latest `v8.*`).
+
+When in doubt whether a symbol shipped, compare against that tag rather than `main`: `git -C "<diff-repo>" fetch --tags` (if the tag isn't local), then `git -C "<diff-repo>" show <tag>:<path>` or `git -C "<diff-repo>" diff <tag> -- <path>`. If a public symbol is absent at the baseline tag, changing or removing it now is not a break.
 
 ## Review focus
 
@@ -36,7 +46,7 @@ What counts as the public surface:
 - **Annotation-key renames** — `MongoAnnotationNames` values are part of the contract. Renames are breaks for compiled models. Add new keys; don't rename.
 - **`MongoEventId` renumbering / reordering / removal** — break for `DiagnosticSource` subscribers.
 - **Default-value changes** — `AutoTransactionBehavior` (was changed in 8.1.0), `QueryableEncryptionSchemaMode`, Guid representation, discriminator-element-name behavior. Each historical default-change is in `BREAKING-CHANGES.md`.
-- **Exception-type changes** for documented exceptions.
+- **Exception-type changes** for documented exceptions. **Exception:** changing the exception type thrown for an *unsupported* feature (e.g. a not-yet-implemented LINQ operator, an unsupported mapping, a guard that exists only to reject something the provider does not support) is **not** a break — the thrown type for an unsupported path is not part of the contract. Only the exception type of a *supported, documented* operation matters.
 - **Enum value renames / numeric-value changes.**
 - **Nullability tightening** under `<Nullable>enable</Nullable>` (the provider has nullable enabled in `src/`).
 - **`[Obsolete]` additions** — confirm a replacement is documented. `[Obsolete]` is the tool for introducing a replacement overload, *not* for in-place behavior changes (those still need a doc break).
@@ -45,7 +55,7 @@ What counts as the public surface:
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. Any "would be good to write a test for X" suggestion is `[external-action]`.
+- Most of your findings are source-level (signatures, visibility, annotation keys) and need no runtime check. But any **behavior-change** finding (a silent semantic shift on an unchanged signature, a changed default that alters runtime behavior) is a functional claim — reproduce it with a minimal test or small `dotnet run` repro before reporting it (the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs here), and include the repro and observed output. Only defer to `[external-action]` when the repro genuinely can't run locally (Atlas-only, encryption infra, or multi-EF divergence needing `/test-all`).
 - The two read-only checks worth running every pass: `git -C "<diff-repo>" diff <base>...<head> -- src/` to inspect every signature change, and a grep over `MongoAnnotationNames` / `MongoEventId` to confirm no values were renamed, renumbered, or removed.
 - If observable public-surface behavior changed without a `BREAKING-CHANGES.md` update, tag that as `[external-action]` (only the user can write the doc).
 
@@ -58,3 +68,9 @@ What counts as the public surface:
 - Rename / removal of a `MongoAnnotationNames` constant.
 - Renumber / reorder / removal of a `MongoEventId` member.
 - Public surface change without a corresponding `BREAKING-CHANGES.md` update (in which case ask the user to add one).
+
+Do **not** escalate (these are not breaks — see the definitions above):
+
+- Changes to anything `internal`, regardless of `InternalsVisibleTo`.
+- A public API added and then changed/removed within the current unreleased cycle — it never shipped, so measure against the latest released version, not `main`.
+- A change to the exception type thrown for an unsupported feature (unimplemented operator, unsupported mapping, reject-guard). Only the exception type of a supported, documented operation is contractual.

--- a/.claude/agents/diagnostics-reviewer.md
+++ b/.claude/agents/diagnostics-reviewer.md
@@ -23,7 +23,7 @@ Read `src/MongoDB.EntityFrameworkCore/Diagnostics/AGENTS.md` first; then root `A
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/ef-conformance-reviewer.md
+++ b/.claude/agents/ef-conformance-reviewer.md
@@ -40,7 +40,7 @@ The `/test-all` skill runs all three EF versions in parallel — invoking it aft
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass — `/test-all` and other multi-EF builds are too slow to fit in a reviewer slot. If a `#if` change makes multi-EF verification worth running, tag the finding `[external-action]` and name `/test-all` explicitly so the user can run it.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim against a single EF configuration with a minimal failing test or small `dotnet run` repro and run it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test -c "Debug EF10"` always runs here — and include the repro and observed output. The genuine exception for this area is **multi-EF divergence**: a claim that behavior differs across EF8/EF9/EF10 needs the full `/test-all` matrix, which is too slow for a reviewer slot — tag that `[external-action]` and name `/test-all` explicitly. A behavior bug you can reproduce on one EF config, though, you must reproduce, not defer.
 - Worth running every pass: scan changed files for `#if EF8|EF9|EF10` and read each branch; grep `MongoServiceCollectionExtensions.AddEntityFrameworkMongoDB()` if a new service replacement is in the diff; grep `MongoAnnotationNames` if a new annotation is in the diff.
 
 ## Escalate to user (do not auto-approve) when

--- a/.claude/agents/encryption-reviewer.md
+++ b/.claude/agents/encryption-reviewer.md
@@ -32,7 +32,7 @@ Driver-side: CSFLE/QE plumbing (KMS providers, the `crypt_shared` library, mongo
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — for this area that especially includes encryption paths needing `CRYPT_SHARED_LIB_PATH` (unset ⇒ `SupportsEncryption` is false and the tests skip), as well as Atlas-only features and multi-EF divergence needing `/test-all` — and then name the exact test/command.
 - Grep the diff for likely-secret patterns (`BEGIN PRIVATE KEY`, `AKIA[0-9A-Z]{16}`, `mongodb+srv://[^/]+:[^@]+@`, service-account JSON, etc.) — any hit is an immediate `[blocking]` finding regardless of how plausible it looks in context. This grep is the one read-only check worth running every pass.
 
 ## Escalate to user (do not auto-approve) when

--- a/.claude/agents/metadata-reviewer.md
+++ b/.claude/agents/metadata-reviewer.md
@@ -25,7 +25,7 @@ Read `src/MongoDB.EntityFrameworkCore/Metadata/AGENTS.md` first; then root `AGEN
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/public-api-reviewer.md
+++ b/.claude/agents/public-api-reviewer.md
@@ -28,7 +28,7 @@ Read `src/MongoDB.EntityFrameworkCore/Extensions/AGENTS.md` first; then root `AG
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/query-reviewer.md
+++ b/.claude/agents/query-reviewer.md
@@ -29,7 +29,7 @@ The provider sits on top of the C# driver's LINQ v3 provider — Query produces 
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -31,7 +31,7 @@ Read root `AGENTS.md` for build/test commands. Security touchpoints in this prov
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. Any "worth a redaction test" suggestion is `[external-action]`.
+- Verify functional findings before reporting them. A claim that a secret reaches a log, that redaction doesn't fire, or that sensitive data is exposed is a runtime-behavior claim — reproduce it with a minimal failing test or small `dotnet run` repro and run it (the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs here), then include the repro and the observed log/output. If the repro doesn't reproduce the exposure, don't report it. Only defer to `[external-action]` when the repro genuinely can't run locally (Atlas-only, missing encryption infra, or multi-EF divergence needing `/test-all`).
 - Always grep the diff for likely-secret patterns — this is the one read-only check worth running every pass and any hit is an immediate `[blocking]` finding:
   - Generic shapes: `password\s*=`, `passwd\s*=`, `apiKey`, `secret`, `token`, `Bearer\s+`.
   - PEM / private keys: `BEGIN PRIVATE KEY`, `BEGIN RSA PRIVATE KEY`, `BEGIN OPENSSH PRIVATE KEY`.

--- a/.claude/agents/serialization-reviewer.md
+++ b/.claude/agents/serialization-reviewer.md
@@ -26,7 +26,7 @@ Read `src/MongoDB.EntityFrameworkCore/Serializers/AGENTS.md` first; then root `A
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/spec-conformance-reviewer.md
+++ b/.claude/agents/spec-conformance-reviewer.md
@@ -26,7 +26,7 @@ Read `tests/MongoDB.EntityFrameworkCore.SpecificationTests/AGENTS.md` first; the
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/storage-reviewer.md
+++ b/.claude/agents/storage-reviewer.md
@@ -27,7 +27,7 @@ Read `src/MongoDB.EntityFrameworkCore/Storage/AGENTS.md` first; then root `AGENT
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/value-generation-reviewer.md
+++ b/.claude/agents/value-generation-reviewer.md
@@ -22,7 +22,7 @@ Read `src/MongoDB.EntityFrameworkCore/ValueGeneration/AGENTS.md` first; then roo
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. If the repro doesn't reproduce the issue, don't report it; include the repro and observed output in the report. Tag a test-needing concern `[external-action]` only when it genuinely can't run here — Atlas-only features (e.g. vector search), missing encryption infra (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF divergence needing `/test-all` — and then name the exact test/command.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/agents/vector-search-reviewer.md
+++ b/.claude/agents/vector-search-reviewer.md
@@ -30,7 +30,7 @@ Read root `AGENTS.md` for build/test commands. Then skim the relevant area `AGEN
 ## Pass discipline
 
 - Emit at most 5 findings per pass; prioritize `[blocking]` > `[substantive]` > `[nit]`. If you have more than 5 candidates, drop the lowest-severity ones — do not pad the list with extra nits.
-- Do not run tests in this pass. If a test would be useful to settle a concern (multi-EF coverage, Atlas-dependent path, encryption infra), tag the finding `[external-action]` and describe what test the user should run.
+- Verify functional findings before reporting them. Reproduce any runtime-behavior claim by adding a minimal failing test (or a small `dotnet run` repro) and running it — the functional-test harness auto-starts a MongoDB testcontainer when `MONGODB_URI`/`ATLAS_URI` are unset, so `dotnet test` always runs on this machine. Note this area is the common exception: vector search runs only against Atlas, which a local testcontainer can't provide — when the configured environment has no Atlas connection, tag such a finding `[external-action]` and name the exact test/command the user should run against Atlas. Non-Atlas findings (index metadata, `BinaryVector` serialization, expression-tree handling) can and should still be reproduced locally; include the repro and observed output in the report.
 
 ## Escalate to user (do not auto-approve) when
 

--- a/.claude/skills/review-ef-core-provider/SKILL.md
+++ b/.claude/skills/review-ef-core-provider/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: review-ef-core-provider
-description: Fan-out review of the current branch, an external PR, or a branch in another clone — runs each per-area reviewer over the files it owns and aggregates findings. With --iterate, alternates review/fix passes until two consecutive clean reviews or the iteration cap is reached.
+description: Fan-out review of the current branch, an external PR, or a branch in another clone — runs each per-area reviewer over the files it owns and aggregates findings. With --iterate, alternates review/fix passes until two consecutive clean reviews or the iteration cap is reached. Requires the superpowers plugin (errors out if it is not available).
 argument-hint: "[--all] [--model opus|sonnet|haiku] [--iterate [--max-iterations N]] [<PR#> | <clone-path> [<base-ref> [<head-ref>]] | <base-ref> [<head-ref>]]"
-allowed-tools: Bash, Read, Glob, Grep, Write, Agent
+allowed-tools: Bash, Read, Glob, Grep, Write, Agent, Skill
 ---
 
 # /review-ef-core-provider
@@ -14,6 +14,14 @@ Run the per-area reviewer sub-agents (`.claude/agents/*-reviewer.md`) over a dif
 - **External clone mode** — diff a branch in a *different* clone of this repo, while running with the current clone's reviewer briefs and `AGENTS.md` files. Useful when the branch being reviewed lacks the latest agent/architecture updates that live in the current clone.
 
 User args: `$ARGUMENTS`
+
+## Step 0 — Require the superpowers plugin (hard gate)
+
+This skill depends on the **superpowers** plugin and will not run without it. Before doing anything else:
+
+1. Check the session's available-skills list (the `<system-reminder>` skill listing) for entries whose names start with `superpowers:`. At minimum, confirm all of these are present: `superpowers:requesting-code-review`, `superpowers:receiving-code-review`, `superpowers:test-driven-development`, `superpowers:systematic-debugging`, `superpowers:verification-before-completion`, and `superpowers:brainstorming`.
+2. If **any** of those are missing, **stop immediately**. Do not parse args, diff, or dispatch reviewers. Emit exactly one error message to the user naming which superpowers skills were not found and saying that `/review-ef-core-provider` requires the superpowers plugin to be installed and enabled. Then end the response.
+3. If all are present, invoke `superpowers:requesting-code-review` now to frame the entire run — this review *is* the code-review request it describes — then continue to Step 1. The superpowers skills are woven into the workflow at the points called out below (fixer pass, convergence gate); honor them there.
 
 ## Step 1 — Determine scope
 
@@ -131,6 +139,18 @@ This is iteration <N> of an `--iterate` run. The file list above is narrowed to 
 
 Read those files at their current state. Run git commands with `git -C "<diff-repo>" …` (e.g. `git -C "<diff-repo>" diff <base>...<head> -- <repo-relative-path>`) — the parent agent's working directory may not be <diff-repo>. Pull in adjacent context only as needed to judge the change.
 
+**Verify every functional finding by running code before you report it (required).** A *functional* finding is any claim about runtime behavior: a thrown or uncaught exception, wrong LINQ translation or query result, wrong persisted document shape, an `#if` branch that changes behavior, lost `CancellationToken` propagation, incorrect value generation, a redaction that doesn't happen, etc. — as opposed to a naming / comment / doc / style nit or a purely source-level signature observation. Too many reported findings turn out not to reproduce, so you **must** reproduce a functional issue and confirm it is real before reporting it; if your repro does not reproduce the problem, do not report it.
+
+You can always run tests on this machine. The functional-test harness (`<diff-repo>/tests/.../FunctionalTests/Utilities/TestServer.cs`) connects to the MongoDB named by the `ATLAS_URI` / `MONGODB_URI` environment variables when they are set, and otherwise **automatically starts a local MongoDB testcontainer via Docker** — so `dotnet test` runs end-to-end here with no manual setup. You have `Read`/`Grep`/`Glob`/`Bash` but **no `Edit`/`Write` tool**, so scaffold the repro with `Bash` — e.g. write a temporary xUnit test file into the matching `<diff-repo>/tests/.../FunctionalTests/<Area>/` folder with a here-doc, or stand up a small throwaway console project in a temp directory. Run everything against `<diff-repo>` (the parent's working directory may not be `<diff-repo>` — in external-clone mode it isn't), so use absolute `<diff-repo>/...` paths. Reproduce a finding by either:
+- running the temporary test: `dotnet test "<diff-repo>/MongoDB.EFCoreProvider.sln" -c "Debug EF10" --filter "FullyQualifiedName~<YourTest>"`, or
+- running a small throwaway repro (`dotnet run`) that exercises the path.
+
+**Clean up after yourself.** Delete any file you created to reproduce, so the diff-repo working tree is left exactly as you found it (in `--iterate` mode the parent diffs the tree between iterations — a stray test file would corrupt the next pass). Verifying a finding never means committing a test; the *fixer* adds the permanent regression test later.
+
+One EF configuration is enough to confirm a behavioral bug. The only findings that stay `[external-action]` for lack of verification are those that genuinely cannot run here: Atlas-only features the local testcontainer can't provide (e.g. vector search), encryption paths needing infrastructure that isn't installed (`CRYPT_SHARED_LIB_PATH` unset), or multi-EF *divergence* that would need `/test-all`. For those, tag `[external-action]` and name the exact test/command the user should run — you still may not merely assert the bug.
+
+**Include the repro in the report** under each functional finding: the test code (or the commands you ran) plus the observed failing output (assertion message, exception, or wrong value). Repro blocks do not count against the 400-word limit.
+
 Produce a report in exactly this shape, no preamble:
 
 **Verdict**: one of `approve`, `flag`, `escalate`.
@@ -138,11 +158,13 @@ Produce a report in exactly this shape, no preamble:
 - flag = non-blocking suggestions or nits
 - escalate = blocking concern that needs user attention before merge (public-API break, annotation-key rename, behavior change affecting stored documents, multi-EF break, spec-conformance regression, security regression)
 
-**Findings**: bulleted list. Each bullet: `<file>:<line> — [fix-in-code|external-action][blocking|substantive|nit] <one-sentence problem> — <one-sentence fix or action>`.
+**Findings**: bulleted list. Each bullet: `<file>:<line> — [fix-in-code|external-action][blocking|substantive|nit] **<TL;DR>** — <one-sentence problem> — <one-sentence fix or action>`.
+
+The `<TL;DR>` is a terse headline (**≤8 words**) that names the issue at a glance, emitted in bold immediately after the tags and before the one-sentence problem. Examples: `**May throw NullReferenceException**`, `**Typo in skip message**`, `**Exception type changed**`, `**Missing #if EF10 branch**`, `**Annotation key renamed**`. Keep it noun-phrase terse — it is a label, not the explanation.
 
 Every finding carries two tags. The first tag says *who can act on it*:
 - `[fix-in-code]` — the finding can be resolved by an in-tree code change (edit a file, add a test, fix a typo, tighten a comment, change a throw type, fix an `#if` branch, etc.) that the fixer agent can make mechanically without external information.
-- `[external-action]` — the finding requires something outside this codebase: confirming a JIRA ticket exists, verifying CI matrix configuration, asking the user to confirm intent, auditing call sites in production code outside the diff, double-checking spec wording against an external source, "worth a quick test asserting…" suggestions where the test would require Atlas or encryption infrastructure you don't have, updating `BREAKING-CHANGES.md` wording on behalf of the user, or any other action the fixer agent cannot perform without leaving the repo.
+- `[external-action]` — the finding requires something outside this codebase: confirming a JIRA ticket exists, verifying CI matrix configuration, asking the user to confirm intent, auditing call sites in production code outside the diff, double-checking spec wording against an external source, a test that can only run against infrastructure you don't have (Atlas-only features such as vector search, or encryption needing `CRYPT_SHARED_LIB_PATH`) or that needs multi-EF `/test-all` to show divergence, updating `BREAKING-CHANGES.md` wording on behalf of the user, or any other action the fixer agent cannot perform without leaving the repo. Note: a test that *can* run against the local testcontainer is **not** an external action — you must run it yourself to verify the finding (see the verification requirement above), not defer it.
 
 When unsure between fix-in-code and external-action, prefer `[external-action]` — it surfaces the concern without claiming the fixer can address it.
 
@@ -155,9 +177,9 @@ When unsure between substantive and nit, prefer `substantive` (conservative — 
 
 Use repo-relative paths in findings (not absolute) so output is portable. Emit at most **5** findings per pass. If you have identified more than 5, sort by tag (blocking → substantive → nit) and drop the lowest-priority ones — do not pad the list with extra nits.
 
-**Tests run**: list any `dotnet test --filter` you actually executed and pass/fail. If none, write `none`.
+**Tests run / repros**: list every `dotnet test --filter` or `dotnet run` repro you actually executed, with pass/fail, and — for each functional finding — the repro test code or commands plus the observed output. If you reported no functional findings and ran nothing, write `none`.
 
-Hard limit: 400 words total. Do not summarize the diff back; the parent agent has it.
+Hard limit: 400 words total, **excluding** repro code/output blocks (those are uncapped — include them in full). Do not summarize the diff back; the parent agent has it.
 ```
 
 ### Cross-cutter prompt template
@@ -181,7 +203,7 @@ This is iteration <N> of an `--iterate` run. The file list above is narrowed to 
 
 Use `git -C "<diff-repo>" diff <base>...<head>` to see the full picture and `git -C "<diff-repo>" diff <base>...<head> -- <repo-relative-path>` to focus. Read files at their current state where context matters. Skip files that are clearly irrelevant to your concern.
 
-Produce a report in exactly the same shape as the area reviewers (Verdict / Findings / Tests run; same format and 400-word cap; same verdict semantics; repo-relative paths in findings; the same `[fix-in-code]` / `[external-action]` tag *and* the same `[blocking]` / `[substantive]` / `[nit]` severity tag on every finding; the same 5-finding cap; and the same carry-forward-nit rule in iteration N > 1). Findings must be specific to your concern — do not duplicate what an area reviewer would catch.
+Produce a report in exactly the same shape as the area reviewers (Verdict / Findings / Tests run / repros; same format and 400-word cap excluding repro blocks; same verdict semantics; repo-relative paths in findings; the same bold `<TL;DR>` headline (≤8 words) before each finding's one-sentence problem; the same `[fix-in-code]` / `[external-action]` tag *and* the same `[blocking]` / `[substantive]` / `[nit]` severity tag on every finding; the same 5-finding cap; and the same carry-forward-nit rule in iteration N > 1). **The same verification requirement applies**: any functional finding (a real runtime-behavior claim — e.g. credentials reaching a log, redaction not happening, a behavior change on an unchanged signature) must be reproduced by running a test or small repro before you report it (the local test harness auto-starts a testcontainer, so `dotnet test` always runs here), with the repro included in the report; only defer to `[external-action]` when it truly can't run locally. Findings must be specific to your concern — do not duplicate what an area reviewer would catch.
 ```
 
 ### PR-summary prompt template (external PR mode only)
@@ -267,6 +289,8 @@ An iteration's aggregated report is **clean** when **all** of these hold:
 
 State your clean/not-clean call explicitly when you announce the iteration result, with a one-line reason: `Iteration <N>: clean — only [nit] findings remain (unused import, message typo); 2 [external-action] notes carried forward.` or `Iteration <N>: not clean — [fix-in-code][substantive]: missing #if EF10 branch weakens multi-EF compat.`
 
+**Verification gate (required).** A "clean" call — and the final "two consecutive clean reviews → converged" announcement — is a completion claim. Before making either, invoke `superpowers:verification-before-completion` and satisfy it with evidence: do not declare an iteration clean on reviewer verdicts alone if the fixer's last commit changed code that should compile or pass tests. Run the relevant build/test command (e.g. `/test-all`, or a scoped `dotnet test --filter` for the touched area) and cite the actual pass/fail output in your clean/not-clean announcement. If you cannot run verification (no DB, slow multi-EF build, etc.), say so explicitly and treat the iteration as not independently verified rather than silently claiming clean.
+
 ### Loop shape
 
 ```
@@ -312,17 +336,23 @@ Re-running Steps 1–4 means re-running `git -C "<diff-repo>" diff --name-only <
 
 ### Fixer agent dispatch
 
-Use the `general-purpose` agent (it has full tools — Read/Write/Edit/Bash — which reviewers lack). One `Agent` block, foreground. Subagent prompt template:
+Use the `general-purpose` agent (it has full tools — Read/Write/Edit/Bash — which reviewers lack, and access to the superpowers skills via the `Skill` tool). One `Agent` block, foreground. Subagent prompt template:
 
 ```
 You are the fix-applying agent in iteration <N> of <max> of an iterative code review of <diff-repo>.
 
 Your job is to address the findings from the review report below by editing files in <diff-repo> and committing in that repo. Then stop and report what you did.
 
+This run depends on the **superpowers** plugin. The parent already confirmed it is available before dispatching you. Work through the superpowers skills as directed below; if you find any of them are NOT available to you via the `Skill` tool, stop and report that as a failure (do not silently proceed without them).
+
 Rules:
+0. **Treat the report as code-review feedback, not orders.** Before implementing, invoke `superpowers:receiving-code-review` and apply it to every finding you intend to act on — verify the diagnosis against the actual code rather than performing agreement; a finding you cannot confirm is a candidate to skip-and-note, not to fix blindly.
 1. Every finding carries two tags: `[fix-in-code|external-action]` (who can act) and `[blocking|substantive|nit]` (how important). Apply every `[fix-in-code][blocking]` and `[fix-in-code][substantive]` finding — those came from a specialised reviewer that knows the area; trust the diagnosis, but read the surrounding code before changing it. Skip every `[external-action]` finding outright regardless of severity — those require something outside this codebase (JIRA, CI config, audits, spec lookups, `BREAKING-CHANGES.md` wording) that you can't perform; they will be surfaced to the user in the closing summary.
 2. **Skip `[fix-in-code][nit]` findings by default.** The reviewer classified them as mechanical cosmetic, not behavior-affecting; the loop tolerates them indefinitely. Exception: if you are already editing a given file for a substantive finding, *and* a nit in that same file is trivially mechanical (one-line edit, no judgment required), you may fix it in passing. Never go out of your way to fix a nit — and never fix a nit in a file you would not otherwise be touching this iteration.
 3. Do not change behavior beyond what the findings demand. No refactoring, no drive-by cleanups, no scope expansion, no unrelated formatting passes.
+3a. **Debug failure-type findings before fixing them.** For any finding describing a bug, exception, test failure, wrong behavior, or broken `#if` branch, invoke `superpowers:systematic-debugging` and follow it to root-cause the issue before editing — do not patch the symptom the reviewer named without confirming the cause.
+3b. **Use TDD when a fix adds or changes tests, or fixes a behavior bug with no covering test.** Invoke `superpowers:test-driven-development` and follow it: write the failing test first, watch it fail, then make it pass. This applies to spec-conformance and functional-test findings in particular.
+3c. **Brainstorm non-mechanical fixes.** If a `[fix-in-code]` finding's resolution is ambiguous, has multiple plausible designs, or requires inferring intent (not a one-line mechanical change), invoke `superpowers:brainstorming` to settle the approach before editing rather than guessing. If brainstorming reveals the fix genuinely needs user judgment, skip-and-note it instead (see rule 7).
 4. Respect the codebase guidance. The parent agent's working directory has up-to-date `AGENTS.md` files — read them as needed via relative paths. In particular: preserve file BOMs; `<Nullable>enable</Nullable>` is on in `src/` — annotate new types accordingly; library code uses `ConfigureAwait(false)`; `CancellationToken` flows through unchanged; multi-EF code uses `#if EF8 / EF9 / EF10` define constants — a fix that compiles on one EF version must compile on all three. The diff-repo at <diff-repo> may have *older* `AGENTS.md` files — prefer the up-to-date ones from the parent agent's cwd when they conflict.
 5. All edits land in <diff-repo>. Use absolute paths under <diff-repo> when calling Edit/Write, and `git -C "<diff-repo>" …` for every git command.
 6. When done editing, run `git -C "<diff-repo>" status --short`. If there are no changes, do not commit — report `no-op` and stop. Otherwise run `git -C "<diff-repo>" add -A` then `git -C "<diff-repo>" commit -m "[review-iter <N>] Address review findings"` (do NOT include any AI-attribution trailers; do NOT push; do NOT amend any previous commit).
@@ -352,10 +382,11 @@ Do not paste the full report transcripts again — they're on disk.
 
 ## Notes
 
-- Reviewers are non-mutating with respect to the source tree: each one is configured with `tools: Read, Grep, Glob, Bash` and has no `Edit` / `Write` / `Patch` tool, so they cannot modify files. They *can* still execute shell commands via `Bash` (e.g. `dotnet test`, `git diff`); scope reviewer Bash usage to inspection commands and treat any suggested fix as something the parent applies, not the reviewer.
+- **This skill hard-depends on the superpowers plugin** (Step 0). If `superpowers:requesting-code-review`, `superpowers:receiving-code-review`, `superpowers:test-driven-development`, `superpowers:systematic-debugging`, `superpowers:verification-before-completion`, or `superpowers:brainstorming` is not available, the skill errors out before doing any work. The framing skill runs at the start, the fixer applies receiving-code-review / systematic-debugging / TDD / brainstorming per its rules, and the convergence check is gated on verification-before-completion.
+- Reviewers must not *fix* the source tree: each one is configured with `tools: Read, Grep, Glob, Bash` and has no `Edit` / `Write` / `Patch` tool, so they can't apply a fix — treat any suggested fix as something the parent/fixer applies, not the reviewer. They *can* and *must* use `Bash` to verify functional findings, which includes running `dotnet test`, scaffolding a throwaway repro test or project via a here-doc, and `git diff`. Any repro file a reviewer creates is temporary and must be deleted before the reviewer returns, leaving the working tree exactly as found (essential in `--iterate` mode, where the parent diffs the tree between iterations).
 - A diff against a feature branch's own base is the typical use; pass an explicit `<base-ref>` for non-`main` cases (e.g. `/review-ef-core-provider release/10.0`). Pass a second positional arg to cap the end of the range (e.g. `/review-ef-core-provider HEAD~5 HEAD~1`).
 - In external PR mode, the remote is inferred from the PR's repo URL, so PRs on forks (`upstream`, `origin`, or any named remote) are handled automatically without any extra flags.
 - In external clone mode, the parent agent stays in the current clone so that `AGENTS.md` files, reviewer briefs, and any other repo guidance load from *here*, while the source code being reviewed and all git history come from `<clone>`. This is the whole point of the mode: review code on a branch that doesn't yet carry the latest agent/architecture updates, using the up-to-date briefs from the current clone. The pr-summary-reviewer does not run in this mode (no PR body to fetch); if you also want a holistic PR summary, run `/review-ef-core-provider <PR#>` separately.
 - `--iterate` makes commits in `<diff-repo>` (one per non-clean iteration). It never pushes. The user can inspect with `git -C <diff-repo> log <base>..HEAD` afterward and amend / squash / drop commits as they see fit. Severity classification (`[blocking]` / `[substantive]` / `[nit]`) is the reviewer's call at emit time, *not* the parent's call after the fact — reviewers see the rubric in their dispatch prompt and pick. The loop terminates as soon as no `[fix-in-code][blocking]` or `[fix-in-code][substantive]` findings remain (`[nit]` and `[external-action]` are carried forward, not counted). If a real substantive concern is leaking through tagged as `[nit]`, the answer is to fix the reviewer brief or surface it to the user — not to tighten the convergence rule.
 - The loop has two convergence guards beyond the max-iterations cap. **`[external-action]` findings don't block convergence**: reviewers tag any finding that requires looking up a JIRA ticket, verifying CI config, auditing call sites outside the diff, updating `BREAKING-CHANGES.md` wording, or otherwise leaving the codebase, and those tags exclude the finding from the clean check. The user still sees them — they're listed in every iteration's report and in the closing summary — but the fixer can't address them so they shouldn't pin the loop open. **A no-op fixer ends the loop**: if the fixer judges that nothing in the current report is mechanically actionable, the next iteration would just be re-rolling LLM verdicts on the same tree, so the loop stops with outcome `no actionable findings remaining` and surfaces the outstanding `[external-action]` items.
-- Test-running by reviewers is opportunistic — most won't, given that the EF Core provider has three build configurations and a `dotnet test` over a real database is slow. The `/test-all` skill is the right tool when a multi-EF build is genuinely needed.
+- Test-running by reviewers is **required for functional findings**, not opportunistic: a reviewer must reproduce any runtime-behavior claim by running code before reporting it (the functional-test harness auto-starts a MongoDB testcontainer when no `MONGODB_URI`/`ATLAS_URI` is set, so `dotnet test` always runs here), and include the repro in its report. One EF configuration suffices to confirm a behavioral bug; the `/test-all` multi-EF matrix is only needed when the concern is *divergence across* EF8/EF9/EF10, which — along with Atlas-only and encryption-infra paths — stays `[external-action]`.

--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -2,7 +2,7 @@
 name: test-all
 description: Build and run tests against all three EF version targets (EF8, EF9, EF10)
 argument-hint: "[optional: test filter or project name] [--model haiku|sonnet|opus]"
-allowed-tools: Bash(dotnet *), Bash(docker info), Read, Glob, Grep, Agent
+allowed-tools: Bash(dotnet *), Bash(docker info), Bash(printenv:*), Read, Glob, Grep, Agent
 ---
 
 # Test All EF Versions
@@ -24,27 +24,73 @@ Parse `$ARGUMENTS` for:
 1. net10.0 SDK — Run `dotnet --list-sdks` and verify a 10.x SDK is installed.
    If missing, stop with: "net10.0 SDK is not installed."
 
-2. Database connectivity — Check that either:
+A variable counts as a **real external database** only when it matches what
+`TestServer.GetOrInitialize` treats as a usable connection: it is set, **not
+empty or whitespace-only** (the harness treats blank as unset), and **not
+`"Disabled"` compared case-insensitively** (`Disabled` / `disabled` / `DISABLED`
+are all the skip-Atlas sentinel, not a connection). Apply this same test in both
+checks below.
+
+2. Database connectivity — Run `printenv MONGODB_URI`, then check that either:
    - Docker is available (`docker info` succeeds), OR
-   - `MONGODB_URI` environment variable is set.
-   If neither: stop with: "No database available. Start Docker or set `MONGODB_URI`."
+   - `MONGODB_URI` is a real external database (per the rule above).
+   `ATLAS_URI` does **not** satisfy this check: it only supplies the Atlas-specific
+   server, while the *default* server every test uses comes from `MONGODB_URI` or a
+   testcontainer (`TestServer.cs`). So without Docker or `MONGODB_URI`, the run
+   can't start even if `ATLAS_URI` is set.
+   If neither holds, stop with: "No database available. Start Docker or set `MONGODB_URI`."
 
-## Phase 2: Parallel Build & Test via Sub-agents
+3. Shared-database detection — Run `printenv MONGODB_URI` and `printenv ATLAS_URI`.
+   If `MONGODB_URI` **or** `ATLAS_URI` is a real external database (per the rule
+   above), the test runs hit that **shared database** instead of a per-process
+   testcontainer — record `SHARED_DB = true`, which forces serial execution in
+   Phase 2. Otherwise `SHARED_DB = false`: each EF version gets its own
+   testcontainer, so parallel execution is safe. (An empty/whitespace value or
+   `ATLAS_URI=Disabled` keeps `SHARED_DB = false`.)
 
-Spawn three sub-agents in parallel (one per EF version: EF8, EF9, EF10)
-using the Agent tool. Set the `model` parameter on each agent.
+## Phase 2: Build & Test via Sub-agents
 
-Each agent's prompt must include the full build and test commands:
+Run one build + test pass per EF version (EF8, EF9, EF10), each via the Agent
+tool with the `model` parameter set. **How they are scheduled depends on
+`SHARED_DB` from Phase 1:**
+
+- **`SHARED_DB = false`** (testcontainers) — spawn all three sub-agents **in
+  parallel** (one assistant message with three `Agent` blocks). Each EF version
+  builds into a separate output dir and gets its own testcontainer, so there is
+  no contention.
+- **`SHARED_DB = true`** (`MONGODB_URI` / `ATLAS_URI` set) — run the three
+  sub-agents **serially**: dispatch one, wait for it to finish, then dispatch the
+  next. The three versions would otherwise all hit the same database
+  concurrently and race on shared global state (the test suite disables
+  intra-assembly parallelization for exactly this reason — see
+  `tests/.../FunctionalTests/Usings.cs`). Never run them in parallel when a
+  shared database is configured.
+
+Each agent's prompt must run the build and test commands below. Both operate on
+the **whole solution `$SLN`**, which is required: it runs **all** test projects —
+`MongoDB.EntityFrameworkCore.UnitTests`, `MongoDB.EntityFrameworkCore.FunctionalTests`,
+and `MongoDB.EntityFrameworkCore.SpecificationTests`. Do not narrow to a single
+project unless the user passed an explicit filter (see Arguments).
 
   1. Build:  dotnet build $SLN -c "Debug EF{version}" -v quiet
   2. Test:   dotnet test  $SLN -c "Debug EF{version}" --no-build
                    --logger "console;verbosity=normal" -v quiet
 
+(If the user passed a filter/project arg, append it — e.g. `--filter "<expr>"`
+or the project path — to the test command; otherwise run the full solution so
+unit, functional, and specification tests all execute.)
+
 ## Important Rules
 
 - Always use absolute paths — never `cd` into directories.
 - Quote configuration names — they contain spaces ("Debug EF8").
-- Parallel is safe — each EF version builds into a separate output dir.
+- Parallelism depends on `SHARED_DB`: safe only when each EF version gets its own
+  testcontainer (`SHARED_DB = false`). When `MONGODB_URI`/`ATLAS_URI` point at a
+  shared database (`SHARED_DB = true`), run the versions serially — builds still
+  go to separate output dirs, but their tests must not hit the shared database
+  concurrently.
+- Run the full solution by default — unit, functional, and specification tests
+  must all run unless the user passed an explicit filter.
 - Continue on failure — if one version fails, still report the others.
 
 ## Phase 3: Console Summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,13 +23,28 @@ The MongoDB database provider for [Entity Framework Core](https://github.com/dot
 
 ## Versioning conventions
 
-This project does **not** follow strict semantic versioning — the major version tracks the EF Core major version it supports, so breaking changes can land in minor releases. See `BREAKING-CHANGES.md` for the running log. What counts as a break:
+This project does **not** follow strict semantic versioning — the major version tracks the EF Core major version it supports, so breaking changes can land in minor releases. See `BREAKING-CHANGES.md` for the running log.
+
+Breaks are always measured **against the latest released version of the assembly** (the most recent published NuGet package), **not** against the current state of `main`. A public API that was added and then changed or removed within the current unreleased development cycle never shipped, so it is not a break.
+
+Releases are tagged `v<major>.<minor>.<patch>` (with optional `-preview.N`), one line per EF major — `v8.*`, `v9.*`, `v10.*` ship in parallel. Find the baseline with the GitHub release list, **not** local `git tag` (a clone's tags are frequently stale and miss recent releases):
+- Absolute latest published version: `gh release list --limit 1 --json tagName,isLatest`.
+- Latest on a given EF major's line (the baseline that matters when assessing a change for that EF version): the highest non-preview `v<major>.*` from `gh release list --limit 100 --json tagName`.
+
+Diff the file at that release tag against the working tree to confirm a change is observable to an upgrading consumer (`git fetch --tags` first if the tag isn't local, then `git show <tag>:<path>`).
+
+What counts as a break:
 
 - Public API signature, default, or visibility changes.
 - Annotation key changes (under the `Mongo:` prefix — see `Metadata/MongoAnnotationNames.cs`) — these affect stored compiled models and design-time output.
 - Behavior changes affecting persisted document shape (element name, BSON representation, discriminator field, Guid representation, etc.).
-- `IMongoClientWrapper` interface changes (users are warned not to implement this themselves; it exists for DI).
+- `IMongoClientWrapper` / `IMongoDatabaseCreator` / `IMongoTransactionManager` interface changes (users are warned not to implement these themselves; they exist for DI, but they're observable public surface).
 - Default-value changes for `AutoTransactionBehavior`, conventions, or `BsonRepresentation` handling.
+
+What does **not** count as a break:
+
+- Changes to anything `internal` — regardless of `InternalsVisibleTo` (which exists only to expose internals to the test assemblies). Internal code is never part of the public surface.
+- Changes to the exception type thrown for an **unsupported** feature (a not-yet-implemented operator, an unsupported mapping, a guard rejecting something the provider doesn't support). Only the exception type of a supported, documented operation is part of the contract.
 
 ## Async conventions
 The provider follows EF Core's pattern, not the C# driver's. There is **no enforced sync/async pairing** of public methods — async surfaces exist where EF Core defines them (`*Async` variants) and where the underlying driver call is async. Library code uses `ConfigureAwait(false)` consistently. `CancellationToken` flows from EF Core through to driver calls without substitution; new async methods must take a `CancellationToken` and pass it on.


### PR DESCRIPTION
- Findings now lead with a terse (<=8 word) bold TL;DR headline.
- /review-ef-core-provider hard-depends on the superpowers plugin.
- Reviewers must reproduce functional findings by running code before reporting.
- Refined the breaking-change definition (internal, baseline, unsupported-feature exceptions).
- /test-all runs serially against a shared DB, and always runs unit + functional + spec tests.

## Review report format
Every finding emitted to the report now starts with a bold <=8-word TL;DR headline (e.g. "May throw NullReferenceException", "Exception type changed") before the one-sentence problem, in both the area and cross-cutting templates.

## Superpowers dependency
/review-ef-core-provider now errors out at a Step 0 gate if the superpowers plugin is unavailable. The run is framed via requesting-code-review; the fixer applies receiving-code-review / systematic-debugging / test-driven-development / brainstorming; and convergence is gated on verification-before-completion. Added Skill to the skill's allowed-tools.

## Reviewers must verify functional findings
Reviewers too often reported issues that don't reproduce. Every functional (runtime-behavior) finding must now be reproduced by running code before it is reported, with the repro included in the report. The functional-test harness connects via ATLAS_URI/MONGODB_URI or auto-starts a Docker testcontainer, so dotnet test always runs locally. Reviewers scaffold the repro via Bash (they have no Edit/Write) and must delete temp files to leave the tree clean (matters for --iterate). A test that can run locally is no longer [external-action]; only Atlas-only features, missing encryption infra (CRYPT_SHARED_LIB_PATH), or multi-EF divergence needing /test-all stay external. Replaced the "Do not run tests" directive in all functional reviewer agents (pr-summary stays opinion-only) and exempted repro blocks from the report word cap.

## Breaking-change definition
Clarified in api-stability-reviewer and AGENTS.md:
- Internal changes are never breaking, regardless of InternalsVisibleTo.
- Breaks are measured against the latest released version, not main; added a baseline-discovery recipe (gh release list, per-EF-major lines) since local git tags are frequently stale.
- Exception-type changes for unsupported features are not breaks.
- Added IMongoDatabaseCreator / IMongoTransactionManager to the break list.

## test-all
- When MONGODB_URI or ATLAS_URI is set, the three EF versions share one database and now run serially instead of in parallel (they would otherwise race on shared global state); testcontainer runs still go in parallel.
- Made explicit that the default run executes all test projects -- unit, functional, and specification -- via the whole solution.