### PR TITLE
EF-250: Support various string operators in final projection

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -38,7 +38,6 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-227](https://jira.mongodb.org/browse/EF-227) | `Max over empty nullables issue EF-227` | `Min` / `Max` over an empty nullable sequence does not produce the EF-expected `null`. | 4 |
 | [EF-228](https://jira.mongodb.org/browse/EF-228) | `Truncation data loss issue EF-228` | `Sum`/`Average` over `float` columns suffers precision/truncation loss when accumulated server-side. | 2 |
 | [EF-229](https://jira.mongodb.org/browse/EF-229) | `Incorrect results issue EF-229` | `Contains` at the top of the query tree returns wrong results in at least one shape. | 1 |
-| [EF-231](https://jira.mongodb.org/browse/EF-231) | `String.FirstOrDefault issue EF-231` | `String.FirstOrDefault()` in a projection forces a client-evaluation path that is not supported. | 1 |
 | [EF-232](https://jira.mongodb.org/browse/EF-232) | `Sum of empty set cast to nullable issue EF-232` | `Sum_with_no_data_cast_to_nullable` does not produce the EF-expected `null`. (The `Compiled_query_when_does_not_end_in_query_operator` failure that previously also cited EF-232 has been re-tagged as `EF-X011`.) | 1 |
 | [EF-234](https://jira.mongodb.org/browse/EF-234) | `translation of Random issue EF-234` | `EF.Functions.Random()` is not translated. | 2 |
 | [EF-235](https://jira.mongodb.org/browse/EF-235) | `Translate Convert methods issue EF-235` | `Convert.ToBoolean/Byte/Int*/Decimal/Double/String/...` calls are not translated. | 8 |
@@ -54,7 +53,6 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-247](https://jira.mongodb.org/browse/EF-247) | `Regex with non-constant pattern issue EF-247` | `Regex.IsMatch` with a non-constant pattern is not translated. | 1 |
 | [EF-248](https://jira.mongodb.org/browse/EF-248) | `Translate String.FirstOrDefault and String.LastOrDefault issue EF-248` | `String.FirstOrDefault()` / `LastOrDefault()` (LINQ-on-string) is not translated. | 2 |
 | [EF-249](https://jira.mongodb.org/browse/EF-249) | `checked issue EF-249` | `checked { ... }` arithmetic is not honored — the `Checked_context_with_arithmetic_does_not_fail` test sees a different exception than EF expects. | 1 |
-| [EF-250](https://jira.mongodb.org/browse/EF-250) | `Client eval in final projection EF-250` | `Select(...)` with a client-evaluated expression in the final projection (e.g. `i.ToString()` on a server value) is not supported. | 7 |
 | [EF-252](https://jira.mongodb.org/browse/EF-252) | `Concurrency detector tests broken EF-252` | `Throws_on_concurrent_query_first/list` — the concurrency detector does not fire as the EF base test expects. | 2 |
 | [EF-253](https://jira.mongodb.org/browse/EF-253) | `Multiple ordering issue EF-253` | `OrderBy(x).ThenBy(x)` on the same column with different directions does not emit the expected MQL. | 1 |
 | [EF-254](https://jira.mongodb.org/browse/EF-254) | `Take zero EF-254` | `.Skip(0).Take(0)` with a parameter does not produce the expected empty result. | 1 |

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -67,9 +67,24 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
                 {
                     var projection = GetProjection(projectionBindingExpression);
                     alias = projection.Alias;
-                    if (alias is null)
-                        return _docParameter;
                     sourceExpression = projection.Expression;
+                    if (alias is null)
+                    {
+                        // A null alias usually means the binding is the whole document/entity
+                        // (e.g. select new { o }) — hand back the BsonDocument for the entity shaper.
+                        // But a scalar root-property binding (e.g. select p.name.ToArray()) also has no
+                        // alias; resolve it to a field read instead of returning the whole document.
+                        var rootField = TryResolveFieldAccess(sourceExpression);
+                        if (rootField.Property != null)
+                            return CreateGetValueExpression(
+                                rootField.DocumentExpression ?? _docParameter, rootField.Property,
+                                projectionBindingExpression.Type);
+                        if (rootField.FieldName != null)
+                            return BsonBinding.CreateGetElementValue(
+                                rootField.DocumentExpression ?? _docParameter, rootField.FieldName,
+                                projectionBindingExpression.Type);
+                        return _docParameter;
+                    }
                 }
                 else
                 {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionAnalyzer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/ProjectionAnalyzer.cs
@@ -14,6 +14,7 @@
  */
 
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 
@@ -32,7 +33,39 @@ internal static class ProjectionAnalyzer
     /// contains entity references or other constructs that require client-side materialization.
     /// </summary>
     public static bool CanPushDown(Expression shaperExpression)
-        => !ContainsEntityReference(shaperExpression);
+        => !ContainsEntityReference(shaperExpression)
+           && !ContainsUntranslatableProjection(shaperExpression);
+
+    private static bool ContainsUntranslatableProjection(Expression expression)
+    {
+        var finder = new UntranslatableProjectionFinder();
+        finder.Visit(expression);
+        return finder.Found;
+    }
+
+    private sealed class UntranslatableProjectionFinder : ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            // A LINQ (Enumerable.*) operator applied to a string treats the string as
+            // IEnumerable<char>, which the driver cannot translate — StringSerializer is not
+            // an IBsonArraySerializer. This covers ToArray / ToList / AsEnumerable /
+            // FirstOrDefault / LastOrDefault / etc. over a string. Don't push the projection
+            // down; route it to the client shaper so the operator runs on the materialized
+            // value. (EF-250, EF-231)
+            if (node.Method.DeclaringType == typeof(Enumerable)
+                && node.Arguments.Count >= 1
+                && node.Arguments[0].Type == typeof(string))
+            {
+                Found = true;
+                return node;
+            }
+
+            return base.VisitMethodCall(node);
+        }
+    }
 
     private static bool ContainsEntityReference(Expression expression)
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -1070,6 +1070,19 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
         Assert.Equal(7, results[1].orderFromSun);
     }
 
+    [Fact]
+    public void Select_untranslatable_in_final_projection_is_client_evaluated()
+    {
+        // EF-250: string.ToArray() has no server translation. The final projection is
+        // client-evaluated (as the SQL providers do): the driver returns the documents and
+        // p.name.ToArray() runs on the client, returning each name as a char[].
+        var results = _db.Planets.Select(p => p.name.ToArray()).ToList();
+
+        Assert.Equal(8, results.Count);
+        Assert.All(results, chars => Assert.NotEmpty(chars));
+        Assert.Contains(results, chars => new string(chars) == "Earth");
+    }
+
     private static string FormatLabel(string name) => $"[{name}]";
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -1963,11 +1963,7 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task String_FirstOrDefault_in_projection_does_not_do_client_eval(bool async)
     {
-        // Fails: String.FirstOrDefault issue EF-231
-        Assert.Contains(
-            "StringSerializer must implement IBsonArraySerializer",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                base.String_FirstOrDefault_in_projection_does_not_do_client_eval(async))).Message);
+        await base.String_FirstOrDefault_in_projection_does_not_do_client_eval(async);
 
         AssertMql(
             """

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -3878,40 +3878,31 @@ Orders.{ "$match" : { "_id" : { "$lt" : 10300 } } }, { "$sort" : { "_id" : 1 } }
 
     public override async Task ToList_over_string(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "StringSerializer must implement IBsonArraySerializer",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.ToList_over_string(async))).Message);
+        await base.ToList_over_string(async);
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$sort" : { "_id" : 1 } }
             """);
     }
 
     public override async Task ToArray_over_string(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "StringSerializer must implement IBsonArraySerializer",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.ToArray_over_string(async))).Message);
+        await base.ToArray_over_string(async);
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$sort" : { "_id" : 1 } }
             """);
     }
 
     public override async Task AsEnumerable_over_string(bool async)
     {
-        // Fails: Client eval in final projection EF-250
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() => base.AsEnumerable_over_string(async))).Message);
+        await base.AsEnumerable_over_string(async);
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$sort" : { "_id" : 1 } }
             """);
     }
 


### PR DESCRIPTION
A final projection containing a LINQ operator over a string (e.g. Select(o => o.Foo.ToArray())) threw 'StringSerializer must implement IBsonArraySerializer to be used with LINQ' because the whole projection was pushed to the driver.

EF Core typically allows such an expression to be client-evaluated in the final projection.

Fixes [EF-231](https://jira.mongodb.org/browse/EF-231) and [EF-250](https://jira.mongodb.org/browse/EF-250)