### PR TITLE
EF-117: Cross-collection filtered Include, merged ThenIncludes, and ComplexNavigations spec suite

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -25,11 +25,11 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | Ticket | Comment subject | Description | Count |
 | --- | --- | --- | --- |
 | [EF-117](https://jira.mongodb.org/browse/EF-117) | _(no remaining `// Fails:` tags)_ | Cross-collection **Include**/`ThenInclude` is now implemented for the tested shapes. The five tests formerly tagged here were re-investigated: `Outer_identifier_correctly_determined_when_doing_include_on_right_side_of_left_join` (tracking + no-tracking) now **passes**; `Collection_include_over_result_of_single_non_scalar` and `Do_not_erase_projection_mapping_when_adding_single_projection` actually fail on cross-`DbSet` subquery translation (re-tagged **EF-X001**); `Included_one_to_many_query_with_client_eval` fails on driver client-evaluation (re-tagged **EF-X003**); and Include on a keyless entity (incl. multi-level) is a genuine PK-less `$lookup` gap (re-tagged **EF-X019**). EF-117 no longer has any active `// Fails:` tags. (Join/GroupJoin/SelectMany/RightJoin/subquery failures formerly tagged here were re-categorized — see EF-X001/EF-216/EF-220/EF-X016/EF-X017/EF-X018.) | 0 |
-| [EF-149](https://jira.mongodb.org/browse/EF-149) | `GroupBy issue EF-149` | `GroupBy` translation is severely limited; most non-trivial group-by shapes fail to translate. | 246 |
+| [EF-149](https://jira.mongodb.org/browse/EF-149) | `GroupBy issue EF-149` | `GroupBy` translation is severely limited; most non-trivial group-by shapes fail to translate. | 266 |
 | [EF-153](https://jira.mongodb.org/browse/EF-153) | `TagWith EF-153` | `TagWith(...)` content is silently dropped — does not appear in the emitted MQL. | 9 |
 | [EF-164](https://jira.mongodb.org/browse/EF-164) | `Missing property values issue EF-164` / `Projections issue EF-164` | BSON documents that omit a required scalar (or required navigation) throw on materialization — `Project_root_with_missing_scalars`, `Project_root_entity_with_missing_required_navigation`, etc. | 3 |
 | [EF-202](https://jira.mongodb.org/browse/EF-202) | `Entity equality issue EF-202` | Comparing two entities (`entity1 == entity2` / `Contains(entity)`) is not lowered to a key-equality comparison. | 4 |
-| [EF-216](https://jira.mongodb.org/browse/EF-216) | `Cross-document navigation access issue EF-216` / `Navigations issue EF-216` | Navigations that cross collection boundaries cannot be translated; surfaces as `Unsupported cross-DbSet query between ...`. Documented at the helper `AssertNoMultiCollectionQuerySupport`. | 265 |
+| [EF-216](https://jira.mongodb.org/browse/EF-216) | `Cross-document navigation access issue EF-216` / `Navigations issue EF-216` | Navigations that cross collection boundaries cannot be translated; surfaces as `Unsupported cross-DbSet query between ...`. Documented at the helper `AssertNoMultiCollectionQuerySupport`. | 270 |
 | [EF-217](https://jira.mongodb.org/browse/EF-217) | `Call ToString on DateTimeOffset EF-217` | `DateTimeOffset.ToString()` cannot be translated. | 2 |
 | [EF-218](https://jira.mongodb.org/browse/EF-218) | `Projecting DateTimeOffset members EF-218` | Projecting individual members of a `DateTimeOffset` (e.g. `.Year`, `.Hour`) is not supported. | 2 |
 | [EF-220](https://jira.mongodb.org/browse/EF-220) | `Multiple query roots issue EF-220` | Queries that reference more than one `DbSet<>` (Cartesian product / cross-join) are not translatable. Includes `SelectMany` across DbSets and tautology-predicate cross-joins. | 10 |
@@ -52,7 +52,7 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-246](https://jira.mongodb.org/browse/EF-246) | `DateTime subtraction issue EF-246` | `(dateA - dateB).TotalDays / TotalHours / TotalSeconds / TotalMilliseconds` is not translated. | 1 |
 | [EF-247](https://jira.mongodb.org/browse/EF-247) | `Regex with non-constant pattern issue EF-247` | `Regex.IsMatch` with a non-constant pattern is not translated. | 1 |
 | [EF-248](https://jira.mongodb.org/browse/EF-248) | `Translate String.FirstOrDefault and String.LastOrDefault issue EF-248` | `String.FirstOrDefault()` / `LastOrDefault()` (LINQ-on-string) is not translated. | 2 |
-| [EF-249](https://jira.mongodb.org/browse/EF-249) | `checked issue EF-249` | `checked { ... }` arithmetic is not honored — the `Checked_context_with_arithmetic_does_not_fail` test sees a different exception than EF expects. | 1 |
+| [EF-249](https://jira.mongodb.org/browse/EF-249) | `checked issue EF-249` | `checked { ... }` arithmetic is not honored — the `Checked_context_with_arithmetic_does_not_fail` test sees a different exception than EF expects. | 2 |
 | [EF-252](https://jira.mongodb.org/browse/EF-252) | `Concurrency detector tests broken EF-252` | `Throws_on_concurrent_query_first/list` — the concurrency detector does not fire as the EF base test expects. | 2 |
 | [EF-253](https://jira.mongodb.org/browse/EF-253) | `Multiple ordering issue EF-253` | `OrderBy(x).ThenBy(x)` on the same column with different directions does not emit the expected MQL. | 1 |
 | [EF-254](https://jira.mongodb.org/browse/EF-254) | `Take zero EF-254` | `.Skip(0).Take(0)` with a parameter does not produce the expected empty result. | 1 |
@@ -80,7 +80,7 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 
 | Temp ticket | Subject | Count |
 | --- | --- | --- |
-| EF-X001 | Sub-query selection across DbSets is not translated | 144 |
+| EF-X001 | Sub-query selection across DbSets is not translated | 198 |
 | EF-X002 | Provider throws a different exception than the EF translation-failure message | 44 |
 | EF-X003 | Driver-level feature gaps surfaced as test failures | 19 |
 | EF-X004 | Float `Sum`/`Average` truncation (likely duplicate of EF-228) | 1 |
@@ -99,8 +99,12 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 | EF-X017 | Join shapes not translated | 5 |
 | EF-X018 | RightJoin not supported | 1 |
 | EF-X019 | Include on keyless entity not supported (no primary key for $lookup join) | 2 |
-| EF-X020 | Cross-collection Include/join/navigation not translated on EF8/EF9 (works on EF10) | 168 |
-| EF-X021 | Filtered Include / query filter on cross-collection target not translated | 0 |
+| EF-X020 | Cross-collection Include/join/navigation not translated on EF8/EF9 (works on EF10) | 193 |
+| EF-X021 | Filtered Include / query-filter predicate on cross-collection target — translated (top-level, nested-target, and best-effort query filters) | 0 (resolved) |
+| EF-X022 | Cross-collection filtered Include returns wrong data (included collection not limited) | 0 (resolved) |
+| EF-X023 | Cross-collection multiple / self-ref / required Include returns wrong data — **deferred to EF-317** (needs depth-aware join model + FK-based nav resolution) | 5 |
+| EF-X024 | Cross-collection reference Include (multi-include / self-ref / nested) returns wrong data / throws "Document element is missing for required non-nullable property" — **deferred to EF-317** | 5 |
+| EF-X025 | Merged Include chains on one navigation with interleaved collection + reference ThenIncludes dropped a branch | 0 (resolved) |
 
 ### EF-X001 — Sub-query selection across DbSets is not translated
 Comment patterns: `// Fails: Subquery selection EF-X001`, `// Fails: Subqueries not supported EF-X001`, `// Fails: No subquery support EF-X001`.
@@ -182,7 +186,7 @@ Affected: 2 tests (`NorthwindKeylessEntitiesQueryMongoTest.KeylessEntity_with_in
 ### EF-X020 — Cross-collection Include/join/navigation not translated on EF8/EF9
 Comment pattern: `// Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020`.
 Test-body pattern: the override is wrapped in `#if EF8 || EF9` / `#else`. The `#if EF8 || EF9` branch asserts the translation failure (`AssertTranslationFailed(() => base.X(...))`); the `#else` branch keeps the working EF10 baseline (the real `base` call plus its `AssertMql(...)`).
-Affected: 168 tests across `NorthwindEFPropertyIncludeQueryMongoTest`, `NorthwindStringIncludeQueryMongoTest`, `NorthwindIncludeQueryMongoTest`, `NorthwindIncludeNoTrackingQueryMongoTest`, `NorthwindNavigationsQueryMongoTest`, `NorthwindMiscellaneousQueryMongoTest`, `NorthwindJoinQueryMongoTest`, `NorthwindAggregateOperatorsQueryMongoTest`, `NorthwindAsNoTrackingQueryMongoTest`, `NorthwindKeylessEntitiesQueryMongoTest`, `NorthwindSelectQueryMongoTest`, `NorthwindSetOperationsQueryMongoTest`, `NorthwindWhereQueryMongoTest`, and `BuiltInDataTypesMongoTest`. These are the cross-collection Include/`ThenInclude`/join/navigation shapes implemented for the EF10-targeted query pipeline. On EF8/EF9 the upstream nav-expansion / query pipeline produces a different expression shape (e.g. an extra `.OrderBy(o => o.OrderID)` injected during navigation expansion) that the EF10-targeted translator does not handle, so translation fails with EF Core's `InvalidOperationException` "could not be translated" (a few also throw the provider's `ExpressionNotSupportedException`); the same query translates and runs on EF10. The provider's local `AssertTranslationFailed` helper swallows whichever exception is thrown, so both shapes are covered. Four `Include_reference_dependent_already_tracked` overrides (in the four Include suites) emit MQL from a first principal query *before* the Include sub-query fails to translate, so their `#if EF8 || EF9` branch asserts only the translation failure and omits the empty `AssertMql()`. `BuiltInDataTypesMongoTest.Can_read_back_bool_mapped_as_int_through_navigation` is split three ways (a nested `#if EF9` inside the file's `#if !EF8` branch, plus the `#else` EF8 branch) because that file uses async signatures on EF9/EF10 and sync `void` signatures on EF8.
+Affected: 190 tests across `NorthwindEFPropertyIncludeQueryMongoTest`, `NorthwindStringIncludeQueryMongoTest`, `NorthwindIncludeQueryMongoTest`, `NorthwindIncludeNoTrackingQueryMongoTest`, `NorthwindNavigationsQueryMongoTest`, `NorthwindMiscellaneousQueryMongoTest`, `NorthwindJoinQueryMongoTest`, `NorthwindAggregateOperatorsQueryMongoTest`, `NorthwindAsNoTrackingQueryMongoTest`, `NorthwindKeylessEntitiesQueryMongoTest`, `NorthwindSelectQueryMongoTest`, `NorthwindSetOperationsQueryMongoTest`, `NorthwindWhereQueryMongoTest`, `BuiltInDataTypesMongoTest`, and `ComplexNavigationsCollectionsQueryMongoTest` (22 — reference/optional/multiple Include shapes that run on EF10 but throw `ArgumentOutOfRangeException`/translation failure on the EF8/EF9 nav-expansion pipeline). These are the cross-collection Include/`ThenInclude`/join/navigation shapes implemented for the EF10-targeted query pipeline. On EF8/EF9 the upstream nav-expansion / query pipeline produces a different expression shape (e.g. an extra `.OrderBy(o => o.OrderID)` injected during navigation expansion) that the EF10-targeted translator does not handle, so translation fails with EF Core's `InvalidOperationException` "could not be translated" (a few also throw the provider's `ExpressionNotSupportedException`); the same query translates and runs on EF10. The provider's local `AssertTranslationFailed` helper swallows whichever exception is thrown, so both shapes are covered. Four `Include_reference_dependent_already_tracked` overrides (in the four Include suites) emit MQL from a first principal query *before* the Include sub-query fails to translate, so their `#if EF8 || EF9` branch asserts only the translation failure and omits the empty `AssertMql()`. `BuiltInDataTypesMongoTest.Can_read_back_bool_mapped_as_int_through_navigation` is split three ways (a nested `#if EF9` inside the file's `#if !EF8` branch, plus the `#else` EF8 branch) because that file uses async signatures on EF9/EF10 and sync `void` signatures on EF8.
 
 ### EF-216 — wrong-data on EF10 (cross-collection navigation), unsupported on EF8/EF9
 
@@ -209,20 +213,167 @@ multi-hop navigation lowering is fixed.
 
 ---
 
-### EF-X021 — Filtered Include / query filter on cross-collection target not translated
+### EF-X021 — Filtered Include / query filter on cross-collection target (mostly translated)
 Comment pattern: `// Fails: Filtered Include / query-filter predicate on a cross-collection $lookup target is not translated EF-X021`.
-Affected: 0 spec overrides today (no specification test currently exercises a *filtered* cross-collection Include
-with a predicate, nor a `HasQueryFilter` on a cross-collection dependent — `Filtered_include_with_multiple_ordering`
-only uses OrderBy/Skip/Take, which *are* translated). Tracked because the provider now **fails loudly** for these
-shapes instead of silently dropping the predicate. A user filtered-Include predicate
-(`.Include(c => c.Orders.Where(o => ...))`) and a dependent-side `HasQueryFilter` (soft-delete / multi-tenant) both
-lower to a `Where` inside the collection-Include subquery; that `Where` is **not** the synthetic FK-correlation join
-condition and is not yet translated into the `$lookup` sub-pipeline `$match`. Previously it was silently dropped
-(returning *all* dependents and bypassing the filter — wrong data); the provider now throws a translation failure
-(`CoreStrings.TranslationFailed`). Translating the predicate into the sub-pipeline `$match` is the follow-up feature
-this ticket tracks. Functional coverage:
-`CrossCollectionIncludeTests.Filtered_collection_include_predicate_is_not_silently_dropped` and
-`CrossCollectionIncludeTests.Query_filter_on_collection_include_target_is_not_silently_dropped`.
+
+A user filtered-Include predicate (`.Include(c => c.Orders.Where(o => ...))`) and a dependent-side `HasQueryFilter`
+(soft-delete / multi-tenant) both lower to a `Where` inside the collection-Include subquery. That `Where` is **not** the
+synthetic FK-correlation join condition; it is now **translated into the `$lookup` sub-pipeline `$match`** by rendering
+the predicate through the EF entity serializer via the driver (the same mechanism the VectorSearch pre-filter uses) — see
+`MongoEFToLinqTranslatingExpressionVisitor.EmitLookupStages` / `RenderFilterPredicateMatch` and the captured
+`LookupExpression.FilterPredicates`. The `$match` is emitted after the FK-correlation `$match` and before any paging
+(`$sort`/`$skip`/`$limit`). Top-level filtered Includes (`Filtered_include_basic_Where(_EF_Property)`,
+`Filtered_include_after_reference_navigation`, `Filtered_include_on_ThenInclude(_EF_Property)`,
+`Filtered_include_and_non_filtered_include_on_same_navigation{1,2}`, `Filtered_include_same_filter_set_on_same_navigation_twice`,
+`Filtered_include_after_different_filtered_include_same_level`, `Filtered_include_variable_used_inside_filter`,
+`Filtered_include_context_accessed_inside_filter`) now translate on EF10. **Nested**-ThenInclude-target filters
+(`Filtered_include_after_different_filtered_include_different_level`) are also translated: the hand-assembled nested
+`$lookup` cannot render a `$match` itself, so its predicate is captured on `LookupExpression.PendingNestedFilterRenders`
+and rendered (in place into the nested sub-pipeline `BsonArray`) by `EmitLookupStages`. The reference-`ThenInclude`-target
+cases are EF10-only (the broader cross-collection Include is unsupported on EF8/EF9 — see EF-X020 — so their overrides
+split with `#if EF8 || EF9`).
+
+A source-side query filter reached *after* the walk descends through a ThenInclude's `Select`/`Join` is captured as a
+**best-effort** predicate (`LookupExpression.BestEffortFilterPredicates`): rendered into the sub-pipeline `$match` when the
+lookup already uses the pipeline form and the driver can express it, otherwise dropped — preserving the pre-EF-X021
+behavior for redundant query filters that may reference a navigation with no `$lookup` representation (e.g.
+`NorthwindQueryFiltersQueryMongoTest`). Functional coverage:
+`CrossCollectionIncludeTests.Filtered_collection_include_predicate_is_translated_to_sub_pipeline_match` and
+`CrossCollectionIncludeTests.Query_filter_on_collection_include_target_is_translated_to_sub_pipeline_match`.
+
+All filtered-Include / query-filter predicate cases are now translated; EF-X021 has no remaining `// Fails:` tags.
+Three formerly-tagged overrides were re-tagged to their true root cause: `Filtered_include_outer_parameter_used_inside_filter`
+→ **EF-X001** (a `Select`-projected correlated cross-DbSet subquery whose filter references the outer parameter,
+`x => x.Id != l1.Id` — not a filtered-Include predicate), and `Include_collection_multiple_with_filter(_EF_Property)`
+→ **EF-216** (a root-level `Where(... .Count() > 0)` correlated cross-collection subquery).
+
+### EF-X022 — Cross-collection filtered Include returns wrong data (included collection not limited) — RESOLVED
+The filtered-Include `Skip`/`Take`/`OrderBy` were dropped from the `$lookup` sub-pipeline **when the filtered Include
+was combined with a `ThenInclude`**: the ThenInclude lowers the collection subquery to
+`Select(<filtered source>.LeftJoin/Join(<thenInclude target>), e => Include(e, …))`, and
+`ExtractFilteredIncludePipeline` (in `MongoProjectionBindingExpressionVisitor`) stopped at the outermost `Select`
+(hitting its `default` branch) before reaching the inner `OrderBy`/`Skip`/`Take`, so the included collection was
+over-populated (e.g. expected 4, actual 5). Fixed by descending the walk through `Select`/`Join`/`LeftJoin` into their
+source so the paging operators below are collected (a `Where` reached *after* descending is treated as a stop boundary
+so plain query-filtered includes are not newly re-interpreted). Of the original 6 tests:
+`Filtered_include_complex_three_level_with_middle_having_filter1`/`2` are now green;
+`Filtered_include_Take_with_another_Take_on_top_level`,
+`Filtered_include_and_non_filtered_include_followed_by_then_include_on_same_navigation`,
+`Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_FirstOrDefault_on_top_level` and
+`..._and_unordered_Take_on_top_level` now apply the paging correctly but still fail on the **reference ThenInclude
+materialization** and so moved to [EF-X024](#ef-x024--cross-collection-reference-include-returns-wrong-data--missing-required-element).
+
+### EF-X023 — Cross-collection multiple / self-ref / required Include returns wrong data
+Comment pattern: `// Fails: Cross-collection multiple/self-ref/required Include returns wrong data EF-X023`.
+Affected: 5 tests in `ComplexNavigationsCollectionsQueryMongoTest` — `Include_collection_multiple`,
+`Multiple_complex_includes_self_ref(_EF_Property)`, `Required_navigation_with_Include`,
+`Required_navigation_with_Include_ThenInclude`. The query runs but a navigation is mis-populated (boolean/identity
+assertions differ, e.g. expected `True`, actual `False`) — multiple sibling collection Includes, self-referencing
+Includes, and required-reference Includes across collections do not all materialize correctly. Not baseline-able (base
+asserts correct data); the override asserts the current failure. (`Include_collection_then_reference`,
+`Include_collection_followed_by_include_reference` and `Include_collection_ThenInclude_two_references` — the
+collection-then-reference shapes — are now **fixed** by the nested-navigation null guard described under EF-X024.)
+
+**Disposition — deferred to [EF-317](https://jira.mongodb.org/browse/EF-317).** A scoping pass confirmed these are not a
+localized shaper/null-key bug but the same structural deficit as EF-X024 (see the shared disposition under EF-X024): the
+`$lookup` join-emulation models cross-collection joins with a single global `UsesDriverJoinFields` boolean and two reserved
+field names (`_outer` root, `_inner` "the one reference"), and resolves intermediate navigations by *first navigation whose
+target type matches* (`MongoQueryableMethodTranslatingExpressionVisitor.cs:442-443,485-490`). Self-ref and
+multiple-navigations-to-the-same-type therefore bind the wrong FK, and >1 reference hop produces a document shape
+(`_outer._outer…` or a flat `_lookup_<Nav>` chain) the single-level shaper deref cannot read. Correcting these requires a
+depth/per-navigation-aware join document model and FK-based navigation resolution — i.e. rebuilding the join-emulation that
+EF-317 (native driver `LeftJoin`) is slated to replace. The overrides assert the failure via `AssertTranslationFailed`.
+
+### EF-X024 — Cross-collection reference Include returns wrong data / missing required element
+Comment patterns: `// Fails: Cross-collection reference Include missing required element on materialization EF-X024` and
+`// Fails: Cross-collection reference ThenInclude returns wrong data (filtered paging now applied; reference not materialized) EF-X024`.
+Root cause (one mechanism, two symptoms): an optional cross-collection reference lowers to `$lookup` +
+`$unwind {preserveNullAndEmptyArrays:true}`. When the reference has no match `_inner` should be absent, but a *later*
+`$lookup` writing a dotted `as` path (`_inner._lookup_<Nav>`, for a collection/reference nested under the reference)
+makes MongoDB **synthesise the parent `_inner`** document containing only the nested array — so `_inner` is
+present-but-keyless. The non-nullable EF materializer then reads the missing required key and throws
+`InvalidOperationException: Document element is missing for required non-nullable property '...'` (typically the joined
+dependent's `Id`), or builds a wrong/empty entity that fixup attaches → an `AssertInclude` data diff.
+
+**Partially fixed (pipeline-level, EF-X024):** a shaper-level fix (key-presence guard / probe-leniency) was first tried
+but had an unacceptable blast radius (regressed ~130 unrelated materialization tests). The committed fix instead emits,
+after a `$lookup` whose `as` writes under an OPTIONAL driver-join reference parent (`_inner` /
+`_lookup_<RefNav>`), a `$set` that re-nulls that parent when its `_id` is missing — so the synthesized-but-keyless
+document becomes absent and the existing left-join null guard nulls the entity (see
+`MongoEFToLinqTranslatingExpressionVisitor.EmitLookupStages` + `LookupExpression.NormalizeParent`). This greens the
+single reference-then-collection cases (`Include_reference_followed_by_include_collection`,
+`Include_reference_and_collection_order_by`, `Include_reference_ThenInclude_collection_order_by`,
+`Include_reference_collection_order_by_reference_navigation`, `Optional_navigation_with_Include_and_order`,
+`Optional_navigation_with_order_by_and_Include`).
+
+**Also fixed (nested-navigation null guard):** a second class of failure was a cross-collection REFERENCE materialized
+*inside a collection element* (`Include(collection).ThenInclude(reference)`). `BsonDocumentInjectingExpressionVisitor`
+wraps each entity shaper with a `joined document is null => null entity` guard, but it did not recurse into a
+`CollectionShaperExpression`'s element shaper — so the nested reference's key-presence test read a missing `_lookup_<Nav>`
+key as the value type's default (e.g. `0`) and materialized a **phantom entity** (`Id = 0`) instead of null. Fixed by
+having that visitor wrap the ThenInclude navigation entities of a collection element (its `IncludeExpression`'s
+`NavigationExpression`s), while leaving the element entity itself directly bound. This greens the
+collection-then-reference and filtered-include-with-reference shapes
+(`Include_collection_then_reference`, `Include_collection_followed_by_include_reference`,
+`Include_collection_ThenInclude_two_references`, `Filtered_include_Take_with_another_Take_on_top_level`,
+`Filtered_include_and_non_filtered_include_followed_by_then_include_on_same_navigation`,
+`Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_FirstOrDefault_on_top_level`,
+`..._and_unordered_Take_on_top_level`).
+
+**Also fixed (driver-join nested-reference field name):** in driver-join mode (`_outer`/`_inner`, used when the query
+also has a top-level reference Include) a cross-collection reference nested under a *collection* element was read from
+the driver-join `_inner` field (the single top-level reference) instead of its own `_lookup_<Nav>` alias —
+`GetCrossCollectionFieldName` blanket-returned `"_inner"` whenever `UsesDriverJoinFields`. Fixed by mirroring
+`GetCrossCollectionRootDocument`'s nesting test: a reference whose parent is a collection element (not the query root)
+reads its `_lookup_<Nav>` alias. Greens `Multiple_complex_includes(_EF_Property)`, `Multiple_complex_include_select`,
+`Include_nested_with_optional_navigation`, `Optional_navigation_with_Include_ThenInclude`.
+
+Still affected: 5 tests (EF-X024) in `ComplexNavigationsCollectionsQueryMongoTest` — multi-optional / partial-build
+shapes that still throw the missing-element error via flat-mode synthesis or deeper nesting:
+`Multiple_optional_navigation_with_Include(_string_based)`,
+`Include_partially_added_before_Where_and_then_build_upon(_with_filtered_include)`,
+`Complex_multi_include_with_order_by_and_paging_joins_on_correct_key`. Same family as
+[EF-164](https://jira.mongodb.org/browse/EF-164). The overrides assert the failure via `AssertTranslationFailed`.
+
+**Disposition — deferred to [EF-317](https://jira.mongodb.org/browse/EF-317).** A scoping pass (covering the 5 EF-X024
+tests above plus the 5 EF-X023 tests — they share one root cause) concluded the remaining failures are **not** fixable by a
+bounded shaper / `$set` change, and deferred them. Findings:
+- The committed `NormalizeParent` `$set` re-null is **necessary but not sufficient**: a prototype extending it to the flat
+  `_lookup_<Nav>` path stopped the crash but data stayed wrong. A shaper-side "treat a present-but-keyless joined
+  sub-document as null" guard (moving the key-presence test into `BsonDocumentInjectingExpressionVisitor` / `BsonBinding` so
+  it does not depend on the pipeline removing the field) is similarly bounded but addresses only the single-level
+  unmatched-optional symptom.
+- Two structural deficits block the rest, neither localized: **(1)** the join document model carries a single global
+  `UsesDriverJoinFields` boolean and exactly two reserved names (`_outer` root, `_inner` the lone reference), and the shaper
+  derefs `_outer` only once (`MongoProjectionBindingRemovingExpressionVisitor.cs:589-591`) — so a 2nd reference hop
+  (`_outer._outer…`, emitted as a doubled `{$project:{_outer:$$ROOT}}`) or a flat `_lookup_<Nav>` chain is unreadable;
+  **(2)** intermediate navigations are resolved target-type-first
+  (`MongoQueryableMethodTranslatingExpressionVisitor.cs:442-443,485-490`), so self-ref and multiple-navs-to-the-same-type
+  bind the wrong FK (the wrong-FK aliases visible in the `Required_navigation_with_Include` / self-ref baselines).
+- Correcting these requires a **depth/per-navigation-aware join document model + FK-based navigation resolution** — i.e.
+  rebuilding the manual `$lookup`/`$unwind` join-emulation that the `TODO(EF-317)` headers in
+  `MongoProjectionBindingExpressionVisitor.Lookup.cs` and `MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs` say is the
+  stopgap to be removed when the C# driver ships native `LeftJoin`. Low ROI to rebuild ahead of that.
+
+One genuinely bounded prerequisite was identified but **greens 0 of the 10 on its own**: replacing the target-type-first
+navigation resolution with FK-based resolution (mirroring `ResolveCollectionNavigation`,
+`MongoProjectionBindingExpressionVisitor.Lookup.cs:333`), which closes a latent silent-wrong-navigation hazard. Best folded
+into the EF-317 work rather than shipped standalone.
+
+### EF-X025 — Merged Include chains dropped an interleaved ThenInclude branch — RESOLVED
+When two Include chains are merged on the same first-level collection navigation but carry **different** ThenInclude
+targets — e.g. `.Include(l1.OneToMany_Optional1.Where(...).Take(2)).ThenInclude(l2.OneToMany_Optional2)` (nested
+collection) together with `.Include(l1.OneToMany_Optional1).ThenInclude(l2.OneToOne_Required_FK2)` (nested reference) —
+EF lowers them to **interleaved** collection and reference `IncludeExpression`s in the merged subquery selector.
+`ExtractThenIncludesFromSubquery` previously walked them with two sequential, type-gated loops (all collections, then
+all references), so whichever kind was nested under the other was silently dropped from the `$lookup` pipeline —
+returning wrong data (`AssertInclude` mismatch). (The earlier `ArgumentNullException` characterization was stale; by the
+time this was fixed the filter-predicate gap was already handled under EF-X021, leaving only the dropped branch.)
+
+Fixed by replacing the two loops with a single walk that dispatches each nested `IncludeExpression` by navigation kind,
+emitting all branches regardless of interleaving order
+(`MongoProjectionBindingExpressionVisitor.ExtractThenIncludesFromSubquery` / `AddCollectionLookupStages`). Also fixed
+`Filtered_include_same_filter_set_on_same_navigation_twice_followed_by_ThenIncludes`, which had the same latent drop.
 
 ## Audit findings — tagging hygiene
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/LookupExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/LookupExpression.cs
@@ -14,6 +14,7 @@
  */
 
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.Bson;
@@ -112,8 +113,42 @@ internal sealed class LookupExpression
     /// </summary>
     public List<BsonDocument> PipelineStages { get; } = [];
 
-    /// <summary>Whether this lookup uses a pipeline (filtered Include).</summary>
-    public bool HasPipeline => PipelineStages.Count > 0;
+    /// <summary>
+    /// User filtered-Include / dependent query-filter predicates applied to this cross-collection target
+    /// (e.g. <c>.Include(c =&gt; c.Orders.Where(o =&gt; o.Total &gt; 100))</c>), in execution order. Captured as raw
+    /// element-parameter lambdas during pipeline extraction and rendered to a sub-pipeline <c>$match</c> by the
+    /// driver (using the EF entity serializer) when the $lookup is emitted — the provider never hand-builds the
+    /// predicate BSON. The <c>$match</c> stages are emitted before any paging (<c>$sort</c>/<c>$skip</c>/<c>$limit</c>).
+    /// </summary>
+    public List<LambdaExpression> FilterPredicates { get; } = [];
+
+    /// <summary>
+    /// Best-effort filter predicates (a source-side query filter reached after descending through a
+    /// ThenInclude's Select/Join). Rendered into the sub-pipeline <c>$match</c> if the driver can express
+    /// them AND the lookup already uses the pipeline form, otherwise DROPPED — these are frequently redundant
+    /// query filters and may reference a navigation that has no <c>$lookup</c> sub-pipeline representation.
+    /// They intentionally do NOT force the pipeline form (so a lookup that would otherwise use
+    /// localField/foreignField keeps that shape, dropping the predicate as before). Distinct from
+    /// <see cref="FilterPredicates"/>, which are explicit user filtered-Include predicates that fail loudly if
+    /// unrenderable. EF-X021.
+    /// </summary>
+    public List<LambdaExpression> BestEffortFilterPredicates { get; } = [];
+
+    /// <summary>Whether this lookup uses a pipeline (filtered Include) rather than localField/foreignField.</summary>
+    public bool HasPipeline => PipelineStages.Count > 0 || FilterPredicates.Count > 0;
+
+    /// <summary>
+    /// Filter-predicate `$match` stages for NESTED ThenInclude targets that are deferred to
+    /// <see cref="Visitors.MongoEFToLinqTranslatingExpressionVisitor.EmitLookupStages"/> for rendering. A nested
+    /// `$lookup` is hand-assembled during projection binding (where the EF→driver-LINQ visitor / serializer are
+    /// unavailable), so its user-filter predicate cannot be rendered there. Each entry records the nested
+    /// pipeline (<see cref="BsonArray"/>, mutated in place before serialization), the index at which to insert
+    /// the rendered `$match` (after the FK-correlation `$match`, before paging), the predicate lambdas, and the
+    /// nested target entity type whose serializer renders them. Collected on the ROOT lookup (bubbled up through
+    /// nesting). EF-X021.
+    /// </summary>
+    public List<(BsonArray Pipeline, int Index, IReadOnlyList<LambdaExpression> Predicates, IEntityType TargetEntityType)>
+        PendingNestedFilterRenders { get; } = [];
 
     /// <summary>Whether this lookup is for a single reference (not a collection).</summary>
     public bool IsReference => !Navigation.IsCollection;
@@ -131,4 +166,15 @@ internal sealed class LookupExpression
     /// reads the <c>_lookup_&lt;Nav&gt;</c> array via <c>{ $size: ... }</c> and so must see it already present.
     /// </summary>
     public bool InjectAfterRoot { get; set; }
+
+    /// <summary>
+    /// Whether the parent sub-document of this lookup's dotted <see cref="As"/> path (an OPTIONAL
+    /// cross-collection reference that was left-joined with <c>preserveNullAndEmptyArrays</c>) must be
+    /// re-nulled when its key is absent. Writing a nested <c>$lookup</c> result into a dotted path
+    /// (<c>_inner._lookup_&lt;Nav&gt;</c>) makes MongoDB synthesise the parent even when the reference had no
+    /// match, producing a present-but-keyless document that defeats the left-join null guard. Only set for
+    /// optional reference parents — required references always match (no synthesis) and the root is never
+    /// absent. See <see cref="Visitors.MongoEFToLinqTranslatingExpressionVisitor"/>. EF-X024.
+    /// </summary>
+    public bool NormalizeParent { get; set; }
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/BsonDocumentInjectingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/BsonDocumentInjectingExpressionVisitor.cs
@@ -77,6 +77,16 @@ internal sealed class BsonDocumentInjectingExpressionVisitor : ExpressionVisitor
 
                     AllVariables.Add(arrayVariable);
 
+                    // Guard nested entities materialized per collection element — in particular cross-collection
+                    // reference ThenIncludes read from "_lookup_<Nav>" sub-documents — with the "joined document
+                    // is null => null entity" check. Without this the nested reference's key-presence test reads a
+                    // missing key as the value type's default (e.g. 0) and materializes a phantom entity instead
+                    // of null. Only the ThenInclude navigation entities are wrapped; the collection ELEMENT itself
+                    // reads from a real array element (never null) and must keep its direct binding. EF-X023/X024.
+                    var updatedCollectionShaper = collectionShaperExpression.Update(
+                        collectionShaperExpression.Projection,
+                        WrapNestedNavigations(collectionShaperExpression.InnerShaper));
+
                     var expressions = new List<Expression>
                     {
                         Expression.Assign(
@@ -87,7 +97,7 @@ internal sealed class BsonDocumentInjectingExpressionVisitor : ExpressionVisitor
                         Expression.Condition(
                             Expression.Equal(arrayVariable, Expression.Constant(null, arrayVariable.Type)),
                             Expression.Constant(null, collectionShaperExpression.Type),
-                            collectionShaperExpression)
+                            updatedCollectionShaper)
                     };
 
                     return Expression.Block(
@@ -99,4 +109,19 @@ internal sealed class BsonDocumentInjectingExpressionVisitor : ExpressionVisitor
 
         return base.VisitExtension(extensionExpression);
     }
+
+    /// <summary>
+    /// Wrap the ThenInclude navigation entities of a collection element's inner shaper with the
+    /// "joined document is null => null entity" guard, without wrapping the element entity itself. The inner
+    /// shaper is an <see cref="IncludeExpression"/> chain whose innermost <c>EntityExpression</c> is the
+    /// collection element (read from a real array element — never null, keeps its direct binding) and whose
+    /// <c>NavigationExpression</c>s are the cross-collection reference/collection ThenIncludes that need the
+    /// guard. EF-X023/X024.
+    /// </summary>
+    private Expression WrapNestedNavigations(Expression innerShaper)
+        => innerShaper is IncludeExpression include
+            ? include.Update(
+                WrapNestedNavigations(include.EntityExpression),
+                Visit(include.NavigationExpression))
+            : innerShaper;
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
@@ -656,6 +656,21 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             return query;
         }
 
+        // Render deferred filter predicates for NESTED ThenInclude targets, mutating each nested sub-pipeline
+        // (a BsonArray captured by reference during projection binding) in place before it is serialized — the
+        // rendered $match is inserted after the FK-correlation $match and before paging. EF-X021.
+        foreach (var lookup in lookupList)
+        {
+            foreach (var (nestedPipeline, index, predicates, targetEntityType) in lookup.PendingNestedFilterRenders)
+            {
+                var insertAt = index;
+                foreach (var predicate in predicates)
+                {
+                    nestedPipeline.Insert(insertAt++, RenderFilterPredicateMatch(predicate, targetEntityType));
+                }
+            }
+        }
+
         var sourceType = query.Type.TryGetItemType() ?? _source.Type.TryGetItemType()!;
         var appendStageMethod = typeof(MongoQueryable).GetMethod(nameof(MongoQueryable.AppendStage))!
             .MakeGenericMethod(sourceType, sourceType);
@@ -668,13 +683,33 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             BsonDocument lookupDoc;
             if (lookup.HasPipeline)
             {
-                // Pipeline form: used for filtered Includes (OrderBy, Skip, Take on the included collection).
+                // Pipeline form: used for filtered Includes (OrderBy, Skip, Take, user Where on the included
+                // collection).
                 var pipeline = new BsonArray
                 {
                     new BsonDocument("$match",
                         new BsonDocument("$expr",
                             new BsonDocument("$eq", new BsonArray { $"${lookup.ForeignField}", "$$localField" })))
                 };
+
+                // Render any user filtered-Include predicates to a $match, immediately after the FK-correlation
+                // $match and before paging ($sort/$skip/$limit). These fail loudly if unrenderable. EF-X021.
+                foreach (var predicate in lookup.FilterPredicates)
+                {
+                    pipeline.Add(RenderFilterPredicateMatch(predicate, lookup.Navigation.TargetEntityType));
+                }
+
+                // Best-effort predicates (source-side query filters below a ThenInclude descent): render where
+                // possible, otherwise drop — they are frequently redundant and may reference a navigation that
+                // has no sub-pipeline representation. EF-X021.
+                foreach (var predicate in lookup.BestEffortFilterPredicates)
+                {
+                    if (TryRenderFilterPredicateMatch(predicate, lookup.Navigation.TargetEntityType, out var match))
+                    {
+                        pipeline.Add(match);
+                    }
+                }
+
                 foreach (var stage in lookup.PipelineStages)
                 {
                     pipeline.Add(stage);
@@ -719,8 +754,105 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
                         Expression.Constant(null, serializerType)),
                     Expression.Constant(null, serializerType));
             }
+
+            // When this $lookup writes into a dotted `as` path nested under a cross-collection REFERENCE that
+            // was left-joined with preserveNullAndEmptyArrays (e.g. "_inner._lookup_<Nav>" or
+            // "_lookup_<RefNav>._lookup_<Nav>"), MongoDB synthesises the parent sub-document to hold the result
+            // even when the reference had no match — producing a present-but-keyless parent (missing its
+            // "_id"). That defeats the shaper's "joined document is null => null entity" left-join guard and
+            // makes the non-nullable materializer read the absent required key. Re-null the parent when its key
+            // element is missing so it is treated as absent. Only emitted when the parent is an OPTIONAL
+            // reference (LookupExpression.NormalizeParent): required references always match (no synthesis) and
+            // the root wrapper ("_outer") is never absent, so those need no normalization. EF-X024.
+            var lastDot = lookup.As.LastIndexOf('.');
+            if (lookup.NormalizeParent && lastDot > 0)
+            {
+                var parentPath = lookup.As[..lastDot];
+                var normalizeDoc = new BsonDocument("$set", new BsonDocument(parentPath,
+                    new BsonDocument("$cond", new BsonArray
+                    {
+                        new BsonDocument("$eq", new BsonArray
+                        {
+                            new BsonDocument("$type", $"${parentPath}._id"),
+                            "missing"
+                        }),
+                        "$$REMOVE",
+                        $"${parentPath}"
+                    })));
+
+                query = Expression.Call(null, appendStageMethod, query,
+                    Expression.New(stageConstructor,
+                        Expression.Constant(normalizeDoc),
+                        Expression.Constant(null, serializerType)),
+                    Expression.Constant(null, serializerType));
+            }
         }
 
         return query;
+    }
+
+    /// <summary>
+    /// Renders a captured filtered-Include / query-filter predicate lambda to a <c>$match</c> stage for a
+    /// cross-collection <c>$lookup</c> sub-pipeline. The predicate is first run through this visitor
+    /// (<c>EF.Property</c> → <c>Mql.Field</c>, query-parameter/closure substitution, entity-equality lowering)
+    /// exactly like the VectorSearch pre-filter, then handed to the DRIVER as an
+    /// <see cref="ExpressionFilterDefinition{TDocument}"/> and rendered with the EF entity serializer (which
+    /// knows the element-name mapping, e.g. <c>Id</c> → <c>_id</c>). The provider never hand-builds the
+    /// predicate BSON. If the driver cannot render the predicate, fail loudly with a translation failure rather
+    /// than silently dropping the filter. EF-X021.
+    /// </summary>
+    private BsonDocument RenderFilterPredicateMatch(LambdaExpression predicate, IEntityType targetEntityType)
+    {
+        try
+        {
+            var visited = Visit(predicate)!;
+            var serializer = _bsonSerializerFactory.GetEntitySerializer(targetEntityType);
+            return (BsonDocument)RenderFilterMatchMethod
+                .MakeGenericMethod(targetEntityType.ClrType)
+                .Invoke(null, [visited, serializer])!;
+        }
+        catch (Exception exception)
+        {
+            // Never silently drop a filter — surface an untranslatable predicate as a translation failure.
+            throw new InvalidOperationException(
+                Microsoft.EntityFrameworkCore.Diagnostics.CoreStrings.TranslationFailed(predicate.Print()), exception);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort variant of <see cref="RenderFilterPredicateMatch"/>: returns <see langword="false"/> instead
+    /// of throwing when the predicate cannot be rendered (e.g. it references a navigation that has no $lookup
+    /// sub-pipeline representation), so the caller can drop it. Used for source-side query filters reached after
+    /// a ThenInclude descent, preserving the pre-EF-X021 behavior for those shapes. EF-X021.
+    /// </summary>
+    private bool TryRenderFilterPredicateMatch(
+        LambdaExpression predicate, IEntityType targetEntityType, out BsonDocument match)
+    {
+        try
+        {
+            var visited = Visit(predicate)!;
+            var serializer = _bsonSerializerFactory.GetEntitySerializer(targetEntityType);
+            match = (BsonDocument)RenderFilterMatchMethod
+                .MakeGenericMethod(targetEntityType.ClrType)
+                .Invoke(null, [visited, serializer])!;
+            return true;
+        }
+        catch
+        {
+            match = null!;
+            return false;
+        }
+    }
+
+    private static readonly MethodInfo RenderFilterMatchMethod =
+        typeof(MongoEFToLinqTranslatingExpressionVisitor).GetMethod(
+            nameof(RenderFilterMatch), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static BsonDocument RenderFilterMatch<TElement>(Expression visitedPredicate, IBsonSerializer serializer)
+    {
+        var filter = new ExpressionFilterDefinition<TElement>((Expression<Func<TElement, bool>>)visitedPredicate);
+        var rendered = filter.Render(
+            new RenderArgs<TElement>((IBsonSerializer<TElement>)serializer, BsonSerializer.SerializerRegistry));
+        return new BsonDocument("$match", rendered);
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
@@ -541,6 +541,18 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
             // Recurse for deeper nesting
             ExtractNestedIncludePipeline(nestedInclude.NavigationExpression, nestedLookup, nestedNav.TargetEntityType);
 
+            // Bubble deferred filter renders discovered in deeper nesting up toward the root lookup.
+            parentLookup.PendingNestedFilterRenders.AddRange(nestedLookup.PendingNestedFilterRenders);
+
+            // This nested $lookup is emitted in localField/foreignField form (no sub-pipeline), so a user filter
+            // predicate on it cannot be carried as a $match here and there is no access to the EF→driver-LINQ
+            // visitor / serializer to render one. Fail loudly rather than silently dropping it. Filtered nested
+            // ThenIncludes that DO use the pipeline form are handled in ExtractThenIncludesFromSubquery. EF-X021.
+            if (nestedLookup.FilterPredicates.Count > 0)
+            {
+                throw new InvalidOperationException(CoreStrings.TranslationFailed(navigationExpression.Print()));
+            }
+
             parentLookup.PipelineStages.Add(new BsonDocument("$lookup", new BsonDocument
             {
                 { "from", nestedLookup.From },
@@ -579,64 +591,94 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
         if (selectorArg is not LambdaExpression { Body: IncludeExpression includeExpr })
             return;
 
-        // Walk nested IncludeExpressions
+        // Walk every nested IncludeExpression, dispatching each by navigation kind. A single walk (rather than
+        // a collection loop followed by a separate reference loop) is required because merging two Include
+        // chains on the same collection navigation — e.g. .Include(c.Orders).ThenInclude(o.Lines) and
+        // .Include(c.Orders).ThenInclude(o.Customer) — lowers to INTERLEAVED collection and reference
+        // ThenIncludes (the reference often outermost). Type-gated sequential loops would drop whichever kind
+        // is nested under the other. EF-X025.
         var current = (Expression)includeExpr;
         while (current is IncludeExpression nested
                && nested.Navigation is INavigation nav
-               && !nav.IsEmbedded() && nav.IsCollection)
+               && !nav.IsEmbedded())
         {
-            var nestedLookup = new LookupExpression(nav);
-
-            // Check for deeper nesting inside this ThenInclude's NavigationExpression
-            if (nested.NavigationExpression is MaterializeCollectionNavigationExpression innerMaterialize)
+            if (nav.IsCollection)
             {
-                ExtractThenIncludesFromSubquery(innerMaterialize.Subquery, nestedLookup);
-                ExtractFilteredIncludePipeline(innerMaterialize.Subquery, nestedLookup, nav.TargetEntityType);
+                AddCollectionLookupStages(parentLookup, nav, nested);
+            }
+            else
+            {
+                // Reference ThenInclude on a collection item (e.g. Product.OrderDetails.ThenInclude(od => od.Order)).
+                // EF lowers the reference to a Join inside the collection subquery; emit it as a nested
+                // $lookup + $unwind inside the parent lookup's pipeline so each collection element carries
+                // its single referenced document under "_lookup_<RefNav>".
+                AddReferenceLookupStages(parentLookup, nav);
             }
 
-            var nestedLookupDoc = new BsonDocument("$lookup", new BsonDocument
-            {
-                { "from", nestedLookup.From },
-                { "localField", nestedLookup.LocalField },
-                { "foreignField", nestedLookup.ForeignField },
-                { "as", nestedLookup.As }
-            });
-
-            if (nestedLookup.HasPipeline)
-            {
-                // Use pipeline form for nested lookups with their own stages
-                var pipeline = new BsonArray
-                {
-                    new BsonDocument("$match",
-                        new BsonDocument("$expr",
-                            new BsonDocument("$eq", new BsonArray { $"${nestedLookup.ForeignField}", "$$localField" })))
-                };
-                foreach (var stage in nestedLookup.PipelineStages)
-                    pipeline.Add(stage);
-
-                nestedLookupDoc = new BsonDocument("$lookup", new BsonDocument
-                {
-                    { "from", nestedLookup.From },
-                    { "let", new BsonDocument("localField", $"${nestedLookup.LocalField}") },
-                    { "pipeline", pipeline },
-                    { "as", nestedLookup.As }
-                });
-            }
-
-            parentLookup.PipelineStages.Add(nestedLookupDoc);
             current = nested.EntityExpression;
         }
+    }
 
-        // Reference ThenInclude on a collection item (e.g. Product.OrderDetails.ThenInclude(od => od.Order)).
-        // EF lowers the reference to a Join inside the collection subquery; emit it as a nested
-        // $lookup + $unwind inside the parent lookup's pipeline so each collection element carries
-        // its single referenced document under "_lookup_<RefNav>".
-        while (current is IncludeExpression { Navigation: INavigation refNav } nestedRef
-               && !refNav.IsEmbedded() && !refNav.IsCollection)
+    /// <summary>
+    /// Add the nested $lookup stages for a collection ThenInclude (with any filtered-Include pipeline and
+    /// deeper nested ThenIncludes) into the parent lookup's pipeline.
+    /// </summary>
+    private static void AddCollectionLookupStages(
+        LookupExpression parentLookup, INavigation nav, IncludeExpression nested)
+    {
+        var nestedLookup = new LookupExpression(nav);
+
+        // Check for deeper nesting inside this ThenInclude's NavigationExpression
+        if (nested.NavigationExpression is MaterializeCollectionNavigationExpression innerMaterialize)
         {
-            AddReferenceLookupStages(parentLookup, refNav);
-            current = nestedRef.EntityExpression;
+            ExtractThenIncludesFromSubquery(innerMaterialize.Subquery, nestedLookup);
+            ExtractFilteredIncludePipeline(innerMaterialize.Subquery, nestedLookup, nav.TargetEntityType);
         }
+
+        var nestedLookupDoc = new BsonDocument("$lookup", new BsonDocument
+        {
+            { "from", nestedLookup.From },
+            { "localField", nestedLookup.LocalField },
+            { "foreignField", nestedLookup.ForeignField },
+            { "as", nestedLookup.As }
+        });
+
+        if (nestedLookup.HasPipeline)
+        {
+            // Use pipeline form for nested lookups with their own stages
+            var pipeline = new BsonArray
+            {
+                new BsonDocument("$match",
+                    new BsonDocument("$expr",
+                        new BsonDocument("$eq", new BsonArray { $"${nestedLookup.ForeignField}", "$$localField" })))
+            };
+
+            // A user filter predicate on this nested ThenInclude target cannot be rendered here (no access
+            // to the EF→driver-LINQ visitor / serializer). Defer it: EmitLookupStages mutates this pipeline
+            // in place, inserting the rendered $match after the FK-correlation $match (index 1) and before
+            // the paging stages added below. Never silently dropped. EF-X021.
+            if (nestedLookup.FilterPredicates.Count > 0)
+            {
+                parentLookup.PendingNestedFilterRenders.Add(
+                    (pipeline, 1, nestedLookup.FilterPredicates, nestedLookup.Navigation.TargetEntityType));
+            }
+
+            foreach (var stage in nestedLookup.PipelineStages)
+                pipeline.Add(stage);
+
+            nestedLookupDoc = new BsonDocument("$lookup", new BsonDocument
+            {
+                { "from", nestedLookup.From },
+                { "let", new BsonDocument("localField", $"${nestedLookup.LocalField}") },
+                { "pipeline", pipeline },
+                { "as", nestedLookup.As }
+            });
+        }
+
+        // Bubble deferred filter renders discovered in deeper nesting up toward the root lookup.
+        parentLookup.PendingNestedFilterRenders.AddRange(nestedLookup.PendingNestedFilterRenders);
+
+        parentLookup.PipelineStages.Add(nestedLookupDoc);
     }
 
     /// <summary>
@@ -675,6 +717,17 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
         var stages = new List<BsonDocument>();
         var current = navigationExpression;
 
+        // Index of the first filter predicate this call appends (the lookup may already carry some from an
+        // earlier extraction pass); only this call's slice is reversed to execution order at the end.
+        var predicatesStart = lookup.FilterPredicates.Count;
+
+        // Whether the walk has descended through a ThenInclude's Select/Join. A user filtered-Include predicate
+        // sits ABOVE that descent (captured as a must-render predicate); a Where reached AFTER descending is the
+        // source-side query filter (e.g. a dependent HasQueryFilter), which is frequently redundant and may
+        // reference a navigation that cannot be expressed in a $lookup sub-pipeline — captured best-effort
+        // (rendered if possible, otherwise dropped, matching the pre-EF-X021 behavior for those shapes).
+        var descended = false;
+
         while (current is MethodCallExpression methodCall)
         {
             var methodName = methodCall.Method.Name;
@@ -707,20 +760,46 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                     break;
 
                 case "Where":
-                    // A collection-Include subquery contains a Where for the synthetic FK-correlation
-                    // predicate (the join condition), which the $lookup localField/foreignField already
-                    // handles, so that one is dropped. But a user filtered-Include predicate
-                    // (.Include(c => c.Orders.Where(...))) and a HasQueryFilter on the dependent entity
-                    // ALSO lower to a Where here. Those are NOT yet translated into the $lookup
-                    // sub-pipeline $match, so silently dropping them would return wrong data (e.g. bypass a
-                    // soft-delete / multi-tenant filter). Fail loudly for those instead of dropping them.
+                    // The synthetic FK-correlation predicate (the join condition) is handled by the $lookup
+                    // localField/foreignField, so it is dropped.
                     if (IsFkCorrelationPredicate(methodCall.Arguments[1].UnwrapLambdaFromQuote()))
                     {
                         current = methodCall.Arguments[0];
                         break;
                     }
 
-                    throw new InvalidOperationException(CoreStrings.TranslationFailed(navigationExpression.Print()));
+                    if (descended)
+                    {
+                        // A Where below a ThenInclude's Select/Join: the source-side query filter. Capture it
+                        // best-effort (rendered into the sub-pipeline $match if the driver can express it,
+                        // otherwise dropped) and stop — matching the pre-EF-X021 behavior so a redundant query
+                        // filter that references a navigation does not break translation. EF-X021.
+                        lookup.BestEffortFilterPredicates.Add(methodCall.Arguments[1].UnwrapLambdaFromQuote());
+                        current = null;
+                        break;
+                    }
+
+                    // A user filtered-Include predicate (.Include(c => c.Orders.Where(...))). Capture it for the
+                    // driver to render into a sub-pipeline $match when the $lookup is emitted (see
+                    // MongoEFToLinqTranslatingExpressionVisitor.EmitLookupStages) — never silently dropped; an
+                    // unrenderable predicate here fails loudly. Collected outermost-first. EF-X021.
+                    lookup.FilterPredicates.Add(methodCall.Arguments[1].UnwrapLambdaFromQuote());
+                    current = methodCall.Arguments[0];
+                    break;
+
+                case "Select":
+                case "Join":
+                case "LeftJoin":
+                    // A filtered Include followed by ThenInclude lowers the collection subquery to
+                    // Select(<filtered source>.LeftJoin/Join(<thenInclude target>, ...), e => Include(e, ...)):
+                    // the outermost call is the entity-materialization Select, below it a Join/LeftJoin for the
+                    // reference ThenInclude, and the filtered OrderBy/Skip/Take live in the join's OUTER source
+                    // (Arguments[0]). These structural operators emit no filtered-pipeline stage of their own
+                    // (the ThenInclude $lookups are appended separately by ExtractThenIncludesFromSubquery);
+                    // descend into the source so the filtered operators/predicates underneath are collected.
+                    descended = true;
+                    current = methodCall.Arguments[0];
+                    break;
 
                 default:
                     // Hit the base (EntityQueryRootExpression or similar) — stop.
@@ -732,7 +811,24 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
         // Stages were collected outermost-first; reverse so they execute in the right order.
         stages.Reverse();
         lookup.PipelineStages.AddRange(stages);
+
+        // Filter predicates were likewise collected outermost-first; reverse for a stable, source-order
+        // sequence of $match stages (their relative order is semantically irrelevant — all are ANDed).
+        if (predicatesStart < lookup.FilterPredicates.Count)
+        {
+            lookup.FilterPredicates.Reverse(predicatesStart, lookup.FilterPredicates.Count - predicatesStart);
+        }
     }
+
+    /// <summary>
+    /// Whether a reference navigation can be absent after a left-join — i.e. its left-joined document may be
+    /// missing. A reference on the dependent side is optional when its foreign key is not required; a
+    /// reference on the principal side (1:1 inverse) is optional when the dependent is not required.
+    /// </summary>
+    private static bool IsOptionalReferenceNavigation(INavigation navigation)
+        => navigation.IsOnDependent
+            ? !navigation.ForeignKey.IsRequired
+            : !navigation.ForeignKey.IsRequiredDependent;
 
     /// <summary>
     /// Determines whether a Where predicate lowered into a collection-Include subquery is the synthetic

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -198,6 +198,15 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                             {
                                 lookup.LocalField = $"_inner.{lookup.LocalField}";
                                 lookup.As = $"_inner.{lookup.As}";
+                                // The "_inner" parent is the driver-native LeftJoin reference Include
+                                // currently on the include stack. Only an OPTIONAL reference can be unmatched
+                                // and so be wrongly synthesized by this nested $lookup; normalize it so the
+                                // unmatched case is re-nulled. Required references always match (no synthesis).
+                                // Default to normalizing if the parent reference cannot be identified. EF-X024.
+                                var parentReference = _includedNavigations.FirstOrDefault(
+                                    n => !n.IsCollection && n.TargetEntityType == declaringType);
+                                lookup.NormalizeParent =
+                                    parentReference == null || IsOptionalReferenceNavigation(parentReference);
                             }
                         }
                         else

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -503,7 +503,21 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
     /// </list>
     /// </summary>
     private string GetCrossCollectionFieldName(ObjectAccessExpression accessExpression)
-        => _queryExpression.UsesDriverJoinFields ? "_inner" : accessExpression.Name;
+    {
+        // A reference nested under a collection element is read from that element's own "_lookup_<Nav>" field
+        // (the alias baked into the access node) — NOT the driver-join "_inner" field, which names only the
+        // single top-level left-joined reference at the query root. Mirror GetCrossCollectionRootDocument's
+        // nesting test so the field name and the document it is read from stay in agreement; otherwise a
+        // collection element's ThenInclude reference would be read from the unrelated "_inner" field. EF-X024.
+        if (accessExpression.AccessExpression is RootReferenceExpression { EntityType: var parentType }
+            && parentType != _queryExpression.CollectionExpression.EntityType
+            && _projectionBindings.ContainsKey(accessExpression.AccessExpression))
+        {
+            return accessExpression.Name;
+        }
+
+        return _queryExpression.UsesDriverJoinFields ? "_inner" : accessExpression.Name;
+    }
 
     /// <summary>
     /// Determine the <see cref="BsonDocument"/> a cross-collection Include result is read from. For a

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -284,37 +284,45 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
 #endif
 
     [Fact]
-    public void Filtered_collection_include_predicate_is_not_silently_dropped()
+    public void Filtered_collection_include_predicate_is_translated_to_sub_pipeline_match()
     {
-        // A user filtered-Include predicate (.Include(c => c.Orders.Where(...))) lowers to a Where inside
-        // the collection subquery. The provider does not yet translate that predicate into the $lookup
-        // sub-pipeline $match. It must fail loudly (translation failure) rather than silently drop the
-        // predicate and return ALL of the customer's orders.
+        // A user filtered-Include predicate (.Include(c => c.Orders.Where(...))) lowers to a Where inside the
+        // collection subquery and is translated into the $lookup sub-pipeline $match (EF-X021), so the
+        // included collection is correctly filtered rather than returning ALL of the customer's orders.
         var (ordersCollection, customersCollection) = SetupOrdersAndCustomers();
 
         using var db = new OrderCustomerDbContext(database, ordersCollection, customersCollection);
 
-        Assert.Throws<InvalidOperationException>(() =>
-            db.Customers
-                .Include(c => c.Orders.Where(o => o.OrderDescription == "Order 1"))
-                .First(c => c.FullName == "Alice"));
+        // Alice has "Order 1" and "Order 2"; the filter must keep only "Order 1".
+        var alice = db.Customers
+            .Include(c => c.Orders.Where(o => o.OrderDescription == "Order 1"))
+            .First(c => c.FullName == "Alice");
+
+        Assert.Equal("Order 1", Assert.Single(alice.Orders).OrderDescription);
     }
 
     [Fact]
-    public void Query_filter_on_collection_include_target_is_not_silently_dropped()
+    public void Query_filter_on_collection_include_target_is_translated_to_sub_pipeline_match()
     {
-        // A HasQueryFilter on the dependent entity (e.g. soft-delete / multi-tenant) also lowers to a Where
-        // inside the collection-Include subquery. The provider does not yet translate it into the $lookup
-        // sub-pipeline $match, so it must fail loudly rather than silently bypass the filter and return
-        // soft-deleted rows.
+        // A HasQueryFilter on the dependent entity (soft-delete) also lowers to a Where inside the
+        // collection-Include subquery and is translated into the $lookup sub-pipeline $match (EF-X021), so
+        // soft-deleted ("tombstone") rows are excluded rather than silently returned.
         var (ordersCollection, customersCollection) = SetupOrdersAndCustomers();
+
+        // Add a soft-deleted order for Alice (alongside her "Order 1"/"Order 2") that the filter must exclude.
+        var aliceId = database.MongoDatabase.GetCollection<BsonDocument>(customersCollection)
+            .Find(new BsonDocument("name", "Alice")).First()["_id"].AsObjectId;
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersCollection)
+            .InsertOne(new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "tombstone" }, { "cust_id", aliceId } });
 
         using var db = new SoftDeleteOrderCustomerDbContext(database, ordersCollection, customersCollection);
 
-        Assert.Throws<InvalidOperationException>(() =>
-            db.Customers
-                .Include(c => c.Orders)
-                .First(c => c.FullName == "Alice"));
+        var alice = db.Customers
+            .Include(c => c.Orders)
+            .First(c => c.FullName == "Alice");
+
+        Assert.Equal(2, alice.Orders.Count);
+        Assert.DoesNotContain(alice.Orders, o => o.OrderDescription == "tombstone");
     }
 
     // BSON uses: desc, cust_id for Orders; name for Customers

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/ComplexNavigationsCollectionsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/ComplexNavigationsCollectionsQueryMongoTest.cs
@@ -1,0 +1,1308 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace MongoDB.EntityFrameworkCore.SpecificationTests.Query;
+
+public class ComplexNavigationsCollectionsQueryMongoTest : ComplexNavigationsCollectionsQueryTestBase<
+    ComplexNavigationsQueryMongoFixture>
+{
+    public ComplexNavigationsCollectionsQueryMongoTest(ComplexNavigationsQueryMongoFixture fixture)
+        : base(fixture)
+        => Fixture.TestMqlLoggerFactory.Clear();
+
+    [ConditionalFact]
+    public virtual void Check_all_tests_overridden()
+        => TestHelpers.AssertAllMethodsOverridden(GetType());
+
+    public override async Task Collection_projection_over_GroupBy_over_parameter(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Collection_projection_over_GroupBy_over_parameter(async));
+        AssertMql();
+    }
+    public override async Task Complex_multi_include_with_order_by_and_paging(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Complex_multi_include_with_order_by_and_paging(async));
+        AssertMql();
+#else
+        await base.Complex_multi_include_with_order_by_and_paging(async);
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "Name" : 1 } }, { "$skip" : 0 }, { "$limit" : 10 }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Required_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Required_Inverse3Id", "as" : "_inner._lookup_OneToMany_Required2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Complex_multi_include_with_order_by_and_paging_joins_on_correct_key(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Complex_multi_include_with_order_by_and_paging_joins_on_correct_key(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection reference Include returns wrong data / missing required element EF-X024
+        await AssertTranslationFailed(() => base.Complex_multi_include_with_order_by_and_paging_joins_on_correct_key(async));
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "Name" : 1 } }, { "$skip" : 0 }, { "$limit" : 10 }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._outer._id", "foreignField" : "Level1_Required_Id", "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Required_Inverse3Id", "as" : "_inner._lookup_OneToMany_Required2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Complex_multi_include_with_order_by_and_paging_joins_on_correct_key2(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Complex_multi_include_with_order_by_and_paging_joins_on_correct_key2(async));
+        AssertMql();
+#else
+        // Fails: Cross-document navigation/multi-include returns wrong data EF-216
+        await AssertTranslationFailed(() => base.Complex_multi_include_with_order_by_and_paging_joins_on_correct_key2(async));
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "Name" : 1 } }, { "$skip" : 0 }, { "$limit" : 10 }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse2Id", "as" : "_lookup_OneToMany_Optional1" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Optional1", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_lookup_OneToMany_Optional1._id", "foreignField" : "_id", "as" : "_lookup_OneToOne_Required_PK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Required_PK2", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_lookup_OneToOne_Required_PK2._id", "foreignField" : "OneToMany_Optional_Inverse4Id", "as" : "_lookup_OneToOne_Required_PK2._lookup_OneToMany_Optional3" } }
+""");
+#endif
+    }
+    public override async Task Complex_query_issue_21665(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Complex_query_issue_21665(async));
+        AssertMql();
+    }
+    public override async Task Complex_query_with_let_collection_projection_FirstOrDefault(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Complex_query_with_let_collection_projection_FirstOrDefault(async));
+        AssertMql();
+    }
+    public override async Task Complex_query_with_let_collection_projection_FirstOrDefault_with_ToList_on_inner_and_outer(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Complex_query_with_let_collection_projection_FirstOrDefault_with_ToList_on_inner_and_outer(async));
+        AssertMql();
+    }
+    public override async Task Filtered_ThenInclude_OrderBy(bool async)
+    {
+        await base.Filtered_ThenInclude_OrderBy(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }], "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_OrderBy(bool async)
+    {
+        await base.Filtered_include_OrderBy(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_OrderBy_EF_Property(bool async)
+    {
+        await base.Filtered_include_OrderBy_EF_Property(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_Skip_Take_with_another_Skip_Take_on_top_level(bool async)
+    {
+        await base.Filtered_include_Skip_Take_with_another_Skip_Take_on_top_level(async);
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "_id" : -1 } }, { "$skip" : 1 }, { "$limit" : 5 }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : -1 } }, { "$skip" : 1 }, { "$limit" : 4 }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_Skip_without_OrderBy(bool async)
+    {
+        await base.Filtered_include_Skip_without_OrderBy(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$skip" : 1 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_Take_with_another_Take_on_top_level(bool async)
+    {
+        await base.Filtered_include_Take_with_another_Take_on_top_level(async);
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "_id" : 1 } }, { "$limit" : 5 }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : -1 } }, { "$limit" : 4 }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_Take_without_OrderBy(bool async)
+    {
+        await base.Filtered_include_Take_without_OrderBy(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$limit" : 1 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_ThenInclude_OrderBy(bool async)
+    {
+        await base.Filtered_include_ThenInclude_OrderBy(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$sort" : { "Name" : -1 } }], "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_after_different_filtered_include_different_level(bool async)
+    {
+        await base.Filtered_include_after_different_filtered_include_different_level(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "Name" : 1 } }, { "$limit" : 3 }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Required_Inverse3Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Bar" } } }, { "$sort" : { "Name" : -1 } }, { "$skip" : 1 }], "as" : "_lookup_OneToMany_Required2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_after_different_filtered_include_same_level(bool async)
+    {
+        await base.Filtered_include_after_different_filtered_include_same_level(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Required_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Bar" } } }, { "$sort" : { "Name" : -1 } }, { "$skip" : 1 }], "as" : "_lookup_OneToMany_Required1" } }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "Name" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_after_reference_navigation(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/ThenInclude not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Filtered_include_after_reference_navigation(async));
+        AssertMql();
+#else
+        await base.Filtered_include_after_reference_navigation(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "Name" : 1 } }, { "$skip" : 1 }, { "$limit" : 3 }], "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Filtered_include_and_non_filtered_include_followed_by_then_include_on_same_navigation(bool async)
+    {
+        await base.Filtered_include_and_non_filtered_include_followed_by_then_include_on_same_navigation(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 1 }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToOne_Optional_PK_Inverse3Id", "as" : "_lookup_OneToOne_Optional_PK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_PK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_and_non_filtered_include_on_same_navigation1(bool async)
+    {
+        await base.Filtered_include_and_non_filtered_include_on_same_navigation1(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_and_non_filtered_include_on_same_navigation2(bool async)
+    {
+        await base.Filtered_include_and_non_filtered_include_on_same_navigation2(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_basic_OrderBy_Skip(bool async)
+    {
+        await base.Filtered_include_basic_OrderBy_Skip(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }, { "$skip" : 1 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_basic_OrderBy_Skip_Take(bool async)
+    {
+        await base.Filtered_include_basic_OrderBy_Skip_Take(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }, { "$skip" : 1 }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_basic_OrderBy_Skip_Take_EF_Property(bool async)
+    {
+        await base.Filtered_include_basic_OrderBy_Skip_Take_EF_Property(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }, { "$skip" : 1 }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_basic_OrderBy_Take(bool async)
+    {
+        await base.Filtered_include_basic_OrderBy_Take(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "Name" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_basic_Where(bool async)
+    {
+        await base.Filtered_include_basic_Where(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "_id" : { "$gt" : 5 } } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_basic_Where_EF_Property(bool async)
+    {
+        await base.Filtered_include_basic_Where_EF_Property(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "_id" : { "$gt" : 5 } } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_calling_methods_directly_on_parameter_throws(bool async)
+    {
+        await base.Filtered_include_calling_methods_directly_on_parameter_throws(async);
+        AssertMql();
+    }
+    public override async Task Filtered_include_complex_three_level_with_middle_having_filter1(bool async)
+    {
+        await base.Filtered_include_complex_three_level_with_middle_having_filter1(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "OneToMany_Required_Inverse4Id", "as" : "_lookup_OneToMany_Required3" } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse4Id", "as" : "_lookup_OneToMany_Optional3" } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 1 }], "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_complex_three_level_with_middle_having_filter2(bool async)
+    {
+        await base.Filtered_include_complex_three_level_with_middle_having_filter2(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "OneToMany_Required_Inverse4Id", "as" : "_lookup_OneToMany_Required3" } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse4Id", "as" : "_lookup_OneToMany_Optional3" } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 1 }], "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_context_accessed_inside_filter(bool async)
+    {
+#if EF8 || EF9
+        await base.Filtered_include_context_accessed_inside_filter(async);
+        AssertMql(
+            """
+LevelOne.{ "$count" : "_v" }
+""",
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+#else
+        await base.Filtered_include_context_accessed_inside_filter(async);
+        AssertMql(
+            """
+LevelOne.{ "$count" : "_v" }
+""",
+            //
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+#endif
+    }
+    public override async Task Filtered_include_context_accessed_inside_filter_correlated(bool async)
+    {
+        await base.Filtered_include_context_accessed_inside_filter_correlated(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_different_filter_set_on_same_navigation_twice(bool async)
+    {
+        await base.Filtered_include_different_filter_set_on_same_navigation_twice(async);
+        AssertMql();
+    }
+    public override async Task Filtered_include_different_filter_set_on_same_navigation_twice_multi_level(bool async)
+    {
+        await base.Filtered_include_different_filter_set_on_same_navigation_twice_multi_level(async);
+        AssertMql();
+    }
+    public override async Task Filtered_include_include_parameter_used_inside_filter_throws(bool async)
+    {
+        await base.Filtered_include_include_parameter_used_inside_filter_throws(async);
+        AssertMql();
+    }
+    public override async Task Filtered_include_is_considered_loaded(bool async)
+    {
+        await base.Filtered_include_is_considered_loaded(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 1 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_on_ThenInclude(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/ThenInclude not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Filtered_include_on_ThenInclude(async));
+        AssertMql();
+#else
+        await base.Filtered_include_on_ThenInclude(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "Name" : 1 } }, { "$skip" : 1 }, { "$limit" : 3 }], "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Filtered_include_on_ThenInclude_EF_Property(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/ThenInclude not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Filtered_include_on_ThenInclude_EF_Property(async));
+        AssertMql();
+#else
+        await base.Filtered_include_on_ThenInclude_EF_Property(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "Name" : 1 } }, { "$skip" : 1 }, { "$limit" : 3 }], "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Filtered_include_outer_parameter_used_inside_filter(bool async)
+    {
+        // Fails: Correlated cross-DbSet subquery in a projection (filter references the outer Select parameter) EF-X001
+        await AssertTranslationFailed(() => base.Filtered_include_outer_parameter_used_inside_filter(async));
+        AssertMql();
+    }
+    public override async Task Filtered_include_same_filter_set_on_same_navigation_twice(bool async)
+    {
+        await base.Filtered_include_same_filter_set_on_same_navigation_twice(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "_id" : -1 } }, { "$limit" : 2 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_same_filter_set_on_same_navigation_twice_followed_by_ThenIncludes(bool async)
+    {
+        await base.Filtered_include_same_filter_set_on_same_navigation_twice_followed_by_ThenIncludes(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 2 }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Required_Id", "as" : "_lookup_OneToOne_Required_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Required_FK2", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Filtered_include_variable_used_inside_filter(bool async)
+    {
+#if EF8 || EF9
+        await base.Filtered_include_variable_used_inside_filter(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+#else
+        await base.Filtered_include_variable_used_inside_filter(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+#endif
+    }
+    public override async Task Filtered_include_with_Distinct_throws(bool async)
+    {
+        await base.Filtered_include_with_Distinct_throws(async);
+        AssertMql();
+    }
+    public override async Task Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_FirstOrDefault_on_top_level(bool async)
+    {
+        await base.Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_FirstOrDefault_on_top_level(async);
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "_id" : 1 } }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$limit" : 40 }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }, { "$limit" : 1 }
+""");
+    }
+    public override async Task Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_unordered_Take_on_top_level(bool async)
+    {
+        await base.Filtered_include_with_Take_without_order_by_followed_by_ThenInclude_and_unordered_Take_on_top_level(async);
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "_id" : 1 } }, { "$limit" : 30 }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$limit" : 40 }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Final_GroupBy_property_entity_Include_collection(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Final_GroupBy_property_entity_Include_collection(async));
+        AssertMql();
+    }
+    public override async Task Final_GroupBy_property_entity_Include_collection_multiple(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Final_GroupBy_property_entity_Include_collection_multiple(async));
+        AssertMql();
+    }
+    public override async Task Final_GroupBy_property_entity_Include_collection_nested(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Final_GroupBy_property_entity_Include_collection_nested(async));
+        AssertMql();
+    }
+    public override async Task Final_GroupBy_property_entity_Include_collection_reference(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Final_GroupBy_property_entity_Include_collection_reference(async));
+        AssertMql();
+    }
+    public override async Task Final_GroupBy_property_entity_Include_collection_reference_same_level(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Final_GroupBy_property_entity_Include_collection_reference_same_level(async));
+        AssertMql();
+    }
+    public override async Task Final_GroupBy_property_entity_Include_reference(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Final_GroupBy_property_entity_Include_reference(async));
+        AssertMql();
+    }
+    public override async Task Final_GroupBy_property_entity_Include_reference_multiple(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Final_GroupBy_property_entity_Include_reference_multiple(async));
+        AssertMql();
+    }
+    public override async Task FirstOrDefault_with_predicate_on_correlated_collection_in_projection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.FirstOrDefault_with_predicate_on_correlated_collection_in_projection(async));
+        AssertMql();
+    }
+    public override async Task Include_ThenInclude_ThenInclude_followed_by_two_nested_selects(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_ThenInclude_ThenInclude_followed_by_two_nested_selects(async));
+        AssertMql();
+    }
+    public override async Task Include_after_Select(bool async)
+    {
+        await base.Include_after_Select(async);
+        AssertMql();
+    }
+    public override async Task Include_after_SelectMany(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_after_SelectMany(async));
+        AssertMql();
+    }
+    public override async Task Include_after_SelectMany_and_multiple_reference_navigations(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_after_SelectMany_and_multiple_reference_navigations(async));
+        AssertMql();
+    }
+    public override async Task Include_after_SelectMany_and_reference_navigation(bool async)
+    {
+        await base.Include_after_SelectMany_and_reference_navigation(async);
+        AssertMql();
+    }
+    public override async Task Include_after_multiple_SelectMany_and_reference_navigation(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_after_multiple_SelectMany_and_reference_navigation(async));
+        AssertMql();
+    }
+    public override async Task Include_and_ThenInclude_collections_followed_by_projecting_the_first_collection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_and_ThenInclude_collections_followed_by_projecting_the_first_collection(async));
+        AssertMql();
+    }
+    public override async Task Include_collection(bool async)
+    {
+        await base.Include_collection(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse2Id", "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Include_collection_ThenInclude_reference_followed_by_projection_into_anonmous_type(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_collection_ThenInclude_reference_followed_by_projection_into_anonmous_type(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_ThenInclude_two_references(bool async)
+    {
+        await base.Include_collection_ThenInclude_two_references(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToOne_Optional_PK_Inverse3Id", "as" : "_lookup_OneToOne_Optional_PK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_PK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Include_collection_and_another_navigation_chain_followed_by_projecting_the_first_collection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_collection_and_another_navigation_chain_followed_by_projecting_the_first_collection(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_followed_by_complex_includes_and_projecting_the_included_collection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_collection_followed_by_complex_includes_and_projecting_the_included_collection(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_followed_by_include_reference(bool async)
+    {
+        await base.Include_collection_followed_by_include_reference(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToOne_Optional_PK_Inverse3Id", "as" : "_lookup_OneToOne_Optional_PK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_PK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Include_collection_followed_by_projecting_the_included_collection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_collection_followed_by_projecting_the_included_collection(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_multiple(bool async)
+    {
+        // Fails: Cross-collection multiple/self-ref/required Include returns wrong data EF-X023
+        await AssertTranslationFailed(() => base.Include_collection_multiple(async));
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToOne_Optional_PK_Inverse3Id", "as" : "_lookup_OneToOne_Optional_PK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_PK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Include_collection_multiple_with_filter(bool async)
+    {
+        // Fails: Cross-collection navigation in a correlated subquery (root Where(... .Count() > 0)) not translated EF-216
+        await AssertTranslationFailed(() => base.Include_collection_multiple_with_filter(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_multiple_with_filter_EF_Property(bool async)
+    {
+        // Fails: Cross-collection navigation in a correlated subquery (root Where(... .Count() > 0)) not translated EF-216
+        await AssertTranslationFailed(() => base.Include_collection_multiple_with_filter_EF_Property(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_then_reference(bool async)
+    {
+        await base.Include_collection_then_reference(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Include_collection_with_conditional_order_by(bool async)
+    {
+        await base.Include_collection_with_conditional_order_by(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$cond" : { "if" : { "$let" : { "vars" : { "start" : { "$subtract" : [{ "$strLenCP" : "$Name" }, 2] } }, "in" : { "$and" : [{ "$gte" : ["$$start", 0] }, { "$eq" : [{ "$indexOfCP" : ["$Name", "03", "$$start"] }, "$$start"] }] } } }, "then" : 1, "else" : 2 } } } }, { "$sort" : { "_key1" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse2Id", "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Include_collection_with_groupby_in_subquery(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Include_collection_with_groupby_in_subquery(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_with_groupby_in_subquery_and_filter_after_groupby(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Include_collection_with_groupby_in_subquery_and_filter_after_groupby(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_with_groupby_in_subquery_and_filter_before_groupby(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Include_collection_with_groupby_in_subquery_and_filter_before_groupby(async));
+        AssertMql();
+    }
+    public override async Task Include_collection_with_multiple_orderbys_complex(bool async)
+    {
+        await base.Include_collection_with_multiple_orderbys_complex(async);
+        AssertMql(
+            """
+LevelTwo.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$add" : [{ "$abs" : "$Level1_Required_Id" }, 7] } } }, { "$sort" : { "_key1" : 1, "_document.Name" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }
+""");
+    }
+    public override async Task Include_collection_with_multiple_orderbys_complex_repeated(bool async)
+    {
+        await base.Include_collection_with_multiple_orderbys_complex_repeated(async);
+        AssertMql(
+            """
+LevelTwo.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$subtract" : [0, "$Level1_Required_Id"] }, "_key2" : { "$subtract" : [0, "$Level1_Required_Id"] } } }, { "$sort" : { "_key1" : 1, "_key2" : 1, "_document.Name" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }
+""");
+    }
+    public override async Task Include_collection_with_multiple_orderbys_complex_repeated_checked(bool async)
+    {
+        // Fails: checked issue EF-249
+        await AssertTranslationFailed(() => base.Include_collection_with_multiple_orderbys_complex_repeated_checked(async));
+        AssertMql(
+            """
+LevelTwo.
+""");
+    }
+    public override async Task Include_collection_with_multiple_orderbys_member(bool async)
+    {
+        await base.Include_collection_with_multiple_orderbys_member(async);
+        AssertMql(
+            """
+LevelTwo.{ "$sort" : { "Name" : 1, "Level1_Required_Id" : 1 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }
+""");
+    }
+    public override async Task Include_collection_with_multiple_orderbys_methodcall(bool async)
+    {
+        await base.Include_collection_with_multiple_orderbys_methodcall(async);
+        AssertMql(
+            """
+LevelTwo.{ "$project" : { "_id" : 0, "_document" : "$$ROOT", "_key1" : { "$abs" : "$Level1_Required_Id" } } }, { "$sort" : { "_key1" : 1, "_document.Name" : 1 } }, { "$replaceRoot" : { "newRoot" : "$_document" } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }
+""");
+    }
+    public override async Task Include_collection_with_multiple_orderbys_property(bool async)
+    {
+        await base.Include_collection_with_multiple_orderbys_property(async);
+        AssertMql(
+            """
+LevelTwo.{ "$sort" : { "Level1_Required_Id" : 1, "Name" : 1 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }
+""");
+    }
+    public override async Task Include_inside_subquery(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Include_inside_subquery(async));
+        AssertMql();
+    }
+    public override async Task Include_nested_with_optional_navigation(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Include_nested_with_optional_navigation(async));
+        AssertMql();
+#else
+        await base.Include_nested_with_optional_navigation(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner.Name" : { "$ne" : "L2 09" } } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Required_Inverse3Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "Level3_Required_Id", "as" : "_lookup_OneToOne_Required_FK3" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Required_FK3", "preserveNullAndEmptyArrays" : true } }], "as" : "_inner._lookup_OneToMany_Required2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Include_partially_added_before_Where_and_then_build_upon(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Include_partially_added_before_Where_and_then_build_upon(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection reference Include missing required element on materialization EF-X024
+        await AssertTranslationFailed(() => base.Include_partially_added_before_Where_and_then_build_upon(async));
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "OneToOne_Optional_PK_Inverse2Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "$or" : [{ "_outer._inner._id" : { "$lt" : 3 } }, { "_inner._id" : { "$gt" : 8 } }] } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "Level3_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK3" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK3", "preserveNullAndEmptyArrays" : true } }], "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Include_partially_added_before_Where_and_then_build_upon_with_filtered_include(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Include_partially_added_before_Where_and_then_build_upon_with_filtered_include(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection reference Include returns wrong data / missing required element EF-X024
+        await AssertTranslationFailed(() => base.Include_partially_added_before_Where_and_then_build_upon_with_filtered_include(async));
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "OneToOne_Optional_PK_Inverse2Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "$or" : [{ "_outer._inner._id" : { "$lt" : 3 } }, { "_inner._id" : { "$gt" : 8 } }] } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Required_Inverse3Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "Level3_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK3" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK3", "preserveNullAndEmptyArrays" : true } }], "as" : "_inner._lookup_OneToMany_Required2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 3 }], "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Include_reference_ThenInclude_collection_order_by(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Include_reference_ThenInclude_collection_order_by(async));
+        AssertMql();
+#else
+        await base.Include_reference_ThenInclude_collection_order_by(async);
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "Name" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Include_reference_and_collection_order_by(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Include_reference_and_collection_order_by(async));
+        AssertMql();
+#else
+        await base.Include_reference_and_collection_order_by(async);
+        AssertMql(
+            """
+LevelOne.{ "$sort" : { "Name" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Include_reference_collection_order_by_reference_navigation(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Include_reference_collection_order_by_reference_navigation(async));
+        AssertMql();
+#else
+        await base.Include_reference_collection_order_by_reference_navigation(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$sort" : { "_inner._id" : 1 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Include_reference_followed_by_include_collection(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Include_reference_followed_by_include_collection(async));
+        AssertMql();
+#else
+        await base.Include_reference_followed_by_include_collection(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Including_reference_navigation_and_projecting_collection_navigation(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Including_reference_navigation_and_projecting_collection_navigation(async));
+        AssertMql();
+    }
+    public override async Task LeftJoin_with_Any_on_outer_source_and_projecting_collection_from_inner(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.LeftJoin_with_Any_on_outer_source_and_projecting_collection_from_inner(async));
+        AssertMql();
+    }
+    public override async Task Lift_projection_mapping_when_pushing_down_subquery(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Lift_projection_mapping_when_pushing_down_subquery(async));
+        AssertMql();
+    }
+    public override async Task Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql(bool async)
+    {
+        await base.Multi_level_include_one_to_many_optional_and_one_to_many_optional_produces_valid_sql(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+    public override async Task Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation(async));
+        AssertMql();
+    }
+    public override async Task Multiple_SelectMany_with_Include(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Multiple_SelectMany_with_Include(async));
+        AssertMql();
+    }
+    public override async Task Multiple_complex_include_select(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_complex_include_select(async));
+        AssertMql();
+#else
+        await base.Multiple_complex_include_select(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_outer._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_outer._lookup_OneToMany_Optional1" } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Multiple_complex_includes(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_complex_includes(async));
+        AssertMql();
+#else
+        await base.Multiple_complex_includes(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_outer._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_outer._lookup_OneToMany_Optional1" } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Multiple_complex_includes_EF_Property(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_complex_includes_EF_Property(async));
+        AssertMql();
+#else
+        await base.Multiple_complex_includes_EF_Property(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_outer._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK2", "preserveNullAndEmptyArrays" : true } }], "as" : "_outer._lookup_OneToMany_Optional1" } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Multiple_complex_includes_self_ref(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_complex_includes_self_ref(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection multiple/self-ref/required Include returns wrong data EF-X023
+        await AssertTranslationFailed(() => base.Multiple_complex_includes_self_ref(async));
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelOne", "localField" : "_outer.OneToOne_Optional_Self1Id", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelOne", "let" : { "localField" : "$_outer._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Self_Inverse1Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelOne", "localField" : "OneToOne_Optional_Self1Id", "foreignField" : "_id", "as" : "_lookup_OneToOne_Optional_Self1" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_Self1", "preserveNullAndEmptyArrays" : true } }], "as" : "_outer._lookup_OneToMany_Optional_Self1" } }
+""");
+#endif
+    }
+    public override async Task Multiple_complex_includes_self_ref_EF_Property(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_complex_includes_self_ref_EF_Property(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection multiple/self-ref/required Include returns wrong data EF-X023
+        await AssertTranslationFailed(() => base.Multiple_complex_includes_self_ref_EF_Property(async));
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelOne", "localField" : "_outer.OneToOne_Optional_Self1Id", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelOne", "let" : { "localField" : "$_outer._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Self_Inverse1Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelOne", "localField" : "OneToOne_Optional_Self1Id", "foreignField" : "_id", "as" : "_lookup_OneToOne_Optional_Self1" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_Self1", "preserveNullAndEmptyArrays" : true } }], "as" : "_outer._lookup_OneToMany_Optional_Self1" } }
+""");
+#endif
+    }
+    public override async Task Multiple_include_with_multiple_optional_navigations(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_include_with_multiple_optional_navigations(async));
+        AssertMql();
+#else
+        // Fails: Cross-document navigation access issue EF-216
+        await AssertTranslationFailed(() => base.Multiple_include_with_multiple_optional_navigations(async));
+        AssertMql(
+            """
+LevelOne.
+""");
+#endif
+    }
+    public override async Task Multiple_optional_navigation_with_Include(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_optional_navigation_with_Include(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection reference Include missing required element on materialization EF-X024
+        await AssertTranslationFailed(() => base.Multiple_optional_navigation_with_Include(async));
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse2Id", "as" : "_lookup_OneToMany_Optional1" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Optional1", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_lookup_OneToMany_Optional1._id", "foreignField" : "_id", "as" : "_lookup_OneToOne_Required_PK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Required_PK2", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_lookup_OneToOne_Required_PK2._id", "foreignField" : "OneToMany_Optional_Inverse4Id", "as" : "_lookup_OneToOne_Required_PK2._lookup_OneToMany_Optional3" } }
+""");
+#endif
+    }
+    public override async Task Multiple_optional_navigation_with_string_based_Include(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Multiple_optional_navigation_with_string_based_Include(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection reference Include missing required element on materialization EF-X024
+        await AssertTranslationFailed(() => base.Multiple_optional_navigation_with_string_based_Include(async));
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse2Id", "as" : "_lookup_OneToMany_Optional1" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Optional1", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_lookup_OneToMany_Optional1._id", "foreignField" : "_id", "as" : "_lookup_OneToOne_Required_PK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Required_PK2", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_lookup_OneToOne_Required_PK2._id", "foreignField" : "OneToMany_Optional_Inverse4Id", "as" : "_lookup_OneToOne_Required_PK2._lookup_OneToMany_Optional3" } }
+""");
+#endif
+    }
+    public override async Task Null_check_in_Dto_projection_should_not_be_removed(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Null_check_in_Dto_projection_should_not_be_removed(async));
+        AssertMql();
+    }
+    public override async Task Null_check_in_anonymous_type_projection_should_not_be_removed(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Null_check_in_anonymous_type_projection_should_not_be_removed(async));
+        AssertMql();
+    }
+    public override async Task Optional_navigation_with_Include_ThenInclude(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Optional_navigation_with_Include_ThenInclude(async));
+        AssertMql();
+#else
+        await base.Optional_navigation_with_Include_ThenInclude(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_inner._id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelFour", "localField" : "_id", "foreignField" : "Level3_Optional_Id", "as" : "_lookup_OneToOne_Optional_FK3" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Optional_FK3", "preserveNullAndEmptyArrays" : true } }], "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Optional_navigation_with_Include_and_order(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Optional_navigation_with_Include_and_order(async));
+        AssertMql();
+#else
+        await base.Optional_navigation_with_Include_and_order(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$sort" : { "_inner.Name" : 1 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Optional_navigation_with_order_by_and_Include(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Optional_navigation_with_order_by_and_Include(async));
+        AssertMql();
+#else
+        await base.Optional_navigation_with_order_by_and_Include(async);
+        AssertMql(
+            """
+LevelOne.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_outer._id", "foreignField" : "Level1_Optional_Id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$sort" : { "_inner.Name" : 1 } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_inner._id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_inner._lookup_OneToMany_Optional2" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
+""");
+#endif
+    }
+    public override async Task Orderby_SelectMany_with_Include1(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Orderby_SelectMany_with_Include1(async));
+        AssertMql();
+    }
+    public override async Task Project_collection_and_include(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_and_include(async));
+        AssertMql();
+    }
+#if !EF8
+    public override async Task Project_collection_and_nested_conditional(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_and_nested_conditional(async));
+        AssertMql();
+    }
+#endif
+    public override async Task Project_collection_and_root_entity(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_and_root_entity(async));
+        AssertMql();
+    }
+    public override async Task Project_collection_navigation(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_navigation(async));
+        AssertMql();
+    }
+    public override async Task Project_collection_navigation_composed(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_navigation_composed(async));
+        AssertMql();
+    }
+    public override async Task Project_collection_navigation_nested(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_navigation_nested(async));
+        AssertMql();
+    }
+    public override async Task Project_collection_navigation_nested_anonymous(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_navigation_nested_anonymous(async));
+        AssertMql();
+    }
+    public override async Task Project_collection_navigation_nested_with_take(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_navigation_nested_with_take(async));
+        AssertMql();
+    }
+    public override async Task Project_collection_navigation_using_ef_property(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_collection_navigation_using_ef_property(async));
+        AssertMql();
+    }
+    public override async Task Project_navigation_and_collection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Project_navigation_and_collection(async));
+        AssertMql();
+    }
+    public override async Task Projecting_collection_after_optional_reference_correlated_with_parent(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Projecting_collection_after_optional_reference_correlated_with_parent(async));
+        AssertMql();
+    }
+    public override async Task Projecting_collection_with_FirstOrDefault(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Projecting_collection_with_FirstOrDefault(async));
+        AssertMql();
+    }
+    public override async Task Projecting_collection_with_group_by_after_optional_reference_correlated_with_parent(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Projecting_collection_with_group_by_after_optional_reference_correlated_with_parent(async));
+        AssertMql();
+    }
+    public override async Task Queryable_in_subquery_works_when_final_projection_is_List(bool async)
+    {
+        await base.Queryable_in_subquery_works_when_final_projection_is_List(async);
+        AssertMql();
+    }
+    public override async Task Required_navigation_with_Include(bool async)
+    {
+        // Fails: Cross-collection multiple/self-ref/required Include returns wrong data EF-X023
+        await AssertTranslationFailed(() => base.Required_navigation_with_Include(async));
+        AssertMql(
+            """
+LevelThree.{ "$lookup" : { "from" : "LevelTwo", "localField" : "OneToMany_Optional_Inverse3Id", "foreignField" : "_id", "as" : "_lookup_OneToMany_Optional_Inverse3" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Optional_Inverse3", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelOne", "localField" : "_lookup_OneToMany_Optional_Inverse3.OneToMany_Required_Inverse2Id", "foreignField" : "_id", "as" : "_lookup_OneToMany_Required_Inverse2" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Required_Inverse2", "preserveNullAndEmptyArrays" : true } }
+""");
+    }
+    public override async Task Required_navigation_with_Include_ThenInclude(bool async)
+    {
+#if EF8 || EF9
+        // Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020
+        await AssertTranslationFailed(() => base.Required_navigation_with_Include_ThenInclude(async));
+        AssertMql();
+#else
+        // Fails: Cross-collection multiple/self-ref/required Include returns wrong data EF-X023
+        await AssertTranslationFailed(() => base.Required_navigation_with_Include_ThenInclude(async));
+        AssertMql(
+            """
+LevelFour.{ "$lookup" : { "from" : "LevelThree", "localField" : "OneToMany_Optional_Inverse4Id", "foreignField" : "_id", "as" : "_lookup_OneToMany_Optional_Inverse4" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Optional_Inverse4", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "_lookup_OneToMany_Optional_Inverse4.OneToMany_Required_Inverse3Id", "foreignField" : "_id", "as" : "_lookup_OneToMany_Required_Inverse3" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Required_Inverse3", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelOne", "localField" : "OneToMany_Optional_Inverse2Id", "foreignField" : "_id", "as" : "_lookup_OneToMany_Optional_Inverse2" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Optional_Inverse2", "preserveNullAndEmptyArrays" : true } }
+""");
+#endif
+    }
+    public override async Task SelectMany_DefaultIfEmpty_multiple_times_with_joins_projecting_a_collection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_DefaultIfEmpty_multiple_times_with_joins_projecting_a_collection(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_navigation_property_followed_by_select_collection_navigation(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_navigation_property_followed_by_select_collection_navigation(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_navigation_property_with_include_and_followed_by_select_collection_navigation(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_navigation_property_with_include_and_followed_by_select_collection_navigation(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_over_conditional_empty_source(bool async)
+    {
+        await base.SelectMany_over_conditional_empty_source(async);
+        AssertMql();
+    }
+    public override async Task SelectMany_over_conditional_null_source(bool async)
+    {
+        await base.SelectMany_over_conditional_null_source(async);
+        AssertMql();
+    }
+    public override async Task SelectMany_with_Include1(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_Include1(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_with_Include2(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_Include2(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_with_Include_ThenInclude(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_Include_ThenInclude(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_with_Include_and_order_by(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_Include_and_order_by(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_with_navigation_and_Distinct(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_navigation_and_Distinct(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_navigation_and_Distinct_projecting_columns_including_join_key(async));
+        AssertMql();
+    }
+    public override async Task SelectMany_with_order_by_and_Include(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_order_by_and_Include(async));
+        AssertMql();
+    }
+    public override async Task Select_nav_prop_collection_one_to_many_required(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Select_nav_prop_collection_one_to_many_required(async));
+        AssertMql();
+    }
+    public override async Task Select_subquery_single_nested_subquery(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Select_subquery_single_nested_subquery(async));
+        AssertMql();
+    }
+    public override async Task Select_subquery_single_nested_subquery2(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Select_subquery_single_nested_subquery2(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_Distinct_on_grouping_element(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_Take_Distinct_on_grouping_element(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_Select_collection_Skip_Take(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Skip_Take_Select_collection_Skip_Take(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_ToList_on_grouping_element(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_Take_ToList_on_grouping_element(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_on_grouping_element(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_Take_on_grouping_element(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_on_grouping_element_inside_collection_projection(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_Take_on_grouping_element_inside_collection_projection(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_on_grouping_element_into_non_entity(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_Take_on_grouping_element_into_non_entity(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_on_grouping_element_with_collection_include(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_Take_on_grouping_element_with_collection_include(async));
+        AssertMql();
+    }
+    public override async Task Skip_Take_on_grouping_element_with_reference_include(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_Take_on_grouping_element_with_reference_include(async));
+        AssertMql();
+    }
+    public override async Task Skip_on_grouping_element(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Skip_on_grouping_element(async));
+        AssertMql();
+    }
+    public override async Task Take_Select_collection_Take(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Take_Select_collection_Take(async));
+        AssertMql();
+    }
+    public override async Task Take_on_correlated_collection_in_projection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Take_on_correlated_collection_in_projection(async));
+        AssertMql();
+    }
+    public override async Task Take_on_grouping_element(bool async)
+    {
+        // Fails: GroupBy issue EF-149
+        await AssertTranslationFailed(() => base.Take_on_grouping_element(async));
+        AssertMql();
+    }
+
+    public override async Task Complex_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_with_other_query_operators_composed_on_top(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.Complex_SelectMany_with_nested_navigations_and_explicit_DefaultIfEmpty_with_other_query_operators_composed_on_top(async));
+        AssertMql();
+    }
+
+    public override async Task Filtered_include_multiple_multi_level_includes_with_first_level_using_filter_include_on_one_of_the_chains_only(bool async)
+    {
+        await base.Filtered_include_multiple_multi_level_includes_with_first_level_using_filter_include_on_one_of_the_chains_only(async);
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$match" : { "Name" : { "$ne" : "Foo" } } }, { "$sort" : { "_id" : 1 } }, { "$limit" : 2 }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "Level2_Required_Id", "as" : "_lookup_OneToOne_Required_FK2" } }, { "$unwind" : { "path" : "$_lookup_OneToOne_Required_FK2", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "LevelThree", "localField" : "_id", "foreignField" : "OneToMany_Optional_Inverse3Id", "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+
+    public override async Task Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times(bool async)
+    {
+        // Fails: Cross-document navigation/multi-include returns wrong data EF-216
+        await AssertTranslationFailed(() => base.Multi_level_include_correct_PK_is_chosen_as_the_join_predicate_for_queries_that_join_same_table_multiple_times(async));
+        AssertMql(
+            """
+LevelOne.{ "$lookup" : { "from" : "LevelTwo", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse2Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelThree", "let" : { "localField" : "$_id" }, "pipeline" : [{ "$match" : { "$expr" : { "$eq" : ["$OneToMany_Optional_Inverse3Id", "$$localField"] } } }, { "$lookup" : { "from" : "LevelTwo", "localField" : "OneToMany_Required_Inverse3Id", "foreignField" : "_id", "as" : "_lookup_OneToMany_Required_Inverse3" } }, { "$unwind" : { "path" : "$_lookup_OneToMany_Required_Inverse3", "preserveNullAndEmptyArrays" : true } }], "as" : "_lookup_OneToMany_Optional2" } }], "as" : "_lookup_OneToMany_Optional1" } }
+""");
+    }
+
+    public override async Task SelectMany_with_predicate_and_DefaultIfEmpty_projecting_root_collection_element_and_another_collection(bool async)
+    {
+        // Fails: Subquery selection EF-X001
+        await AssertTranslationFailed(() => base.SelectMany_with_predicate_and_DefaultIfEmpty_projecting_root_collection_element_and_another_collection(async));
+        AssertMql();
+    }
+
+    protected new static async Task AssertTranslationFailed(Func<Task> query)
+    {
+        try
+        {
+            await query();
+        }
+        catch
+        {
+            return;
+        }
+
+        throw new Xunit.Sdk.XunitException("Expected query to fail but it succeeded.");
+    }
+
+    private void AssertMql(params string[] expected)
+        => Fixture.TestMqlLoggerFactory.AssertBaseline(expected);
+}

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/ComplexNavigationsQueryMongoFixture.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/ComplexNavigationsQueryMongoFixture.cs
@@ -1,0 +1,107 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
+
+namespace MongoDB.EntityFrameworkCore.SpecificationTests.Query;
+
+public class ComplexNavigationsQueryMongoFixture : ComplexNavigationsQueryFixtureBase
+{
+    protected override string StoreName
+        => TestDatabaseNamer.GetUniqueDatabaseName("ComplexNavigations");
+
+    private ITestStoreFactory? _testStoreFactory;
+
+    protected override ITestStoreFactory TestStoreFactory
+        => _testStoreFactory!;
+
+    public TestServer TestServer { get; private set; }
+
+    public override async Task InitializeAsync()
+    {
+        TestServer = await TestServer.GetOrInitializeTestServerAsync(MongoCondition.None);
+        _testStoreFactory = new MongoTestStoreFactory(TestServer);
+
+        await base.InitializeAsync();
+    }
+
+    protected override bool UsePooling
+        => false;
+
+    public TestMqlLoggerFactory TestMqlLoggerFactory
+        => (TestMqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+
+    protected override bool ShouldLogCategory(string logCategory)
+        => logCategory == DbLoggerCategory.Query.Name;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.OnModelCreating(modelBuilder, context);
+
+        // MongoDB requires every entity's primary key to be mapped to the "_id" element. The
+        // complex-navigation entities use string keys (Name/DefaultText/Text) that are not auto-mapped.
+        modelBuilder.Entity<ComplexNavigationField>().Property(e => e.Name).HasElementName("_id");
+        modelBuilder.Entity<ComplexNavigationString>().Property(e => e.DefaultText).HasElementName("_id");
+        modelBuilder.Entity<ComplexNavigationGlobalization>().Property(e => e.Text).HasElementName("_id");
+        modelBuilder.Entity<ComplexNavigationLanguage>().Property(e => e.Name).HasElementName("_id");
+
+        // The seed data uses Unspecified-kind DateTimes; MongoDB stores DateTime as UTC, so on write the
+        // driver shifts the value by the local UTC offset and breaks data assertions. Pin the kind to UTC
+        // before serialization so the components round-trip unchanged (the Northwind fixture does the
+        // equivalent by normalizing its seed data to UTC).
+        var toUtc = new ValueConverter<DateTime, DateTime>(
+            v => DateTime.SpecifyKind(v, DateTimeKind.Utc),
+            v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+        var toUtcNullable = new ValueConverter<DateTime?, DateTime?>(
+            v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : v,
+            v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : v);
+
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetDeclaredProperties())
+            {
+                if (property.ClrType == typeof(DateTime))
+                {
+                    property.SetValueConverter(toUtc);
+                }
+                else if (property.ClrType == typeof(DateTime?))
+                {
+                    property.SetValueConverter(toUtcNullable);
+                }
+            }
+        }
+
+        // The one-to-one relationships produce unique indexes on nullable foreign keys. MongoDB rejects a
+        // unique index when more than one document is null/missing for that key (and partial filters cannot
+        // express "not null"), which breaks EnsureCreated for the seeded data. Index uniqueness is not needed
+        // for query correctness in these tests, so relax the auto-created FK indexes to non-unique.
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (var index in entityType.GetDeclaredIndexes().Where(i => i.IsUnique))
+            {
+                index.IsUnique = false;
+            }
+        }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindEFPropertyIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindEFPropertyIncludeQueryMongoTest.cs
@@ -79,7 +79,7 @@ Customers.{ "$sort" : { "CompanyName" : -1 } }, { "$lookup" : { "from" : "Orders
         await base.Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(async);
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -161,7 +161,7 @@ Customers.{ "$skip" : 10 }, { "$limit" : 5 }, { "$lookup" : { "from" : "Orders",
 
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$limit" : 2 }
+Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$limit" : 2 }
 """);
 #endif
     }
@@ -176,7 +176,7 @@ Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "
         await base.Include_references_then_include_collection(async);
         AssertMql(
             """
-Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -686,7 +686,7 @@ OrderDetails.{ "$match" : { "_id.OrderID" : { "$mod" : [23, 13] } } }, { "$proje
         await base.Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(async);
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -758,7 +758,7 @@ OrderDetails.{ "$match" : { "_id.OrderID" : { "$mod" : [23, 13] } } }, { "$looku
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -1108,7 +1108,7 @@ Orders.{ "$match" : { "CustomerID" : "ALFKI" } }, { "$project" : { "_outer" : "$
         await base.Include_reference_and_collection_order_by(async);
         AssertMql(
             """
-Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -1157,7 +1157,7 @@ Customers.{ "$skip" : 10 }, { "$lookup" : { "from" : "Orders", "localField" : "_
 
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$limit" : 2 }
+Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$limit" : 2 }
 """);
 #endif
     }

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeNoTrackingQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeNoTrackingQueryMongoTest.cs
@@ -692,7 +692,7 @@ OrderDetails.{ "$match" : { "_id.OrderID" : { "$mod" : [23, 13] } } }, { "$proje
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeQueryMongoTest.cs
@@ -80,7 +80,7 @@ Customers.{ "$sort" : { "CompanyName" : -1 } }, { "$lookup" : { "from" : "Orders
         await base.Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(async);
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -162,7 +162,7 @@ Customers.{ "$skip" : 10 }, { "$limit" : 5 }, { "$lookup" : { "from" : "Orders",
 
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$limit" : 2 }
+Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$limit" : 2 }
 """);
 #endif
     }
@@ -177,7 +177,7 @@ Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "
         await base.Include_references_then_include_collection(async);
         AssertMql(
             """
-Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -687,7 +687,7 @@ OrderDetails.{ "$match" : { "_id.OrderID" : { "$mod" : [23, 13] } } }, { "$proje
         await base.Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(async);
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -759,7 +759,7 @@ OrderDetails.{ "$match" : { "_id.OrderID" : { "$mod" : [23, 13] } } }, { "$looku
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -1109,7 +1109,7 @@ Orders.{ "$match" : { "CustomerID" : "ALFKI" } }, { "$project" : { "_outer" : "$
         await base.Include_reference_and_collection_order_by(async);
         AssertMql(
             """
-Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -1158,7 +1158,7 @@ Customers.{ "$skip" : 10 }, { "$lookup" : { "from" : "Orders", "localField" : "_
 
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$limit" : 2 }
+Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$limit" : 2 }
 """);
 #endif
     }

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindStringIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindStringIncludeQueryMongoTest.cs
@@ -80,7 +80,7 @@ Customers.{ "$sort" : { "CompanyName" : -1 } }, { "$lookup" : { "from" : "Orders
         await base.Include_with_cycle_does_not_throw_when_AsTracking_NoTrackingWithIdentityResolution(async);
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -162,7 +162,7 @@ Customers.{ "$skip" : 10 }, { "$limit" : 5 }, { "$lookup" : { "from" : "Orders",
 
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$limit" : 2 }
+Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$limit" : 2 }
 """);
 #endif
     }
@@ -177,7 +177,7 @@ Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "
         await base.Include_references_then_include_collection(async);
         AssertMql(
             """
-Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -689,7 +689,7 @@ OrderDetails.{ "$match" : { "_id.OrderID" : { "$mod" : [23, 13] } } }, { "$proje
         await base.Include_with_cycle_does_not_throw_when_AsNoTrackingWithIdentityResolution(async);
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "_id" : { "$lt" : 10800 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -761,7 +761,7 @@ OrderDetails.{ "$match" : { "_id.OrderID" : { "$mod" : [23, 13] } } }, { "$looku
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_outer.City" : "Seattle" } }, { "$lookup" : { "from" : "OrderDetails", "localField" : "_inner._id", "foreignField" : "_id.OrderID", "as" : "_inner._lookup_OrderDetails" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -1111,7 +1111,7 @@ Orders.{ "$match" : { "CustomerID" : "ALFKI" } }, { "$project" : { "_outer" : "$
         await base.Include_reference_and_collection_order_by(async);
         AssertMql(
             """
-Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }
+Orders.{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }
 """);
 #endif
     }
@@ -1160,7 +1160,7 @@ Customers.{ "$skip" : 10 }, { "$lookup" : { "from" : "Orders", "localField" : "_
 
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$limit" : 2 }
+Orders.{ "$match" : { "_id" : 10248 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_inner._id", "foreignField" : "CustomerID", "as" : "_inner._lookup_Orders" } }, { "$set" : { "_inner" : { "$cond" : [{ "$eq" : [{ "$type" : "$_inner._id" }, "missing"] }, "$$REMOVE", "$_inner"] } } }, { "$limit" : 2 }
 """);
 #endif
     }


### PR DESCRIPTION
- Port the EF Core ComplexNavigationsCollectionsQueryTestBase suite to the MongoDB provider
- Translate filtered-Include / dependent query-filter predicates into the $lookup sub-pipeline $match (EF-X021)
- Apply filtered-Include paging (OrderBy/Skip/Take) combined with ThenInclude (EF-X022)
- Emit every interleaved collection+reference ThenInclude branch on a merged collection Include (EF-X025)
- Materialize cross-collection reference ThenIncludes nested in collection elements; re-null synthesized keyless optional-reference parents (EF-X023/X024, partial)
- Re-tag mis-bucketed failures to their real cause (EF-X001, EF-216); document the remaining reference-materialization shapes as deferred to EF-317

Filtered-Include predicates are rendered by the driver (via ExpressionFilterDefinition with the EF entity serializer, like the VectorSearch pre-filter) and inserted into the $lookup sub-pipeline after the FK-correlation $match and before paging; predicates captured below a ThenInclude descent that the driver cannot express (e.g. a query filter referencing a navigation) are best-effort (rendered when possible, else dropped, never silently dropping an explicit user filter). ThenInclude extraction now walks the merged selector with a single type-dispatching pass so interleaved collection/reference branches are all emitted. Nested-target filter $match stages are deferred to EmitLookupStages (where the visitor/serializer are available) and inserted in place.

The deeper multi-level / multi-chain / self-ref reference-materialization shapes (EF-X023/X024, 10 tests) are deferred to EF-317: they need a depth/per-navigation-aware join document model and FK-based navigation resolution, i.e. rebuilding the manual $lookup join-emulation that native driver LeftJoin will replace.

Verified across EF8/EF9/EF10: full specification suite and functional Query tests green.