### PR TITLE
Remove now-incorrect LeftJoin test

### DIFF
--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/UnsupportedQueryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/UnsupportedQueryTests.cs
@@ -38,20 +38,6 @@ public sealed class UnsupportedQueriesTests(ReadOnlySampleGuidesFixture database
         Assert.Contains(" could not be translated", ex.Message);
     }
 
-#if !EF8 && !EF9
-
-    [Fact]
-    public void LeftJoin_throws_not_supported_exception()
-    {
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => _db.Planets.LeftJoin(_db.Moons, p => p._id, m => m.planetId, (p, m) => new {p, m}).ToList());
-
-        Assert.Contains(".LeftJoin(", ex.Message);
-        Assert.Contains(" could not be translated", ex.Message);
-    }
-
-#endif
-
     [Fact]
     public void SelectMany_throws_because_target_is_not_primitive()
     {


### PR DESCRIPTION
Now removing this test.

Note, we can't invert this test as while it's negative against C# driver main, it's positive for released versions of the driver.