### PR TITLE
EF-316: Harden Atlas TestContainers startup and readiness probe

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/LoggingTests.cs
@@ -452,8 +452,11 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     [InlineData(true)]
     public async Task Vector_query_warning_logged_with_sensitive_data(bool async)
     {
+        var atlasFixture = new AtlasSampleGuidesFixture();
+        await atlasFixture.InitializeAsync();
+
         List<string> logs = [];
-        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(atlasFixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);
@@ -476,8 +479,11 @@ public class LoggingTests(SampleGuidesFixture fixture, ITestOutputHelper testOut
     [InlineData(true)] // Ticket EF-270
     public async Task Vector_query_warning_logged_without_sensitive_data(bool async)
     {
+        var atlasFixture = new AtlasSampleGuidesFixture();
+        await atlasFixture.InitializeAsync();
+
         List<string> logs = [];
-        using var db = GuidesDbContext.Create(fixture.MongoDatabase, s =>
+        using var db = GuidesDbContext.Create(atlasFixture.MongoDatabase, s =>
         {
             logs.Add(s);
             testOutputHelper.WriteLine(s);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoDatabaseCreatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Storage/MongoDatabaseCreatorTests.cs
@@ -28,12 +28,13 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Storage;
 [XUnitCollection("StorageTests")]
 public class MongoDatabaseCreatorTests
 {
-    [Theory]
+    [AtlasTheory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task EnsureCreated_returns_true_and_seeds_when_database_did_not_exist(bool async)
     {
-        var database = await TemporaryDatabaseFixture.CreateInitializedAsync();
+        // GuidesDbContext defines a vector index, so EnsureCreated issues Atlas Search commands.
+        var database = await AtlasTemporaryDatabaseFixture.CreateInitializedAsync();
 
         await using var db = GuidesDbContext.Create(database.MongoDatabase);
 
@@ -50,12 +51,13 @@ public class MongoDatabaseCreatorTests
         Assert.Contains("PURPLE DINOSAUR", planets[0].parkingCars.Select(e => e.reg));
     }
 
-    [Theory]
+    [AtlasTheory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task EnsureCreated_returns_false_and_does_not_seed_when_database_already_exists(bool async)
     {
-        var database = await TemporaryDatabaseFixture.CreateInitializedAsync();
+        // GuidesDbContext defines a vector index, so EnsureCreated issues Atlas Search commands.
+        var database = await AtlasTemporaryDatabaseFixture.CreateInitializedAsync();
 
         await using var db = GuidesDbContext.Create(database.MongoDatabase);
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/AtlasTemporaryDatabaseFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/AtlasTemporaryDatabaseFixture.cs
@@ -19,6 +19,13 @@ public class AtlasTemporaryDatabaseFixture : TemporaryDatabaseFixtureBase
 {
     private TestServer? _server;
 
+    public static async Task<AtlasTemporaryDatabaseFixture> CreateInitializedAsync()
+    {
+        var fixture = new AtlasTemporaryDatabaseFixture();
+        await fixture.InitializeAsync();
+        return fixture;
+    }
+
     public override TestServer TestServer
         => _server!;
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/MongoDbAtlasBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/MongoDbAtlasBuilder.cs
@@ -41,7 +41,15 @@ public sealed class MongoDbAtlasBuilder : ContainerBuilder<MongoDbAtlasBuilder, 
     {
         Validate();
 
-        var builder = WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitIndicateReadiness()));
+        // The mongodb-atlas-local image starts mongod, then SIGTERMs and restarts it a couple of
+        // seconds later to inject the mongot/search wiring (mongotHost + searchIndexManagementHostAndPort).
+        // Until that restart completes, a vector query either hits the node mid-shutdown
+        // (MongoNodeIsRecoveringException, ShutdownInProgress) or finds mongot's query port (27027) not yet
+        // serving (Connection refused). Wait for the image's own healthcheck first - it only reports healthy
+        // after the restart and mongot wiring complete - then run the search-index probe as a final check.
+        var builder = WithWaitStrategy(Wait.ForUnixContainer()
+            .UntilContainerIsHealthy()
+            .AddCustomWaitStrategy(new WaitIndicateReadiness()));
 
         return new(builder.DockerResourceConfiguration);
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/MongoDbAtlasBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/MongoDbAtlasBuilder.cs
@@ -69,13 +69,13 @@ public sealed class MongoDbAtlasBuilder : ContainerBuilder<MongoDbAtlasBuilder, 
 
             using var client = new MongoClient(connectionString);
             var databaseName = Guid.NewGuid().ToString();
-            var weGood = false;
+            var ready = false;
 
             try
             {
                 var database = client.GetDatabase(databaseName);
                 var collectionName = Guid.NewGuid().ToString();
-                await database.CreateCollectionAsync(collectionName);
+                await database.CreateCollectionAsync(collectionName).ConfigureAwait(false);
 
                 var model = new CreateSearchIndexModel(
                     Guid.NewGuid().ToString(),
@@ -94,25 +94,26 @@ public sealed class MongoDbAtlasBuilder : ContainerBuilder<MongoDbAtlasBuilder, 
                     }
                     """));
 
-                await database.GetCollection<BsonDocument>(collectionName).SearchIndexes.CreateOneAsync(model);
-                using var _ = await database.GetCollection<BsonDocument>(collectionName).SearchIndexes.ListAsync();
-                weGood = true;
+                var collection = database.GetCollection<BsonDocument>(collectionName);
+                await collection.SearchIndexes.CreateOneAsync(model).ConfigureAwait(false);
+                using var _ = await collection.SearchIndexes.ListAsync().ConfigureAwait(false);
+                ready = true;
             }
-            catch
+            catch (Exception ex) when (ex is MongoException or TimeoutException)
             {
-                // Intentionally ignored.
+                // Container/search-index service not yet ready - will be retried on the next poll.
             }
 
             try
             {
-                await client.DropDatabaseAsync(databaseName);
+                await client.DropDatabaseAsync(databaseName).ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex) when (ex is MongoException or TimeoutException)
             {
-                // Intentionally ignored.
+                // Best-effort cleanup of the throwaway readiness database.
             }
 
-            return weGood;
+            return ready;
         }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SampleGuidesFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/SampleGuidesFixture.cs
@@ -31,3 +31,14 @@ public class SampleGuidesFixture : TemporaryDatabaseFixture
         SampleGuides.Populate(MongoDatabase);
     }
 }
+
+// Atlas-connected variant for tests that need Atlas search capabilities (e.g. vector search).
+// Connects via ATLAS_URI rather than the default MONGODB_URI server.
+public class AtlasSampleGuidesFixture : AtlasTemporaryDatabaseFixture
+{
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        SampleGuides.Populate(MongoDatabase);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestContainersTestServer.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Utilities/TestContainersTestServer.cs
@@ -30,10 +30,29 @@ public class TestContainersTestServer : TestServer
 
     public override async Task InitializeAsync()
     {
-        _container = new MongoDbAtlasBuilder().Build();
+        // Dispose any container left over from a prior failed start before allocating a new one.
+        if (_container != null)
+        {
+            await _container.DisposeAsync().ConfigureAwait(false);
+            _container = null;
+        }
 
-        await _container.StartAsync().ConfigureAwait(false);
+        var container = new MongoDbAtlasBuilder().Build();
 
+        try
+        {
+            // Bound startup so a stuck readiness probe (e.g. the Atlas Search Index Management
+            // service never coming up) fails fast instead of hanging the run indefinitely.
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            await container.StartAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            await container.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+
+        _container = container;
         _client = new(ConnectionString);
     }
 


### PR DESCRIPTION
Port the container-readiness hardening from mongo-mevd-provider#2 (which
itself was ported from this repo's test infra):

- MongoDbAtlasBuilder.WaitIndicateReadiness: scope the probe's catch to
  MongoException/TimeoutException instead of a bare catch, so unexpected
  exceptions propagate rather than being silently retried forever; add
  ConfigureAwait(false).
- TestContainersTestServer.InitializeAsync: bound StartAsync with a 5-minute
  CancellationTokenSource so a stuck readiness probe (e.g. the Atlas Search
  Index Management service never coming up) fails fast instead of hanging the
  run; dispose the container on a failed start and dispose any leftover
  container before allocating a new one.