### PR TITLE
EF-320: Reject concurrency tokens on owned entities

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoModelValidator.cs
@@ -72,6 +72,7 @@ public class MongoModelValidator : ModelValidator
 
         ValidateNoTablePerType(model);
         ValidateMaximumOneRowVersionPerEntity(model);
+        ValidateNoConcurrencyTokensOnOwnedEntities(model);
         ValidateNoUnsupportedAttributesOrAnnotations(model);
         ValidateElementNames(model);
         ValidateOwnedTypeMappingConsistency(model);
@@ -148,6 +149,37 @@ public class MongoModelValidator : ModelValidator
                 throw new NotSupportedException(
                     $"Entity '{entityType.DisplayName()}' has multiple properties '{propertyNames
                     }' configured as row versions. Only one row version property per entity is supported.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Validate that concurrency tokens are only configured on document-root entities.
+    /// </summary>
+    /// <param name="model">The <see cref="IModel"/> to validate for correctness.</param>
+    /// <remarks>
+    /// A concurrency token on an owned entity cannot be honored: updates operate on the whole
+    /// document and the update filter is built only from the document-root entity's properties
+    /// (see <c>MongoUpdate.WriteConcurrencyTokens</c>). Rather than silently ignore the token and
+    /// give a false sense of optimistic-concurrency protection, the configuration is rejected.
+    /// A concurrency token on the document-root entity guards the whole document, including any
+    /// changes to its owned entities.
+    /// </remarks>
+    /// <exception cref="NotSupportedException">When a concurrency token is configured on an owned entity.</exception>
+    private static void ValidateNoConcurrencyTokensOnOwnedEntities(IModel model)
+    {
+        foreach (var entityType in model.GetEntityTypes())
+        {
+            if (entityType.IsDocumentRoot()) continue;
+
+            var concurrencyToken = entityType.GetProperties().FirstOrDefault(p => p.IsConcurrencyToken);
+            if (concurrencyToken != null)
+            {
+                throw new NotSupportedException(
+                    PropertyOnEntity(concurrencyToken) +
+                    " is configured as a concurrency token, but it belongs to an owned entity." +
+                    " Concurrency tokens are only supported on the document-root entity, where they" +
+                    " guard the whole document including its owned entities.");
             }
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoModelValidatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoModelValidatorTests.cs
@@ -492,6 +492,78 @@ public static class MongoModelValidatorTests
         Assert.Contains($"{nameof(VersionableEntity.VersionB)}", ex.Message);
     }
 
+    class OwnerWithConcurrencyCheckedOwned
+    {
+        public int _id { get; set; }
+        public ConcurrencyTokenOwned Owned { get; set; }
+    }
+
+    class ConcurrencyTokenOwned
+    {
+        [ConcurrencyCheck] public int Version { get; set; }
+        public string Text { get; set; }
+    }
+
+    class OwnerWithPlainOwned
+    {
+        public int _id { get; set; }
+        public int RootVersion { get; set; }
+        public PlainOwned Owned { get; set; }
+    }
+
+    class PlainOwned
+    {
+        public int Version { get; set; }
+        public string Text { get; set; }
+    }
+
+    [Fact]
+    public static void Validate_throws_when_owned_entity_has_concurrency_token_attribute()
+    {
+        using var db = SingleEntityDbContext.Create<OwnerWithConcurrencyCheckedOwned>();
+
+        var ex = Assert.Throws<NotSupportedException>(() => db.Model);
+        Assert.Contains($"'{nameof(ConcurrencyTokenOwned.Version)}'", ex.Message);
+        Assert.Contains("concurrency token", ex.Message);
+        Assert.Contains("owned entity", ex.Message);
+    }
+
+    [Fact]
+    public static void Validate_throws_when_owned_entity_has_fluent_concurrency_token()
+    {
+        using var db = SingleEntityDbContext.Create<OwnerWithPlainOwned>(mb =>
+            mb.Entity<OwnerWithPlainOwned>()
+                .OwnsOne(e => e.Owned, b => b.Property(p => p.Version).IsConcurrencyToken()));
+
+        var ex = Assert.Throws<NotSupportedException>(() => db.Model);
+        Assert.Contains($"'{nameof(PlainOwned.Version)}'", ex.Message);
+        Assert.Contains("concurrency token", ex.Message);
+    }
+
+    [Fact]
+    public static void Validate_throws_when_owned_entity_has_row_version()
+    {
+        using var db = SingleEntityDbContext.Create<OwnerWithPlainOwned>(mb =>
+            mb.Entity<OwnerWithPlainOwned>()
+                .OwnsOne(e => e.Owned, b => b.Property(p => p.Version).IsRowVersion()));
+
+        var ex = Assert.Throws<NotSupportedException>(() => db.Model);
+        Assert.Contains($"'{nameof(PlainOwned.Version)}'", ex.Message);
+    }
+
+    [Fact]
+    public static void Validate_succeeds_when_root_entity_has_concurrency_token()
+    {
+        using var db = SingleEntityDbContext.Create<OwnerWithPlainOwned>(mb =>
+            mb.Entity<OwnerWithPlainOwned>(e =>
+            {
+                e.Property(p => p.RootVersion).IsConcurrencyToken();
+                e.OwnsOne(o => o.Owned);
+            }));
+
+        Assert.NotNull(db.Model);
+    }
+
     class VersionableEntity
     {
         public int _id { get; set; }


### PR DESCRIPTION
A concurrency token (e.g. [ConcurrencyCheck], [Timestamp], .IsConcurrencyToken(), .IsRowVersion()) configured on an owned entity was silently ignored: updates operate on the whole document and the update filter is built only from the document-root entity's properties, so the token never reached the filter and concurrent edits to the owned entity went undetected.

Reject this configuration during model validation rather than give a false sense of optimistic-concurrency protection. A token on the document-root entity already guards the whole document, including its owned entities.