### PR TITLE
EF-323: Native query-translation foundation (native filter / sort / paging)

### DIFF
--- a/benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/HeadlineBenchmarks.cs
+++ b/benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/HeadlineBenchmarks.cs
@@ -1,23 +1,29 @@
 using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
+using MongoDB.EntityFrameworkCore.Infrastructure;
 
 namespace MongoDB.EntityFrameworkCore.Benchmarks;
 
-// Two-config headline benchmarks (on main, before the native path exists):
-//   DriverOnly  - raw MongoDB C# driver LINQ / aggregation, no EF Core (perf floor).
-//   EF          - the current EF provider (driver-LINQ delegation == main baseline).
-// A third config (EF-Native) is added in sub-project 1. All configs read the SAME documents
-// seeded once in [GlobalSetup], via one shared MongoClient (fairness: a per-context client would
-// charge connection-pool + topology startup to the EF numbers).
+// Three-config headline benchmarks (EF-323: native query path):
+//   DriverOnly      - raw MongoDB C# driver LINQ / aggregation, no EF Core (perf floor).
+//   EF_DriverLinq   - EF provider pinned to UseQueryMode(MongoQueryMode.DriverLinq) == the
+//                     pre-rebuild "EF-current" baseline (matches the numbers in perf-baseline.md).
+//   EF_Native       - EF provider in UseQueryMode(MongoQueryMode.Native) == the new native path.
+//                     ReferenceInclude falls back to driver-LINQ (deferred — Include is not yet
+//                     native), so EF_Native ≈ EF_DriverLinq for that shape.
+// All configs read the SAME documents seeded once in [GlobalSetup], via one shared MongoClient
+// (fairness: a per-context client would charge connection-pool + topology startup to EF numbers).
 [Config(typeof(BenchmarkConfig))]
 public class HeadlineBenchmarks
 {
     private const int N = 10_000;
 
-    private DbContextOptions<BenchmarkDbContext> _efOptions = null!;
+    private DbContextOptions<BenchmarkDbContext> _efOptionsDriverLinq = null!;
+    private DbContextOptions<BenchmarkDbContext> _efOptionsNative = null!;
     private IMongoCollection<FlatItem> _flatColl = null!;
     private IMongoCollection<Review> _reviewColl = null!;
     private IMongoCollection<Product> _productColl = null!;
@@ -31,10 +37,18 @@ public class HeadlineBenchmarks
         _dbName = "ef_bench_headline_" + Guid.NewGuid().ToString("N");
         _client = new MongoClient(conn);
 
-        _efOptions = new DbContextOptionsBuilder<BenchmarkDbContext>()
-            .UseMongoDB(_client, _dbName).Options;
+        _efOptionsDriverLinq = new DbContextOptionsBuilder<BenchmarkDbContext>()
+            .UseMongoDB(_client, _dbName, o => o.UseQueryMode(MongoQueryMode.DriverLinq))
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
 
-        using (var ctx = new BenchmarkDbContext(_efOptions))
+        _efOptionsNative = new DbContextOptionsBuilder<BenchmarkDbContext>()
+            .UseMongoDB(_client, _dbName, o => o.UseQueryMode(MongoQueryMode.Native))
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
+
+        // Seed using DriverLinq options (seeding is writes, unaffected by query mode).
+        using (var ctx = new BenchmarkDbContext(_efOptionsDriverLinq))
         {
             BenchmarkSeeder.Seed(ctx, flatCount: N, productCount: 100, reviewCount: N);
         }
@@ -53,17 +67,35 @@ public class HeadlineBenchmarks
         var driverWhere = _flatColl.AsQueryable().Where(f => f.Active).ToList().Count;
         var driverReview = DriverReviewInclude();
 
-        using var ef = new BenchmarkDbContext(_efOptions);
-        var efAll = ef.FlatItems.AsNoTracking().ToList().Count;
-        var efWhere = ef.FlatItems.AsNoTracking().Where(f => f.Active).ToList().Count;
-        var efReview = ef.Reviews.AsNoTracking().Include(r => r.Product).ToList().Count(r => r.Product != null);
+        // Validate EF_DriverLinq
+        using (var efDl = new BenchmarkDbContext(_efOptionsDriverLinq))
+        {
+            var efAll = efDl.FlatItems.AsNoTracking().ToList().Count;
+            var efWhere = efDl.FlatItems.AsNoTracking().Where(f => f.Active).ToList().Count;
+            var efReview = efDl.Reviews.AsNoTracking().Include(r => r.Product).ToList().Count(r => r.Product != null);
 
-        if (driverAll != N || efAll != N)
-            throw new InvalidOperationException($"FlatItem count mismatch: driver={driverAll}, ef={efAll}, expected {N}.");
-        if (driverWhere != efWhere)
-            throw new InvalidOperationException($"Where count mismatch: driver={driverWhere}, ef={efWhere}.");
-        if (driverReview != N || efReview != N)
-            throw new InvalidOperationException($"Review+Product mismatch: driver={driverReview}, ef={efReview}, expected {N}.");
+            if (driverAll != N || efAll != N)
+                throw new InvalidOperationException($"FlatItem count mismatch (DriverLinq): driver={driverAll}, ef={efAll}, expected {N}.");
+            if (driverWhere != efWhere)
+                throw new InvalidOperationException($"Where count mismatch (DriverLinq): driver={driverWhere}, ef={efWhere}.");
+            if (driverReview != N || efReview != N)
+                throw new InvalidOperationException($"Review+Product mismatch (DriverLinq): driver={driverReview}, ef={efReview}, expected {N}.");
+        }
+
+        // Parity: EF_Native must return the same counts as EF_DriverLinq (correctness gate).
+        using (var efN = new BenchmarkDbContext(_efOptionsNative))
+        {
+            var efAllNative = efN.FlatItems.AsNoTracking().ToList().Count;
+            var efWhereNative = efN.FlatItems.AsNoTracking().Where(f => f.Active).ToList().Count;
+            var efReviewNative = efN.Reviews.AsNoTracking().Include(r => r.Product).ToList().Count(r => r.Product != null);
+
+            if (driverAll != efAllNative)
+                throw new InvalidOperationException($"FlatItem count mismatch (Native): driver={driverAll}, efNative={efAllNative}, expected {N}.");
+            if (driverWhere != efWhereNative)
+                throw new InvalidOperationException($"Where count mismatch (Native): driver={driverWhere}, efNative={efWhereNative}.");
+            if (efReviewNative != N)
+                throw new InvalidOperationException($"Review+Product mismatch (Native): efNative={efReviewNative}, expected {N}.");
+        }
     }
 
     // Hand-written $lookup + $unwind equivalent of Reviews.Include(r => r.Product).
@@ -97,7 +129,7 @@ public class HeadlineBenchmarks
     [GlobalCleanup]
     public void Cleanup()
     {
-        using var ctx = new BenchmarkDbContext(_efOptions);
+        using var ctx = new BenchmarkDbContext(_efOptionsDriverLinq);
         ctx.Database.EnsureDeleted();
     }
 
@@ -105,30 +137,47 @@ public class HeadlineBenchmarks
     [Benchmark] public int WhereToList_DriverOnly()
         => _flatColl.AsQueryable().Where(f => f.Active).ToList().Count;
 
-    [Benchmark] public int WhereToList_EF()
-    { using var ctx = new BenchmarkDbContext(_efOptions); return ctx.FlatItems.AsNoTracking().Where(f => f.Active).ToList().Count; }
+    [Benchmark] public int WhereToList_EF_DriverLinq()
+    { using var ctx = new BenchmarkDbContext(_efOptionsDriverLinq); return ctx.FlatItems.AsNoTracking().Where(f => f.Active).ToList().Count; }
+
+    [Benchmark] public int WhereToList_EF_Native()
+    { using var ctx = new BenchmarkDbContext(_efOptionsNative); return ctx.FlatItems.AsNoTracking().Where(f => f.Active).ToList().Count; }
 
     // ----- whole-entity ToList() -----
     [Benchmark] public int WholeEntityToList_DriverOnly()
         => _flatColl.AsQueryable().ToList().Count;
 
-    [Benchmark] public int WholeEntityToList_EF_NoTracking()
-    { using var ctx = new BenchmarkDbContext(_efOptions); return ctx.FlatItems.AsNoTracking().ToList().Count; }
+    [Benchmark] public int WholeEntityToList_EF_DriverLinq_NoTracking()
+    { using var ctx = new BenchmarkDbContext(_efOptionsDriverLinq); return ctx.FlatItems.AsNoTracking().ToList().Count; }
 
-    [Benchmark] public int WholeEntityToList_EF_Tracked()
-    { using var ctx = new BenchmarkDbContext(_efOptions); return ctx.FlatItems.ToList().Count; }
+    [Benchmark] public int WholeEntityToList_EF_DriverLinq_Tracked()
+    { using var ctx = new BenchmarkDbContext(_efOptionsDriverLinq); return ctx.FlatItems.ToList().Count; }
+
+    [Benchmark] public int WholeEntityToList_EF_Native_NoTracking()
+    { using var ctx = new BenchmarkDbContext(_efOptionsNative); return ctx.FlatItems.AsNoTracking().ToList().Count; }
+
+    [Benchmark] public int WholeEntityToList_EF_Native_Tracked()
+    { using var ctx = new BenchmarkDbContext(_efOptionsNative); return ctx.FlatItems.ToList().Count; }
 
     // ----- OrderBy(x => x.Count).Take(100).ToList() -----
     [Benchmark] public int OrderByTake_DriverOnly()
         => _flatColl.AsQueryable().OrderBy(f => f.Count).Take(100).ToList().Count;
 
-    [Benchmark] public int OrderByTake_EF()
-    { using var ctx = new BenchmarkDbContext(_efOptions); return ctx.FlatItems.AsNoTracking().OrderBy(f => f.Count).Take(100).ToList().Count; }
+    [Benchmark] public int OrderByTake_EF_DriverLinq()
+    { using var ctx = new BenchmarkDbContext(_efOptionsDriverLinq); return ctx.FlatItems.AsNoTracking().OrderBy(f => f.Count).Take(100).ToList().Count; }
+
+    [Benchmark] public int OrderByTake_EF_Native()
+    { using var ctx = new BenchmarkDbContext(_efOptionsNative); return ctx.FlatItems.AsNoTracking().OrderBy(f => f.Count).Take(100).ToList().Count; }
 
     // ----- Reviews.Include(r => r.Product).ToList() -----
+    // Note: ReferenceInclude falls back to driver-LINQ even in Native mode (Include is deferred —
+    // not yet native). EF_Native ≈ EF_DriverLinq for this shape.
     [Benchmark] public int ReferenceInclude_DriverOnly()
         => DriverReviewInclude();
 
-    [Benchmark] public int ReferenceInclude_EF()
-    { using var ctx = new BenchmarkDbContext(_efOptions); return ctx.Reviews.AsNoTracking().Include(r => r.Product).ToList().Count; }
+    [Benchmark] public int ReferenceInclude_EF_DriverLinq()
+    { using var ctx = new BenchmarkDbContext(_efOptionsDriverLinq); return ctx.Reviews.AsNoTracking().Include(r => r.Product).ToList().Count; }
+
+    [Benchmark] public int ReferenceInclude_EF_Native()
+    { using var ctx = new BenchmarkDbContext(_efOptionsNative); return ctx.Reviews.AsNoTracking().Include(r => r.Product).ToList().Count; }
 }

--- a/benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/Program.cs
+++ b/benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/Program.cs
@@ -1,5 +1,87 @@
 using Microsoft.EntityFrameworkCore;
+using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Benchmarks;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+
+if (args.Contains("--verify-native"))
+{
+    var conn = Environment.GetEnvironmentVariable("MONGODB_URI") ?? "mongodb://localhost:27017";
+    var dbName = "ef_bench_nativeverify_" + Guid.NewGuid().ToString("N");
+    var client = new MongoClient(conn);
+
+    var seedOptions = new DbContextOptionsBuilder<BenchmarkDbContext>()
+        .UseMongoDB(client, dbName, o => o.UseQueryMode(MongoQueryMode.DriverLinq)).Options;
+    var nativeOnlyOptions = new DbContextOptionsBuilder<BenchmarkDbContext>()
+        .UseMongoDB(client, dbName, o => o.UseQueryMode(MongoQueryMode.NativeOnly)).Options;
+
+    try
+    {
+        using (var ctx = new BenchmarkDbContext(seedOptions))
+            BenchmarkSeeder.Seed(ctx, flatCount: 100, productCount: 20, reviewCount: 100);
+
+        Console.WriteLine("=== NativeOnly verification ===");
+
+        static void RunShape(string label, Action test, bool expectFallback = false)
+        {
+            try
+            {
+                test();
+                if (expectFallback)
+                    Console.WriteLine($"{label}: NATIVE OK <-- UNEXPECTED, should fall back!");
+            }
+            catch (Exception ex) when (ex.GetType().Name == "NativeTranslationNotSupportedException")
+            {
+                if (expectFallback)
+                    Console.WriteLine($"{label}: FALLBACK CONFIRMED (NativeTranslationNotSupportedException)");
+                else
+                    Console.WriteLine($"{label}: FALLBACK (unexpected) — {ex.Message[..Math.Min(80, ex.Message.Length)]}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"{label}: ERROR — {ex.GetType().Name}: {ex.Message[..Math.Min(80, ex.Message.Length)]}");
+            }
+        }
+
+        // WhereToList — should be NATIVE OK
+        RunShape("WhereToList:      ", () =>
+        {
+            using var ctx = new BenchmarkDbContext(nativeOnlyOptions);
+            var count = ctx.FlatItems.AsNoTracking().Where(f => f.Active).ToList().Count;
+            Console.WriteLine($"WhereToList:       NATIVE OK (count={count})");
+        });
+
+        // WholeEntityToList — should be NATIVE OK
+        RunShape("WholeEntityToList:", () =>
+        {
+            using var ctx = new BenchmarkDbContext(nativeOnlyOptions);
+            var count = ctx.FlatItems.AsNoTracking().ToList().Count;
+            Console.WriteLine($"WholeEntityToList: NATIVE OK (count={count})");
+        });
+
+        // OrderByTake — should be NATIVE OK
+        RunShape("OrderByTake:      ", () =>
+        {
+            using var ctx = new BenchmarkDbContext(nativeOnlyOptions);
+            var count = ctx.FlatItems.AsNoTracking().OrderBy(f => f.Count).Take(10).ToList().Count;
+            Console.WriteLine($"OrderByTake:       NATIVE OK (count={count})");
+        });
+
+        // ReferenceInclude — expected to throw NativeTranslationNotSupportedException (Include deferred)
+        RunShape("ReferenceInclude: ", () =>
+        {
+            using var ctx = new BenchmarkDbContext(nativeOnlyOptions);
+            var count = ctx.Reviews.AsNoTracking().Include(r => r.Product).ToList().Count;
+        }, expectFallback: true);
+
+        Console.WriteLine("=== verification done ===");
+    }
+    finally
+    {
+        using var ctx = new BenchmarkDbContext(seedOptions);
+        ctx.Database.EnsureDeleted();
+    }
+    return;
+}
 
 if (args.Contains("--extended-smoke"))
 {

--- a/benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/results/perf-baseline.md
+++ b/benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/results/perf-baseline.md
@@ -47,3 +47,64 @@ ACCOUNT_N=200, ORDER_N=10,000, WIDE_N=5,000. Order shape: 3 lines × 2 discounts
 - Each EF op constructs a new DbContext (realistic per-unit-of-work usage) while the driver reuses one IMongoCollection — a deliberate asymmetry.
 - EF (tracked) measures change-tracking/snapshot overhead, not relationship fixup (FlatItem has no navigations).
 - Aborted runs leak GUID-named `ef_bench_*` databases (cleanup runs only in GlobalCleanup).
+
+---
+
+## Native config (EF-323) — authoritative (quiet-machine pass)
+
+Run: 2026-06-29, **quiet Apple M4 Max** (14 cores), machine held idle during the run (no parallel work). BenchmarkDotNet v0.15.8, .NET 10.0.9 Arm64. Supersedes the earlier provisional containerized pass — both Mean and Allocated are authoritative here and directly comparable to the baseline table above.
+
+Three configs:
+- **DriverOnly** — raw MongoDB C# driver LINQ, no EF Core (floor).
+- **EF_DriverLinq** — EF provider pinned to `UseQueryMode(MongoQueryMode.DriverLinq)` (pre-rebuild baseline; matches the EF numbers in the table above).
+- **EF_Native** — EF provider using `UseQueryMode(MongoQueryMode.Native)` (new path).
+
+N = 10,000. Config: Release EF10, InProcessEmitToolchain, 3 warmup / 10 iterations, MemoryDiagnoser.
+
+### Three-config table
+
+| Shape | Config | Mean (quiet M4 Max) | Allocated |
+|---|---|---|---|
+| WhereToList | DriverOnly | 6.084 ms | 1589.90 KB |
+| WhereToList | EF_DriverLinq | 15.146 ms | 22683.02 KB |
+| WhereToList | EF_Native | 8.269 ms | 9590.97 KB |
+| WholeEntityToList | DriverOnly | 8.481 ms | 3133.01 KB |
+| WholeEntityToList | EF_DriverLinq (no-track) | 32.373 ms | 45284.27 KB |
+| WholeEntityToList | EF_DriverLinq (tracked) | 42.683 ms | 51369.10 KB |
+| WholeEntityToList | EF_Native (no-track) | 15.813 ms | 19108.57 KB |
+| WholeEntityToList | EF_Native (tracked) | 25.219 ms | 25196.83 KB |
+| OrderByTake | DriverOnly | 2.326 ms | 59.42 KB |
+| OrderByTake | EF_DriverLinq | 3.197 ms | 513.80 KB |
+| OrderByTake | EF_Native | 2.608 ms | 243.13 KB |
+| ReferenceInclude | DriverOnly | 37.310 ms | 7332.72 KB |
+| ReferenceInclude | EF_DriverLinq | 136.710 ms | 51953.32 KB |
+| ReferenceInclude | EF_Native | 138.487 ms | 51952.91 KB |
+
+### Native-vs-EF_DriverLinq allocation delta (authoritative)
+
+| Shape | EF_DriverLinq Allocated | EF_Native Allocated | Delta (KB) | Delta (%) |
+|---|---|---|---|---|
+| WhereToList | 22565.71 KB | 9590.87 KB | -12974.84 KB | **-57.5%** |
+| WholeEntityToList (no-track) | 45049.07 KB | 19108.51 KB | -25940.56 KB | **-57.6%** |
+| WholeEntityToList (tracked) | 51134.06 KB | 25195.16 KB | -25938.90 KB | **-50.7%** |
+| OrderByTake | 511.44 KB | 243.16 KB | -268.28 KB | **-52.5%** |
+| ReferenceInclude | 51952.73 KB | 51952.50 KB | ~0 KB | **0%** (Include falls back — deferred) |
+
+### Key observations
+
+- **WhereToList / WholeEntityToList / OrderByTake**: native path cuts allocations by ~50-58% **and** wall-clock time by ~18-51% versus EF_DriverLinq. Native-vs-EF_DriverLinq Mean: WhereToList 8.27 vs 15.15 ms (**-45%**); WholeEntity no-track 15.81 vs 32.37 ms (**-51%**); WholeEntity tracked 25.22 vs 42.68 ms (**-41%**); OrderByTake 2.61 vs 3.20 ms (**-18%**).
+- **ReferenceInclude EF_Native ≈ EF_DriverLinq**: Include navigation is not yet native (deferred) — the query falls back to driver-LINQ automatically in `Native` mode, so both configs produce identical allocations and similar times. This is expected behavior.
+- **EF_DriverLinq baseline vs prior-recorded EF numbers**: EF_DriverLinq allocations (22566 / 45049 / 51134 / 511 / 51953 KB) match the previously recorded EF numbers in the baseline table (22563 / 45048 / 51132 / 509 / 51956 KB) within normal run-to-run variance — confirming EF_DriverLinq is a faithful reproduction of the old EF baseline.
+- **vs the spike's recorded headline (the SP1 "native ≥ spike" success bar): MET on the realized native slice.** The program design recorded (current → native): Where→ToList 15.1→8.3 ms / 22.7→9.6 MB; whole-entity no-track 33.4→15.6 ms / 45.3→19.1 MB. Our quiet-machine native matches almost exactly — Where 8.27 ms / 9.59 MB, whole-entity 15.81 ms / 19.11 MB — i.e. the B2 rebuild reproduces the spike's native performance (≥, within run-to-run noise), confirming no perf regression vs the spike for filter/sort/paging/whole-entity.
+- **Reference Include is the one shape below the spike — by design (deferred).** The spike did Include natively (recorded 114.7 ms / 22.3 MB); here Include falls back to driver-LINQ (~138 ms / 52 MB ≈ EF_DriverLinq), so the spike's Include-native win is **not** realized yet — it is the payoff of the future Collection Includes sub-project, not an SP1 regression.
+
+### Genuine-native confirmation (NativeOnly mode)
+
+Verified by running each shape against `MongoQueryMode.NativeOnly` — a mode that throws `NativeTranslationNotSupportedException` instead of falling back:
+
+| Shape | Result |
+|---|---|
+| WhereToList | NATIVE OK |
+| WholeEntityToList | NATIVE OK |
+| OrderByTake | NATIVE OK |
+| ReferenceInclude | FALLBACK CONFIRMED (NativeTranslationNotSupportedException thrown) |

--- a/docs/superpowers/plans/2026-06-25-mongo-query-ast-foundation-plan.md
+++ b/docs/superpowers/plans/2026-06-25-mongo-query-ast-foundation-plan.md
@@ -1,0 +1,901 @@
+# Native query-translation foundation (sub-project 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the first working native read path — a real Mongo query expression tree + lowerer + renderer + compile-time pipeline factory, plus the native execution path / streaming materializer / DOM shaper / query-mode gate — at **parity** with the spike's native slice (single-collection filter / sort / paging + single-level reference Include over whole-entity results), with driver-LINQ as the gated fallback for everything else.
+
+**Architecture:** The QMTEV stops returning `null` for `Where`/`OrderBy`/`ThenBy`/`Skip`/`Take`/`Select`; instead it populates logical slots on a `MongoSelectExpression` (custom `Expression`, EF `SelectExpression`-style). A `MongoSelectLowerer` turns those slots into a typed `MongoPipelineStage[]` IR; a `MongoQueryLanguageRenderer` renders that to `BsonDocument[]` **once at compile time** into a `MongoPipelineFactory` whose `MongoParameterExpression` placeholders bind per execution. The native-vs-driver decision moves to compile time (deterministic, on `IsNativeRepresentable` + lowering/rendering success), replacing the spike's per-execution try/catch. The streaming materializer, DOM shaper, dual-shaper enumerable, and native execution branch in `MongoClientWrapper.Execute` are **reproduced faithfully** from the spike (reference, not ported wholesale).
+
+**Tech Stack:** C# / .NET (`net10.0` for EF10, `net8.0` for EF8/EF9), EF Core 8/9/10 (multi-config build), MongoDB C# driver (LINQ v3 + raw `MongoDB.Bson`), xUnit + FluentAssertions, BenchmarkDotNet (EF-324 harness).
+
+## Reference material (read before starting)
+
+- **Design (the *how*):** `docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-design.md`.
+- **Overview (the *what/why*):** `docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-overview.md`.
+- **Program design (SP0–SP7 context):** `docs/superpowers/specs/2026-06-23-native-query-provider-design.md` (on `main` since EF-322 merged).
+- **Spike — REFERENCE ONLY, do NOT port wholesale; reproduce the named files faithfully:** branch `spike/low-level-provider`. Read with `git show "origin/spike/low-level-provider:<path>"` (quote the whole arg — zsh treats a bare `$VAR:path` as a history modifier). The native code lives under `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/`.
+
+## Global Constraints
+
+- **Branch base:** implementation is cut from **`EF-324-benchmarks`** (PR #321, not yet merged) so SP0's benchmark harness is present; rebase onto `main` once EF-324 merges. The docs already live on `EF-323-ast-foundation` off `main`.
+- **Multi-EF targeting via build *configurations*, not TFMs:** `Debug|Release EF8`, `Debug|Release EF9`, `Debug|Release EF10`. Build a single version with the **quoted** config: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF10"`. Conditional code uses the `EF8` / `EF9` / `EF10` define constants. Common guards: `#if EF8 || EF9` (legacy) and `#if !EF8` (EF9+).
+- **`<Nullable>enable</Nullable>`** on all `src/` code — annotate new types accordingly.
+- **`<NoWarn>EF1001</NoWarn>`** — consuming EF Core internal APIs is intentional.
+- **Preserve BOMs** on any existing file that has one. New files need no BOM.
+- **Tests run serially** (`[assembly: CollectionBehavior(DisableTestParallelization = true)]`); each functional test gets a unique DB via `TestDatabaseNamer.GetUniqueDatabaseName()`.
+- **Functional/Specification tests need MongoDB** (replica set — `SaveChanges` uses transactions). `MONGODB_URI` / `ATLAS_URI`, else Docker auto-spins. Benchmarks need a replica set via `MONGODB_URI`.
+- **Async:** new async methods take a `CancellationToken` and flow it through unchanged; library code uses `ConfigureAwait(false)`.
+- **QueryContext parameter access guard** (reused verbatim from `MongoShapedQueryCompilingExpressionVisitor.cs:621-633`):
+  ```csharp
+  #if EF8 || EF9
+      // queryContext.ParameterValues.TryGetValue(param.Name, out var value)
+  #else
+      // queryContext.Parameters[queryParam.Name]  (QueryParameterExpression)
+  #endif
+  ```
+- **Don't break the bulk seam.** `ExecuteUpdate`/`ExecuteDelete` cross to Storage as *behavior* (`MongoBulkPlan` delegates), not as data. This plan does not touch it.
+- **Parity, not breadth.** Anything outside the slice (predicate breadth, `$project` pushdown, scalar cardinality, collection/nested/filtered Includes, `GroupBy`/`SelectMany`/set ops/`Distinct`/`OfType`/`VectorSearch`, non-canonical paging) must set `IsNativeRepresentable = false` and fall back — not be half-translated.
+
+---
+
+## File Structure
+
+All new translator code under `src/MongoDB.EntityFrameworkCore/Query/`.
+
+- `NativeTranslation/NativeTranslationNotSupportedException.cs` — **[NEW]** internal signal for un-representable shapes (reproduce spike).
+- `NativeTranslation/MongoQueryMode.cs` — **[NEW]** the gate's effective-mode resolution (replaces spike's `NativeQueryMode` + env var with the public enum).
+- `Expressions/MongoExpression.cs` (+ `MongoFieldExpression`, `MongoConstantExpression`, `MongoParameterExpression`, `MongoBinaryExpression`, `MongoUnaryExpression`, `MongoBinaryOperator`/`MongoUnaryOperator` enums) — **[NEW]** dialect-agnostic `SqlExpression`-analog hierarchy.
+- `Expressions/MongoOrdering.cs` — **[NEW]** `(MongoExpression KeySelector, bool Ascending)`.
+- `Expressions/MongoSelectExpression.cs` — **[NEW]** query-expression-tree root with logical slots; evolves `MongoQueryExpression`.
+- `NativeTranslation/Stages/Mongo{Match,Sort,Skip,Limit,Lookup,Unwind}Stage.cs` (+ `MongoPipelineStage.cs` base) — **[NEW]** typed stage IR.
+- `NativeTranslation/MongoExpressionTranslator.cs` — **[NEW]** EF predicate/key-selector body → `MongoExpression` (carries `NativeExpressionHelpers` element-name + serializer coercion).
+- `NativeTranslation/MongoSelectLowerer.cs` — **[NEW]** `MongoSelectExpression → MongoPipelineStage[]` (absorbs `NativeLookupStages` emission).
+- `NativeTranslation/MongoQueryLanguageRenderer.cs` — **[NEW]** `MongoExpression → $match BSON` (query dialect; `CombineAnd` from `MongoPredicateTranslator`).
+- `NativeTranslation/MongoExprRenderer.cs` — **[NEW]** stubbed `$expr` (aggregation-expression) renderer seam; throws "not yet implemented".
+- `NativeTranslation/MongoPipelineFactory.cs` — **[NEW]** rendered template + placeholder table; `Build(parameterValues) → BsonDocument[]`.
+- `NativeTranslation/{MongoStreamingEntityMaterializerRewriter,BsonRowReader,StreamingEligibility}.cs` — **[NEW, reproduced faithfully from spike]**.
+- `NativeTranslation/DispatchingQueryingEnumerable.cs` — **[NEW, reproduced]** dual-shaper.
+- Modify: `Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs` — slot population.
+- Modify: `Visitors/MongoShapedQueryCompilingExpressionVisitor.cs` — the compile-time gate + native shaper compilation.
+- Modify: `MongoExecutableQuery.cs` — add the `MongoPipelineFactory` (native pipeline carrier).
+- Modify: `QueryingEnumerable.cs` — native source row lifecycle.
+- Modify: `Storage/MongoClientWrapper.cs` — native `Aggregate` branch (reproduce spike `:95-115`).
+- Modify: `Infrastructure/MongoOptionsExtension.cs`, `Infrastructure/MongoDbContextOptionsBuilder.cs`, `Query/MongoQueryCompilationContext.cs` (+ its factory) — the public `MongoQueryMode` option.
+- Modify: `Query/AGENTS.md` — describe the rebuilt architecture (carried-over cleanup).
+- Delete (only after the native path covers the slice — Task 16): `NativeTranslation/MongoPipelineTranslator.cs`, `NativeTranslation/MongoPredicateTranslator.cs` (if reproduced as scaffolding) — superseded by lowerer + renderer + `MongoExpressionTranslator`.
+- Tests: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/*` (new unit tests), `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeOptionTests.cs`.
+- Benchmarks (EF-324 harness): `benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/HeadlineBenchmarks.cs` (+ `BenchmarkConfig.cs`) — add the **native** config; `results/perf-baseline.md` — append native numbers.
+
+---
+
+## Task 1: Branch setup + native-translation scaffolding
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/NativeTranslationNotSupportedException.cs`
+- Reference: spike `NativeTranslation/NativeTranslationNotSupportedException.cs`
+
+**Interfaces:**
+- Produces: `internal sealed class NativeTranslationNotSupportedException : Exception` with `(string message)` ctor — thrown by `MongoExpressionTranslator`/lowerer/renderer when a node can't be represented natively; caught at the gate to flip to the driver path.
+
+- [ ] **Step 1: Cut the implementation branch from EF-324**
+
+```bash
+git fetch origin EF-324-benchmarks
+git switch -c EF-323-impl origin/EF-324-benchmarks
+# Bring the EF-323 design + this plan onto the impl branch:
+git checkout EF-323-ast-foundation -- docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-design.md \
+  docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-overview.md \
+  docs/superpowers/plans/2026-06-25-mongo-query-ast-foundation-plan.md
+```
+
+- [ ] **Step 2: Verify the EF-324 harness is present**
+
+Run: `ls benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/HeadlineBenchmarks.cs benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/results/perf-baseline.md`
+Expected: both paths exist.
+
+- [ ] **Step 3: Build the solution to confirm a green baseline**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF10"`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Add the exception type (reproduce from spike)**
+
+```csharp
+internal sealed class NativeTranslationNotSupportedException : Exception
+{
+    public NativeTranslationNotSupportedException(string message) : base(message) { }
+}
+```
+(Use the spike file's license header; namespace `MongoDB.EntityFrameworkCore.Query.NativeTranslation`.)
+
+- [ ] **Step 5: Build + commit**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF10"` → Build succeeded.
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/NativeTranslationNotSupportedException.cs docs/
+git commit -m "EF-323: Scaffold native-translation foundation (branch off EF-324)"
+```
+
+---
+
+## Task 2: Public `MongoQueryMode` config option + gate plumbing
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Infrastructure/MongoQueryMode.cs` (the public enum)
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoQueryMode.cs` (effective-mode resolution helper — name it `MongoQueryModeResolver` to avoid clashing with the enum)
+- Modify: `src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs`
+- Modify: `src/MongoDB.EntityFrameworkCore/Infrastructure/MongoDbContextOptionsBuilder.cs`
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs` + `Query/Factories/MongoQueryCompilationContextFactory.cs`
+- Reference: spike `MongoOptionsExtension.cs:233-239` (`UseNativeQuery`), `MongoDbContextOptionsBuilder.cs:49-53` (`UseNativeQuery`), `MongoQueryCompilationContextFactory.cs:49`, `NativeTranslation/NativeQueryMode.cs:36-49`
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeOptionTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `public enum MongoQueryMode { Native, DriverLinq, NativeOnly }` (default `Native`).
+  - `MongoOptionsExtension.QueryMode { get; }` + `WithQueryMode(MongoQueryMode)` (clone pattern, like `WithDatabaseName`); folded into `ServiceProviderHash`/`ShouldUseSameServiceProvider`/`LogFragment`/`PopulateDebugInfo` (annotation key `"Mongo:QueryMode"`).
+  - `MongoDbContextOptionsBuilder.UseQueryMode(MongoQueryMode mode)`.
+  - `MongoQueryCompilationContext.QueryMode { get; }` (read from the extension in the factory).
+
+**Note (API stability):** `MongoQueryMode` and `UseQueryMode` are net-new public surface — additive, not a break. The annotation key `"Mongo:QueryMode"` is new (no compiled-model break vs. the latest release). The spike's `MONGODB_EF_NATIVE_QUERY` env var and internal `NativeQueryMode` are **not** reproduced — the public enum replaces them per the design.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+public class QueryModeOptionTests
+{
+    [Fact]
+    public void QueryMode_defaults_to_Native()
+    {
+        var options = new DbContextOptionsBuilder<DbContext>();
+        new MongoDbContextOptionsBuilder(options); // no UseQueryMode call
+        var ext = options.Options.FindExtension<MongoOptionsExtension>();
+        ext!.QueryMode.Should().Be(MongoQueryMode.Native);
+    }
+
+    [Fact]
+    public void UseQueryMode_round_trips_through_the_extension()
+    {
+        var options = new DbContextOptionsBuilder<DbContext>();
+        var optionsExtension = new MongoOptionsExtension().WithConnectionString("mongodb://localhost");
+        ((IDbContextOptionsBuilderInfrastructure)options).AddOrUpdateExtension(optionsExtension);
+        new MongoDbContextOptionsBuilder(options).UseQueryMode(MongoQueryMode.DriverLinq);
+        options.Options.FindExtension<MongoOptionsExtension>()!.QueryMode.Should().Be(MongoQueryMode.DriverLinq);
+    }
+}
+```
+(Mirror the existing options-test setup pattern in `tests/.../FunctionalTests/` — check a sibling test for the exact `MongoDbContextOptionsBuilder` construction idiom and adapt.)
+
+- [ ] **Step 2: Run it; verify it fails to compile (`MongoQueryMode`/`UseQueryMode`/`QueryMode` undefined)**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~QueryModeOptionTests"`
+Expected: compile failure — symbols not defined.
+
+- [ ] **Step 3: Add the enum + option, modeled on the spike's `UseNativeQuery` plumbing**
+
+`Infrastructure/MongoQueryMode.cs`:
+```csharp
+namespace MongoDB.EntityFrameworkCore.Infrastructure;
+
+/// <summary>Selects how the provider translates LINQ queries to MongoDB.</summary>
+public enum MongoQueryMode
+{
+    /// <summary>Native translation when representable; driver-LINQ fallback otherwise. (Default.)</summary>
+    Native,
+    /// <summary>Always use the driver's LINQ provider (the pre-rebuild behavior).</summary>
+    DriverLinq,
+    /// <summary>Native translation only; throw at compile time on an un-representable query (diagnostic).</summary>
+    NativeOnly
+}
+```
+In `MongoOptionsExtension`: add `public virtual MongoQueryMode QueryMode { get; private set; } = MongoQueryMode.Native;`, copy it in the copy-ctor, add `WithQueryMode(...)` (clone-and-set, like `WithDatabaseName` at `:115`), and fold it into `ServiceProviderHash` / `ShouldUseSameServiceProvider` / `LogFragment` / `PopulateDebugInfo` exactly where the spike folds `UseNativeQuery` (`:301`, `:313`, `:356`, `:322`).
+In `MongoDbContextOptionsBuilder`: add `UseQueryMode(MongoQueryMode mode)` returning `WithOption(e => e.WithQueryMode(mode))` (match the existing builder method idiom).
+
+- [ ] **Step 4: Plumb the mode onto `MongoQueryCompilationContext`**
+
+Add `public MongoQueryMode QueryMode { get; }` to `MongoQueryCompilationContext`; set it in `MongoQueryCompilationContextFactory.Create` from `dependencies...FindExtension<MongoOptionsExtension>()?.QueryMode ?? MongoQueryMode.Native` (mirror spike factory `:49`).
+
+- [ ] **Step 5: Run the test; verify it passes**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~QueryModeOptionTests"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Infrastructure/ src/MongoDB.EntityFrameworkCore/Query/ tests/
+git commit -m "EF-323: Add public MongoQueryMode option (Native/DriverLinq/NativeOnly)"
+```
+
+---
+
+## Task 3: `MongoExpression` hierarchy (dialect-agnostic nodes)
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoExpression.cs` (abstract base + the operator enums)
+- Create: `.../Expressions/MongoFieldExpression.cs`, `MongoConstantExpression.cs`, `MongoParameterExpression.cs`, `MongoBinaryExpression.cs`, `MongoUnaryExpression.cs`, `MongoOrdering.cs`
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoExpressionTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `internal abstract class MongoExpression : Expression { public override Type Type { get; } public override ExpressionType NodeType => ExpressionType.Extension; }`
+  - `MongoFieldExpression(IProperty property, string elementName)` — exposes `Property`, `ElementName`.
+  - `MongoConstantExpression(object? value, IProperty? forSerialization)` — `Value`, `ForSerialization`.
+  - `MongoParameterExpression(string name, IProperty? forSerialization)` — `Name`, `ForSerialization` (the B2 placeholder).
+  - `enum MongoBinaryOperator { Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual, AndAlso, OrElse }`
+  - `MongoBinaryExpression(MongoBinaryOperator op, MongoExpression left, MongoExpression right)` — `Operator`, `Left`, `Right`.
+  - `enum MongoUnaryOperator { Not }`
+  - `MongoUnaryExpression(MongoUnaryOperator op, MongoExpression operand)` — `Operator`, `Operand`.
+  - `readonly record struct MongoOrdering(MongoExpression KeySelector, bool Ascending)`.
+- Consumes: `IProperty` (Metadata).
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+public class MongoExpressionTests
+{
+    [Fact]
+    public void Binary_node_exposes_operator_and_operands()
+    {
+        var left = new MongoConstantExpression(1, forSerialization: null);
+        var right = new MongoConstantExpression(2, forSerialization: null);
+        var bin = new MongoBinaryExpression(MongoBinaryOperator.LessThan, left, right);
+
+        bin.Operator.Should().Be(MongoBinaryOperator.LessThan);
+        bin.Left.Should().BeSameAs(left);
+        bin.Right.Should().BeSameAs(right);
+        bin.NodeType.Should().Be(ExpressionType.Extension);
+    }
+
+    [Fact]
+    public void Ordering_carries_key_and_direction()
+    {
+        var key = new MongoConstantExpression(0, null);
+        var ordering = new MongoOrdering(key, Ascending: false);
+        ordering.KeySelector.Should().BeSameAs(key);
+        ordering.Ascending.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run; verify fail to compile**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~MongoExpressionTests"`
+Expected: compile failure.
+
+- [ ] **Step 3: Implement the node hierarchy**
+
+Implement each as `internal sealed` subclass of `MongoExpression`. `MongoExpression` overrides `VisitChildren` to return `this` by default (leaf nodes); `MongoBinaryExpression`/`MongoUnaryExpression` override `VisitChildren` to visit operands and rebuild on change (the EF `SqlExpression` idiom). Keep them **dialect-agnostic** — no BSON here. Annotate nullability (`object?`, `IProperty?`). See `Expressions/MongoQueryExpression.cs` for the existing custom-`Expression` style in this codebase.
+
+- [ ] **Step 4: Run; verify pass**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --filter "FullyQualifiedName~MongoExpressionTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Expressions/ tests/
+git commit -m "EF-323: Add dialect-agnostic MongoExpression node hierarchy"
+```
+
+---
+
+## Task 4: `MongoSelectExpression` (logical slots)
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoSelectExpression.cs`
+- Reference: `Expressions/MongoQueryExpression.cs` (the type it evolves) + `MongoQueryExpression.Lookup.cs`
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoSelectExpressionTests.cs`
+
+**Interfaces:**
+- Produces (slots per design doc § *`MongoSelectExpression`*):
+  - `MongoCollectionExpression Source { get; }`
+  - `MongoExpression? Predicate { get; set; }`
+  - `IReadOnlyList<MongoOrdering> Orderings { get; }` + `void ResetOrderings(MongoOrdering first)` + `void AppendOrdering(MongoOrdering next)`
+  - `MongoExpression? Limit { get; set; }`, `MongoExpression? Offset { get; set; }`
+  - `ProjectionMapping Projection { get; }` (carried; client-side at parity)
+  - `IReadOnlyList<LookupExpression> Lookups { get; }` (fed by the kept reconstruction — Task 13)
+  - `Expression? CapturedExpression { get; set; }` (raw LINQ chain — coexistence rule)
+  - `bool IsNativeRepresentable { get; set; }` (default `true`; QMTEV flips to `false` on any non-parity shape)
+  - `void AddPredicateConjunct(MongoExpression conjunct)` — AND-combines into `Predicate`.
+- Consumes: `MongoCollectionExpression`, `LookupExpression`, `MongoExpression`, `MongoOrdering` (Task 3).
+
+**Note:** `MongoSelectExpression` keeps `CapturedExpression` + projection plumbing so the existing fallback + shaper binding keep working; it *adds* the structured slots and becomes the source of truth for the native path. Decide during implementation whether to extend `MongoQueryExpression` in place or introduce `MongoSelectExpression` as its successor — the design frames it as the evolution of `MongoQueryExpression`; prefer extending the existing type's slot set to minimize churn to the QMTEV/shaper plumbing, renaming only if a clean cut is lower-risk. Record the choice in the commit message.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+public class MongoSelectExpressionTests
+{
+    [Fact]
+    public void AddPredicateConjunct_ANDs_into_a_single_predicate()
+    {
+        var select = TestSelect();          // helper builds a MongoSelectExpression over a stub collection
+        var a = new MongoConstantExpression(true, null);
+        var b = new MongoConstantExpression(true, null);
+
+        select.AddPredicateConjunct(a);
+        select.AddPredicateConjunct(b);
+
+        select.Predicate.Should().BeOfType<MongoBinaryExpression>()
+            .Which.Operator.Should().Be(MongoBinaryOperator.AndAlso);
+    }
+
+    [Fact]
+    public void New_select_is_native_representable_by_default()
+        => TestSelect().IsNativeRepresentable.Should().BeTrue();
+}
+```
+
+- [ ] **Step 2: Run; verify fail**. Run: `dotnet test ... --filter "FullyQualifiedName~MongoSelectExpressionTests"` → compile failure.
+
+- [ ] **Step 3: Implement the slots.** `AddPredicateConjunct(c)` sets `Predicate = Predicate is null ? c : new MongoBinaryExpression(AndAlso, Predicate, c)`. Orderings backed by a `List<MongoOrdering>` (`ResetOrderings` clears+adds; `AppendOrdering` adds).
+
+- [ ] **Step 4: Run; verify pass.** Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Expressions/ tests/
+git commit -m "EF-323: Add MongoSelectExpression logical-slot query tree"
+```
+
+---
+
+## Task 5: `MongoExpressionTranslator` (EF body → `MongoExpression`)
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoExpressionTranslator.cs`
+- Reference: spike `NativeTranslation/MongoPredicateTranslator.cs` (body-walking half) + `NativeExpressionHelpers.cs` (element-name resolution + serializer value coercion — **carry over verbatim, already correct**)
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoExpressionTranslatorTests.cs`
+
+**Interfaces:**
+- Produces: `internal sealed class MongoExpressionTranslator` with
+  `bool TryTranslate(Expression efBody, [NotNullWhen(true)] out MongoExpression? result)` — returns `false` (and `result = null`) for any node in the un-translatable set (nullable-equality, numeric casts on the member side, method calls, dictionary/list access, composite-PK member access, unserializable values) instead of throwing.
+- Consumes: `MongoFieldExpression`/`MongoConstant`/`MongoParameter`/`MongoBinary`/`MongoUnary` (Task 3); `IProperty.GetElementName()`, `LookupExpression.GetFieldPath` (for `_id.<prop>` composite-key field paths).
+
+**Note:** The acceptance set must be **exactly** where the spike falls back today — no wider, no narrower. Member access maps to `MongoFieldExpression` via the carried-over element-name resolution; key-property paths use `LookupExpression.GetFieldPath` (`_id.<prop>` for composite PKs) per the design's *Composite keys* note. A `QueryParameterExpression` (EF10) / prefixed `ParameterExpression` (EF8/EF9) maps to `MongoParameterExpression`; a captured constant maps to `MongoConstantExpression`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+public class MongoExpressionTranslatorTests
+{
+    [Fact]
+    public void Translates_simple_comparison_to_a_field_op()
+    {
+        // x => x.Age > 21  over an entity with int Age mapped to element "Age"
+        var (body, prop) = Predicate<Customer>(c => c.Age > 21);
+        var translator = NewTranslator<Customer>();
+
+        translator.TryTranslate(body, out var mongo).Should().BeTrue();
+        var bin = mongo.Should().BeOfType<MongoBinaryExpression>().Subject;
+        bin.Operator.Should().Be(MongoBinaryOperator.GreaterThan);
+        bin.Left.Should().BeOfType<MongoFieldExpression>().Which.ElementName.Should().Be("Age");
+        bin.Right.Should().BeOfType<MongoConstantExpression>().Which.Value.Should().Be(21);
+    }
+
+    [Fact]
+    public void Conjunction_maps_to_AndAlso()
+    {
+        var (body, _) = Predicate<Customer>(c => c.Age > 21 && c.Age < 65);
+        NewTranslator<Customer>().TryTranslate(body, out var mongo).Should().BeTrue();
+        mongo.Should().BeOfType<MongoBinaryExpression>().Which.Operator.Should().Be(MongoBinaryOperator.AndAlso);
+    }
+
+    [Fact]
+    public void Unsupported_node_reports_not_translatable()
+    {
+        // method call on the member side — outside the parity acceptance set
+        var (body, _) = Predicate<Customer>(c => c.Name.StartsWith("A"));
+        NewTranslator<Customer>().TryTranslate(body, out var mongo).Should().BeFalse();
+        mongo.Should().BeNull();
+    }
+}
+```
+(Build the `Predicate<T>(...)` / `NewTranslator<T>()` helpers against a minimal in-memory `IModel` — see existing UnitTests that construct an `IModel`/`IEntityType` for translator tests and copy the pattern.)
+
+- [ ] **Step 2: Run; verify fail.** `--filter "FullyQualifiedName~MongoExpressionTranslatorTests"` → compile failure.
+
+- [ ] **Step 3: Implement** as an `ExpressionVisitor`-style recursive translator: map `BinaryExpression` comparison/logical nodes to `MongoBinaryExpression`, `UnaryExpression(Not)`/bare-bool to `MongoUnaryExpression`, member access to `MongoFieldExpression`, parameters to `MongoParameterExpression`, constants to `MongoConstantExpression`. Any node outside the set ⇒ `return false`. Lift element-name + serializer coercion helpers from `NativeExpressionHelpers` verbatim.
+
+- [ ] **Step 4: Run; verify pass.** Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoExpressionTranslator.cs tests/
+git commit -m "EF-323: Add MongoExpressionTranslator (EF body -> MongoExpression)"
+```
+
+---
+
+## Task 6: QMTEV slot population
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs` (the `Translate*` overrides at `:763-804` that return `null` today; `CapturedExpression` set at `:152`)
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/SlotPopulationTests.cs`
+
+**Interfaces:**
+- Consumes: `MongoExpressionTranslator` (Task 5), `MongoSelectExpression` slots (Task 4).
+- Produces: populated slots on the `MongoSelectExpression` per the design's *Population in the QMTEV* table.
+
+| Override | Action |
+|---|---|
+| `TranslateWhere` | `TryTranslate` body → `MongoExpression`; `AddPredicateConjunct`. Un-translatable ⇒ `IsNativeRepresentable = false`, return `source`. |
+| `TranslateOrderBy`/`TranslateThenBy` (+ descending) | translate key selector; `OrderBy` ⇒ `ResetOrderings`, `ThenBy` ⇒ `AppendOrdering`. Un-translatable key ⇒ not-representable. |
+| `TranslateSkip`/`TranslateTake` | set `Offset`/`Limit` to `MongoConstant`/`MongoParameter`; enforce canonical order (Skip-before-Take, single each) else not-representable. |
+| `TranslateSelect` | pure entity-materialization Select ⇒ no-op (existing behavior at `:159-175`). A *projecting* Select ⇒ `IsNativeRepresentable = false` (deferred to SP3). |
+
+**Coexistence rule (critical):** every override still returns a valid `ShapedQueryExpression` and the QMTEV still sets `CapturedExpression` at `:152` regardless of slot population — the driver-LINQ fallback must stay intact. Setting a slot must never *remove* the captured chain.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+public class SlotPopulationTests
+{
+    [Fact]
+    public void Where_populates_the_predicate_slot()
+    {
+        var select = TranslateToSelect<Customer>(q => q.Where(c => c.Age > 21));
+        select.Predicate.Should().NotBeNull();
+        select.IsNativeRepresentable.Should().BeTrue();
+        select.CapturedExpression.Should().NotBeNull("the raw chain is always captured");
+    }
+
+    [Fact]
+    public void OrderBy_then_ThenBy_preserves_order()
+    {
+        var select = TranslateToSelect<Customer>(q => q.OrderBy(c => c.Age).ThenByDescending(c => c.Name));
+        select.Orderings.Should().HaveCount(2);
+        select.Orderings[0].Ascending.Should().BeTrue();
+        select.Orderings[1].Ascending.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Where_after_Take_is_not_native_representable()
+    {
+        var select = TranslateToSelect<Customer>(q => q.Take(10).Where(c => c.Age > 21));
+        select.IsNativeRepresentable.Should().BeFalse();
+        select.CapturedExpression.Should().NotBeNull("fallback chain still captured");
+    }
+
+    [Fact]
+    public void Projecting_Select_is_not_native_representable()
+    {
+        var select = TranslateToSelect<Customer>(q => q.Select(c => c.Name));
+        select.IsNativeRepresentable.Should().BeFalse();
+    }
+}
+```
+(`TranslateToSelect<T>(Func<IQueryable<T>,IQueryable>)` drives the real EF query pipeline to the post-QMTEV `MongoSelectExpression` — model it on how existing UnitTests invoke the translation visitors; if no such harness exists, build a minimal one that compiles a query against an `IModel` and runs `MongoQueryableMethodTranslatingExpressionVisitor`.)
+
+- [ ] **Step 2: Run; verify fail.** `--filter "FullyQualifiedName~SlotPopulationTests"` → assertions fail (slots not populated yet).
+
+- [ ] **Step 3: Implement the overrides.** Replace the `return null` bodies (`:785-804`) with slot population per the table; flip `IsNativeRepresentable = false` and `return source` on any un-translatable input or non-canonical order. Do **not** alter `:152` capture.
+
+- [ ] **Step 4: Run; verify pass.** Expected: PASS (4 tests).
+
+- [ ] **Step 5: Build EF8 too (signatures differ across versions).** Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF8"` → Build succeeded. Add `#if` guards if any `Translate*` signature differs (see `TranslateExecuteUpdate` EF8/EF9 split at `:621-632` for the pattern).
+
+- [ ] **Step 6: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs tests/
+git commit -m "EF-323: Populate native query slots in the QMTEV"
+```
+
+---
+
+## Task 7: Typed stage IR (`MongoPipelineStage`)
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoPipelineStage.cs` (abstract base) + `MongoMatchStage.cs`, `MongoSortStage.cs`, `MongoSkipStage.cs`, `MongoLimitStage.cs`, `MongoLookupStage.cs`, `MongoUnwindStage.cs`
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoPipelineStageTests.cs`
+
+**Interfaces:**
+- Produces (plain typed stages — **not** `Expression`s; 1:1 with a rendered pipeline doc):
+  - `internal abstract class MongoPipelineStage`
+  - `MongoMatchStage(MongoExpression Predicate)`, `MongoSortStage(IReadOnlyList<MongoOrdering> Orderings)`, `MongoSkipStage(MongoExpression Offset)`, `MongoLimitStage(MongoExpression Limit)`, `MongoLookupStage(LookupExpression Lookup)`, `MongoUnwindStage(LookupExpression Lookup)`.
+
+- [ ] **Step 1: Write the failing test**
+```csharp
+public class MongoPipelineStageTests
+{
+    [Fact]
+    public void Match_stage_carries_its_predicate()
+    {
+        var predicate = new MongoConstantExpression(true, null);
+        new MongoMatchStage(predicate).Predicate.Should().BeSameAs(predicate);
+    }
+}
+```
+- [ ] **Step 2: Run; verify fail.** → compile failure.
+- [ ] **Step 3: Implement** as simple records/sealed classes deriving from `MongoPipelineStage`.
+- [ ] **Step 4: Run; verify pass.**
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/ tests/
+git commit -m "EF-323: Add typed MongoPipelineStage IR"
+```
+
+---
+
+## Task 8: `MongoSelectLowerer` (slots → stage IR)
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoSelectLowerer.cs`
+- Reference: spike `NativeTranslation/NativeLookupStages.cs` (the `$lookup`/`$unwind` *emission* logic + reference-only / no-pipeline-stages / no-`_lookup_`-localField guards — move it here)
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoSelectLowererTests.cs`
+
+**Interfaces:**
+- Produces: `internal sealed class MongoSelectLowerer { IReadOnlyList<MongoPipelineStage> Lower(MongoSelectExpression select); }`
+- Consumes: `MongoSelectExpression` slots (Task 4), stage IR (Task 7), `LookupExpression` emission guards.
+
+**Note:** Canonical order `$match → $sort → $skip → $limit → $lookup/$unwind`; drop empty slots (no predicate ⇒ no `MongoMatchStage`). At the foundation, `Lookups` is still fed by the kept reconstruction (Task 13) — the lowerer just consumes the resulting list.
+
+- [ ] **Step 1: Write the failing tests**
+```csharp
+public class MongoSelectLowererTests
+{
+    [Fact]
+    public void Empty_slots_lower_to_no_stages()
+        => new MongoSelectLowerer().Lower(TestSelect()).Should().BeEmpty();
+
+    [Fact]
+    public void Filter_sort_paging_lower_in_canonical_order()
+    {
+        var select = TestSelect();
+        select.AddPredicateConjunct(new MongoConstantExpression(true, null));
+        select.AppendOrdering(new MongoOrdering(new MongoConstantExpression(0, null), true));
+        select.Offset = new MongoConstantExpression(5, null);
+        select.Limit = new MongoConstantExpression(10, null);
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        stages.Select(s => s.GetType()).Should().ContainInOrder(
+            typeof(MongoMatchStage), typeof(MongoSortStage), typeof(MongoSkipStage), typeof(MongoLimitStage));
+    }
+}
+```
+- [ ] **Step 2: Run; verify fail.** → assertions fail.
+- [ ] **Step 3: Implement** the canonical-order walk; append `MongoLookupStage`+`MongoUnwindStage` for each `LookupExpression` (port `NativeLookupStages` emission + guards).
+- [ ] **Step 4: Run; verify pass.**
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoSelectLowerer.cs tests/
+git commit -m "EF-323: Add MongoSelectLowerer (slots -> stage IR)"
+```
+
+---
+
+## Task 9: `MongoQueryLanguageRenderer` + stubbed `$expr` seam
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoQueryLanguageRenderer.cs`
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoExprRenderer.cs` (stub seam)
+- Reference: spike `MongoPredicateTranslator.cs` — `CombineAnd` (field merge, operator-doc merge, `$and` fallback on collision) + the query/match dialect shape (`{field:{$gt:v}}`, `$and`/`$or`, bare-bool, `$ne`)
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoQueryLanguageRendererTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `internal sealed class MongoQueryLanguageRenderer { BsonValue Render(MongoExpression predicate, PlaceholderTable placeholders); }` — emits `$match`-dialect BSON, recording `MongoParameterExpression` sites into `placeholders` (Task 10 owns `PlaceholderTable`); constants serialized inline via the property's `IBsonSerializer`.
+  - `internal sealed class MongoExprRenderer` — throws `NativeTranslationNotSupportedException("$expr rendering not yet implemented")`; wired into the lowerer's dialect-selection seam (entry point for SP2).
+- Consumes: `MongoExpression` (Task 3), `NativeTranslationNotSupportedException` (Task 1).
+
+**Note:** Dialect choice is made by the caller (lowerer), never in the renderer or the node types. For parity only the query/match dialect is built; the `$expr` renderer stays a throwing stub.
+
+- [ ] **Step 1: Write the failing tests** (render against an inline placeholder table; assert the BSON shape)
+```csharp
+public class MongoQueryLanguageRendererTests
+{
+    [Fact]
+    public void Renders_greater_than_in_query_dialect()
+    {
+        var field = new MongoFieldExpression(AgeProperty, "Age");
+        var pred = new MongoBinaryExpression(MongoBinaryOperator.GreaterThan, field, new MongoConstantExpression(21, AgeProperty));
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+        rendered.Should().Be(BsonDocument.Parse("{ Age: { $gt: 21 } }"));
+    }
+
+    [Fact]
+    public void Merges_two_ranges_on_one_field()
+    {
+        var field = new MongoFieldExpression(AgeProperty, "Age");
+        var pred = new MongoBinaryExpression(MongoBinaryOperator.AndAlso,
+            new MongoBinaryExpression(MongoBinaryOperator.GreaterThan, field, new MongoConstantExpression(21, AgeProperty)),
+            new MongoBinaryExpression(MongoBinaryOperator.LessThan, field, new MongoConstantExpression(65, AgeProperty)));
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+        rendered.Should().Be(BsonDocument.Parse("{ Age: { $gt: 21, $lt: 65 } }"));
+    }
+}
+```
+- [ ] **Step 2: Run; verify fail.** → compile failure (`PlaceholderTable` from Task 10 not yet present — implement Task 10's `PlaceholderTable` type first if needed, or stub it minimally here and complete in Task 10). Expected: FAIL.
+- [ ] **Step 3: Implement** the query-dialect renderer; port `CombineAnd`/field-merge from `MongoPredicateTranslator`. Add the throwing `MongoExprRenderer` stub.
+- [ ] **Step 4: Run; verify pass.**
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoQueryLanguageRenderer.cs src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoExprRenderer.cs tests/
+git commit -m "EF-323: Add query-dialect renderer + stubbed \$expr seam"
+```
+
+---
+
+## Task 10: `MongoPipelineFactory` (B2 template + per-execution bind)
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoPipelineFactory.cs` (+ `PlaceholderTable`)
+- Test: `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoPipelineFactoryTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `internal sealed class PlaceholderTable` — records `(pipeline location, parameter name, IBsonSerializer)` entries; `int Add(string parameterName, IBsonSerializer serializer)` returns a sentinel id used in the template.
+  - `internal sealed class MongoPipelineFactory { BsonDocument[] Build(IReadOnlyDictionary<string, object?> parameterValues); }` — produced once at compile time from the rendered template + `PlaceholderTable`; clones the template and substitutes each placeholder per execution, serializing through the recorded serializer. Constants are baked into the template.
+- Consumes: rendered template (Task 9), `PlaceholderTable`.
+
+**Note:** This is the perf delta over the spike — lowering/rendering leave the hot path; `Build` is clone-and-substitute. Bridge `QueryContext.Parameters` (EF10) vs `QueryContext.ParameterValues` (EF8/EF9) at the call site that produces `parameterValues` (the global guard), not inside `Build`.
+
+- [ ] **Step 1: Write the failing test (the cache-correctness case)**
+```csharp
+public class MongoPipelineFactoryTests
+{
+    [Fact]
+    public void Same_template_binds_different_parameter_values_across_executions()
+    {
+        // Build a factory whose $match is { Age: { $gt: <param p0> } } with an Int32 serializer.
+        var factory = BuildAgeGreaterThanFactory(parameterName: "p0");
+
+        var first  = factory.Build(new Dictionary<string, object?> { ["p0"] = 21 });
+        var second = factory.Build(new Dictionary<string, object?> { ["p0"] = 40 });
+
+        first[0].Should().Be(BsonDocument.Parse("{ $match: { Age: { $gt: 21 } } }"));
+        second[0].Should().Be(BsonDocument.Parse("{ $match: { Age: { $gt: 40 } } }"));
+        // template is not mutated between builds:
+        factory.Build(new Dictionary<string, object?> { ["p0"] = 21 })[0]
+            .Should().Be(first[0]);
+    }
+}
+```
+- [ ] **Step 2: Run; verify fail.** → compile/assertion failure.
+- [ ] **Step 3: Implement** `PlaceholderTable` + `MongoPipelineFactory.Build` (deep-clone template, substitute sentinels, serialize each value via the recorded serializer into a `BsonValue`).
+- [ ] **Step 4: Run; verify pass.** Expected: PASS.
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoPipelineFactory.cs tests/
+git commit -m "EF-323: Add MongoPipelineFactory (compile-time template + per-exec bind)"
+```
+
+---
+
+## Task 11: Native execution path (`MongoExecutableQuery` + `MongoClientWrapper`)
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs` (add the native pipeline carrier)
+- Modify: `src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs` (native `Aggregate` branch)
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs` (native source row lifecycle)
+- Reference: spike `Storage/MongoClientWrapper.cs:95-115` (the `executableQuery.NativePipeline is { } stages` branch over `RawBsonDocument`), spike `MongoExecutableQuery` (`NativePipeline`/`Session`/`Streaming` additions), spike `QueryingEnumerable` (generic-over-`TSource` row disposal)
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativePipelineExecutionTests.cs` (real DB)
+
+**Interfaces:**
+- Produces: `MongoExecutableQuery` gains a `MongoPipelineFactory? NativePipeline` (or equivalent carrier per the design's "`MongoExecutableQuery` gains the `MongoPipelineFactory`"); when set, `MongoClientWrapper.Execute` runs `collection.Aggregate(rawPipeline)` instead of the driver-LINQ `Provider.Execute`. The per-execution `NativePipeline` documents = `factory.Build(parameterValues)`.
+- Consumes: `MongoPipelineFactory` (Task 10).
+
+**Note:** Reproduce the spike's native branch faithfully (raw `BsonDocument[]` pipeline → `Aggregate` → cursor). Storage's `Execute` still receives a `BsonDocument[]`; the boundary is unchanged in spirit. Keep the driver-LINQ branch intact for fallback.
+
+- [ ] **Step 1: Write the failing functional test**
+```csharp
+public class NativePipelineExecutionTests : IClassFixture<TemporaryDatabaseFixture>
+{
+    [Fact]
+    public void Where_executes_natively_and_returns_correct_rows()
+    {
+        // seed Customers; query in Native mode; assert results AND assert the captured MQL is a
+        // raw $match pipeline (via TestMqlLoggerFactory / AssertMql), not a driver-LINQ pipeline.
+    }
+}
+```
+(Use the existing `AssertMql` + `TemporaryDatabaseFixture` helpers; copy a sibling functional Query test's fixture setup.)
+- [ ] **Step 2: Run; verify fail.** Expected: FAIL (no native carrier wired).
+- [ ] **Step 3: Implement** the `MongoExecutableQuery` carrier + the `MongoClientWrapper.Execute` native branch (reproduce spike `:95-115`) + `QueryingEnumerable` source handling.
+- [ ] **Step 4: Run; verify pass.** Expected: PASS.
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs tests/
+git commit -m "EF-323: Add native BsonDocument[] execution path"
+```
+
+---
+
+## Task 12: Streaming materializer (reproduce faithfully)
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoStreamingEntityMaterializerRewriter.cs`, `BsonRowReader.cs`, `StreamingEligibility.cs`
+- Reference (reproduce, do not redesign): spike files of the same names; spike specs `docs/superpowers/specs/2026-06-18-streaming-materializer-design.md` and `2026-06-18-streaming-owned-collections-design.md`
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/StreamingMaterializerTests.cs`
+
+**Interfaces:**
+- Produces: `StreamingEligibility.IsEligible(IEntityType)` (single-property PK, owned-reference-only navigations, recursive); `BsonRowReader` (forward-only `IBsonReader` over `RawBsonDocument`); `MongoStreamingEntityMaterializerRewriter` (rewrites the EF materializer to read via the reader, no DOM build).
+- Consumes: native cursor rows (Task 11).
+
+**Note:** The known per-row double-pass overhead is **out of scope** (SP7) — reproduce as-is, do not "fix" it; just don't regress it.
+
+- [ ] **Step 1: Write the failing test** — whole-entity no-track read returns correct POCOs via the streaming path; assert eligibility gates a non-eligible entity (multi-prop PK) to the DOM path.
+- [ ] **Step 2: Run; verify fail.**
+- [ ] **Step 3: Reproduce** the three files faithfully from the spike (preserve their structure; adapt namespaces/`#if` only).
+- [ ] **Step 4: Run; verify pass.**
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/ tests/
+git commit -m "EF-323: Reproduce streaming materializer + eligibility"
+```
+
+---
+
+## Task 13: DOM shaper, dual-shaper enumerable, and Lookups slot feeding
+
+**Files:**
+- Create: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/DispatchingQueryingEnumerable.cs`
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs` (compile both streaming + DOM shapers; choose per `StreamingEligibility`)
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoSelectExpression.cs` — feed `Lookups` from the **kept** `MongoQueryExpression.GetStreamingReferenceLookups()` / `InnerCollections` reconstruction (`Lookup.cs`)
+- Reference: spike `DispatchingQueryingEnumerable` + spike `MongoShapedQueryCompilingExpressionVisitor.CompileShapedQuery`; current `MongoQueryExpression.Lookup.cs` (`GetPendingLookups`/`UsesDriverJoinFields`/`GetFieldPath`)
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeIncludeTests.cs`
+
+**Interfaces:**
+- Produces: `DispatchingQueryingEnumerable<TResult>` dispatching streaming vs DOM; the `Lookups` slot populated for single-level reference Includes.
+- Consumes: `StreamingEligibility` (Task 12), the kept lookup reconstruction.
+
+**Note (deferred clean-up):** At the foundation, `Lookups` is fed by the existing `GetStreamingReferenceLookups()` reconstruction (kept alongside the driver-LINQ fallback). Structural `Lookups` population — and deleting `GetStreamingReferenceLookups()`/`UsesDriverJoinFields`/inner-collection tracking — is the **Collection Includes sub-project's** job, not this one. Hold the spike's single-level-reference-Include acceptance set exactly; add zero new Include work.
+
+- [ ] **Step 1: Write the failing test** — `.Include(o => o.Customer)` (reference nav) executes natively via `$lookup`+`$unwind`; assert the MQL and the materialized graph. A collection Include must fall back (not native).
+- [ ] **Step 2: Run; verify fail.**
+- [ ] **Step 3: Implement** the dual-shaper + wire `Lookups` from the kept reconstruction; lowerer (Task 8) consumes it.
+- [ ] **Step 4: Run; verify pass.**
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/ tests/
+git commit -m "EF-323: Add DOM/streaming dual-shaper + single-level reference Include lowering"
+```
+
+---
+
+## Task 14: Compile-time gate
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs` (`VisitShapedQuery` `:131-153`; `TranslateQuery` `:277-314`)
+- Test: `tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeGateTests.cs`
+
+**Interfaces:**
+- Consumes: `MongoQueryCompilationContext.QueryMode` (Task 2), `MongoSelectExpression.IsNativeRepresentable` (Task 4/6), `MongoSelectLowerer`+renderer+factory (Tasks 8-10), `CapturedExpression` (driver fallback).
+
+**Gate semantics (design § *Pipeline selection*):**
+- `Native`: if `IsNativeRepresentable` **and** lowering/rendering succeed ⇒ compile the native path (pipeline factory + streaming/DOM shaper); else compile the driver-LINQ path from `CapturedExpression`.
+- `NativeOnly`: a non-representable query (or a lowering/rendering failure) **throws at compile time** (`NativeTranslationNotSupportedException`) — the coverage instrument.
+- `DriverLinq`: never attempt native.
+
+**Note:** This replaces the spike's per-execution try/catch in `TranslateQuery` with a deterministic compile-time decision. Preserve the `streaming`/`DispatchingQueryingEnumerable` discipline unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+```csharp
+public class QueryModeGateTests
+{
+    [Fact] public void Native_mode_uses_native_for_representable_query() { /* AssertMql shows raw pipeline */ }
+    [Fact] public void Native_mode_falls_back_for_unrepresentable_query() { /* projecting Select -> driver pipeline */ }
+    [Fact] public void NativeOnly_mode_throws_on_unrepresentable_query()
+    { /* Assert.Throws on a projecting Select under NativeOnly */ }
+    [Fact] public void DriverLinq_mode_never_goes_native() { /* even Where uses driver pipeline */ }
+}
+```
+- [ ] **Step 2: Run; verify fail.**
+- [ ] **Step 3: Implement** the gate at the compile-time entry; wrap lowering/rendering in a try that catches `NativeTranslationNotSupportedException` and falls back (or rethrows under `NativeOnly`).
+- [ ] **Step 4: Run; verify pass.**
+- [ ] **Step 5: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs tests/
+git commit -m "EF-323: Compile-time native-vs-driver gate honoring MongoQueryMode"
+```
+
+---
+
+## Task 15: Full-suite validation (zero regressions, no coverage shrink)
+
+**Files:** no product code unless a regression is found.
+
+- [ ] **Step 1: Run the full functional + specification suites on EF10, `Native` mode (default)**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10"`
+Expected: green (fallback covers the non-parity remainder). Triage any failure as a regression and fix in the owning task's area.
+
+- [ ] **Step 2: Run the full suites on EF8**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF8"`
+Expected: green. (Use the `/test-all` skill to cover EF8/EF9/EF10 in parallel.)
+
+- [ ] **Step 3: Confirm native-only-mode coverage does not shrink vs the spike**
+
+Run the suites under `NativeOnly` (set the test context's `UseQueryMode(MongoQueryMode.NativeOnly)` via the test fixture's options hook) and confirm the set of green tests ≥ the spike's recorded acceptance set (~64% spec / ~82% functional Query). Record the measured percentages in the commit message.
+Expected: no shrink.
+
+- [ ] **Step 4: Commit any regression fixes**
+```bash
+git commit -am "EF-323: Fix regressions surfaced by full-suite validation"
+```
+
+---
+
+## Task 16: Remove superseded re-walkers
+
+**Files:**
+- Delete: `src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoPipelineTranslator.cs`, `MongoPredicateTranslator.cs` (only if they were reproduced as transitional scaffolding; if never reproduced, skip — they don't exist on `main`).
+- Keep (until the Includes sub-project): `MongoEFToLinqTranslatingExpressionVisitor` (+ `.LeftJoin.cs`) and `MongoQueryExpression.Lookup.cs`'s reconstruction — still the fallback + `Lookups` feeder.
+
+- [ ] **Step 1: Confirm nothing references the re-walkers**
+
+Run: `git grep -n "MongoPipelineTranslator\|MongoPredicateTranslator" src/`
+Expected: no references outside the files being deleted (the lowerer + renderer + `MongoExpressionTranslator` replaced them).
+
+- [ ] **Step 2: Delete + build**
+
+Run: `dotnet build MongoDB.EFCoreProvider.sln -c "Debug EF10"` → Build succeeded.
+
+- [ ] **Step 3: Re-run the full EF10 suite**
+
+Run: `dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10"` → green.
+
+- [ ] **Step 4: Commit.**
+```bash
+git commit -am "EF-323: Remove superseded per-execution chain re-walkers"
+```
+
+---
+
+## Task 17: Benchmark — add native config + re-run headline (EF-324 harness)
+
+**Files:**
+- Modify: `benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/HeadlineBenchmarks.cs` (+ `BenchmarkConfig.cs` / `Program.cs` as needed) — add the **native** config alongside EF-324's DriverOnly + EF-current.
+- Modify: `benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/results/perf-baseline.md` — append the native numbers.
+- Reference: spike benchmark harness (three-config) on `spike/low-level-provider`; the EF-324 plan `docs/superpowers/plans/2026-06-23-benchmark-harness-baselines.md`.
+
+**Note:** Requires a MongoDB replica set via `MONGODB_URI`. EF10-only harness; quoted config `"Release EF10"`; InProcess toolchain.
+
+- [ ] **Step 1: Smoke the harness**
+
+Run: from `benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/`, `dotnet run -c "Release EF10" -- --smoke`
+Expected: correctness gate passes.
+
+- [ ] **Step 2: Add the native config and re-run the headline set**
+
+Run: `dotnet run -c "Release EF10"`
+Expected: native, DriverOnly, EF-current rows for each headline shape (Where→ToList; whole-entity tracked/no-track; reference Include; OrderByTake).
+
+- [ ] **Step 3: Assert the bar (native alloc/time ≥ spike's; ≥ EF-current)**
+
+Compare native rows against the spike's recorded headline and the EF-current baseline already in `perf-baseline.md`. Native alloc/time must be **≥** (no worse than) the spike's; the B2 translation-off-hot-path win is expected upside, not required.
+
+- [ ] **Step 4: Append numbers + commit**
+```bash
+git add benchmarks/
+git commit -m "EF-323: Add native benchmark config + record headline numbers"
+```
+
+---
+
+## Task 18: Carried-over cleanup — update Query/AGENTS.md
+
+**Files:**
+- Modify: `src/MongoDB.EntityFrameworkCore/Query/AGENTS.md`
+
+**Note:** The current AGENTS.md states the provider "sits on top of the driver's LINQ v3 provider … does not generate aggregation BSON itself." That is no longer true for the native path. Update the *Scope*, *Pipeline at a glance*, and *Key entry points* sections to describe the rebuilt architecture (QMTEV slot population → `MongoSelectExpression` → `MongoSelectLowerer` → stage IR → `MongoQueryLanguageRenderer` → `MongoPipelineFactory` → native `Aggregate`), with driver-LINQ as the gated fallback. Note the `MongoQueryMode` gate. Preserve the BOM if present.
+
+- [ ] **Step 1: Update the doc** to reflect the native path + the retained driver-LINQ fallback boundary.
+- [ ] **Step 2: Commit.**
+```bash
+git add src/MongoDB.EntityFrameworkCore/Query/AGENTS.md
+git commit -m "EF-323: Update Query/AGENTS.md for the native translation path"
+```
+
+---
+
+## Self-review checklist (run before handing off for execution)
+
+- **Spec coverage:** every component in the design doc's *Architecture* / *New types* has a task — nodes (T3), select tree (T4), translator (T5), QMTEV population (T6), stage IR (T7), lowerer (T8), renderer + `$expr` seam (T9), factory (T10), execution (T11), streaming (T12), DOM/dual-shaper + Lookups (T13), gate (T14), config option (T2). Validation (T15), cleanup (T16/T18), benchmark (T17). ✔
+- **Out-of-scope guard:** parity-only enforced via `IsNativeRepresentable = false` in T6 and the gate in T14; projecting Select, predicate breadth, collection Includes, non-canonical paging all fall back. ✔
+- **Type consistency:** `IsNativeRepresentable`, `AddPredicateConjunct`, `MongoSelectLowerer.Lower`, `MongoPipelineFactory.Build`, `PlaceholderTable`, `MongoQueryMode` used consistently across tasks. ✔
+- **Multi-EF:** EF8 build/test gates in T6 and T15; the parameter-access `#if` guard is a global constraint. ✔
+- **Benchmark dependency:** T17 runs on the EF-324-based branch; rebase to `main` once EF-324 merges (Global Constraints). ✔

--- a/docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-design.md
@@ -1,33 +1,47 @@
-# Mongo query AST foundation — design
+# Native query-translation foundation (sub-project 1) — design
 
 **Date:** 2026-06-20
-**Status:** Approved; pending implementation plan
-**Branch:** `EF-322-native-query` (off `main`) · **JIRA:** EF-322
+**Status:** Approved. Implementation plan: `../plans/2026-06-25-mongo-query-ast-foundation-plan.md`.
+**Branch:** `EF-323-ast-foundation` (docs off `main`). Implementation is based on `EF-324-benchmarks`
+(so SP0's harness is present) and rebases onto `main` once EF-324 merges. · **JIRA:** EF-323
 **Overview / review entry point:** `2026-06-20-mongo-query-ast-foundation-overview.md` — read that for
 the terse *what / why*; this doc is the full *how*.
 **Program:** sub-project 1 of the ground-up native LINQ query rebuild. See
 `2026-06-23-native-query-provider-design.md` for the program-level decision, the keep-vs-rebuild
 inventory, and the class-(c) intrinsic-limits reconnaissance. This spec implements that design's
-"Sub-project 1: AST foundation" in full (the canonical AST + pipeline generator, the slot
+"Sub-project 1: native query-translation foundation" in full (the canonical query expression tree + pipeline generator, the slot
 population that feeds it, and the compile-time gate that selects it).
 
 ## Goal
 
-Stand up the **first working native read path** — a real, canonical MongoDB query AST and a pipeline
+Stand up the **first working native read path** — a real, canonical MongoDB query expression tree and a pipeline
 generator that consumes it — at **parity** with what the spike already runs natively (single-collection
 filter / sort / paging + single-level reference Include over whole-entity results). The driver-LINQ
 path remains the gated fallback for everything outside that slice.
 
+> **Scope change (2026-06-27, as-built):** native single-level **reference Include** is **deferred to
+> the Collection Includes sub-project**. EF nav-expands a reference `Include` into a `LeftJoin`, and the
+> QMTEV conservatively marks non-slot operators (including joins) non-native, so reference Include
+> falls back to the driver-LINQ `$lookup`/LeftJoin path under `Native` mode (correct results) and
+> **throws under `NativeOnly`**. The native lookup machinery (Tasks 8/12/13 — lowerer `$lookup`/`$unwind`
+> emission, `GetStreamingReferenceLookups`, streaming-Include eligibility) is built and dormant, ready
+> for that sub-project to activate. Consequence: the realized native parity slice is **filter / sort /
+> paging** only; reference Include is native-coverage-deferred (see the success-bar note below).
+
 The spike is **reference only** — nothing is ported; everything here is rebuilt fresh on main. Because
 none of the native machinery exists on main yet, this sub-project builds it all (spike as reference):
 the **native execution path** (raw `BsonDocument[]` pipeline via `Aggregate` → cursor → shaper), the
-**streaming materializer** (+ DOM shaper), the **query-mode config-option gate**, and the **AST +
+**streaming materializer** (+ DOM shaper), the **query-mode config-option gate**, and the **query expression tree +
 lowerer + renderer + pipeline factory**. The MQL-assertion + spec-conformance test infra already
 exists on main and is reused as-is. (The benchmark harness + perf/conformance baselines are
-sub-project 0, landed before this.)
+**sub-project 0 — EF-324, in review as PR #321, not yet merged**. SP1 is developed on a branch cut
+from `EF-324-benchmarks` so the harness is available for the success-bar benchmark re-run, and is
+rebased onto `main` once EF-324 lands. The harness lives at
+`benchmarks/MongoDB.EntityFrameworkCore.Benchmarks/` with baselines under `results/perf-baseline.md`
+and `results/2026-06-23-query-conformance-baseline.md`.)
 
-The success bar is **zero regressions** and **no shrink** in native strict-mode coverage: the same
-query shapes that go native today must still go native, now via the structured AST rather than by
+The success bar is **zero regressions** and **no shrink** in native-only-mode coverage: the same
+query shapes that go native today must still go native, now via the structured query expression tree rather than by
 re-walking the captured LINQ chain.
 
 ## Why this shape (decisions taken during brainstorming)
@@ -37,30 +51,34 @@ captured LINQ `MethodCallExpression` chain** (`MongoQueryExpression.CapturedExpr
 execution, because `MongoQueryableMethodTranslatingExpressionVisitor` returns `null` for
 `Where`/`OrderBy`/`Skip`/`Take`/… and never structures them. Translation logic is therefore
 duplicated (native re-walker *and* the driver-LINQ re-walker) and the predicate translator covers
-only a tiny operator slice. The foundational fix is to **populate a structured AST in the QMTEV**
+only a tiny operator slice. The foundational fix is to **populate a structured query expression tree in the QMTEV**
 (where it returns `null` today) and have the generator consume *that*.
 
 Two architectural decisions were taken explicitly:
 
-- **AST structural model = A3 (hybrid).** A logical-slot `MongoSelectExpression` (EF
-  `SelectExpression`-aligned, so the team's instincts transfer and the future operator set has a
-  home) that **lowers to** an explicit typed stage-list IR (`MongoStage[]`, mirroring MongoDB's real
+- **Query representation = A3 (hybrid).** Built **the EF way** — the nodes are custom subclasses of
+  `System.Linq.Expressions.Expression` (the relational `SelectExpression`/`SqlExpression` pattern),
+  driven by EF's `ExpressionVisitor`, not a standalone hand-rolled tree. A logical-slot
+  `MongoSelectExpression` (a custom `Expression`, EF `SelectExpression`-aligned, so the team's
+  instincts transfer and the future operator set has a
+  home) that **lowers to** an explicit typed stage-list IR (`MongoPipelineStage[]`, mirroring MongoDB's real
   pipeline), which then **renders to** `BsonDocument[]`. The Mongo-specific concerns —
-  canonicalization, the two BSON dialects (query/match language vs aggregation-expression `$expr`),
-  and future pushdown — live at the lowering boundary, not smeared across the visitor or the
+  canonicalization, a future second BSON dialect (the aggregation-expression `$expr` language, alongside
+  the foundation's query/match language — **deferred to SP2**, not built here), and future pushdown —
+  have a home at the lowering boundary, not smeared across the visitor or the
   renderer. Rejected: A1 (slots rendered straight to BSON — less separation for the dialect concern)
-  and A2 (a bare stage-list AST — furthest from EF's mental model; projection/cardinality semantics
+  and A2 (a bare stage-list IR — furthest from EF's mental model; projection/cardinality semantics
   must be re-derived).
 
-- **Pipeline generation timing = B2 (compile-time template + per-execution bind).** Because the AST
-  is built once at compile time, lower/render it **once** into a cached pipeline *factory* whose
+- **Pipeline generation timing = B2 (compile-time template + per-execution bind).** Because the query
+  expression tree is built once at compile time, lower/render it **once** into a cached pipeline *factory* whose
   parameter placeholders are bound to live values per execution. This moves translation off the hot
   path (a real slice of the perf headline) and is EF-relational-idiomatic. Rejected: B1
   (per-execution regeneration — parity with the spike, but re-pays generation cost every run).
 
 A consequence of B2: the native-vs-driver decision **moves to compile time** and becomes
 deterministic (on `IsNativeRepresentable` + lowering/rendering success), replacing the spike's
-per-execution try/catch in `TranslateQuery`. Strict mode still surfaces gaps — just earlier.
+per-execution try/catch in `TranslateQuery`. Native-only mode still surfaces gaps — just earlier.
 
 ## Architecture
 
@@ -71,12 +89,12 @@ QMTEV  (MongoQueryableMethodTranslatingExpressionVisitor)
    │   Translate{Where,OrderBy,ThenBy,Skip,Take,Select,Join…} POPULATE slots
    │   (instead of returning null); STILL captures the raw chain for fallback
    ▼
-MongoSelectExpression           [NEW] canonical AST (logical slots); replaces the shallow
+MongoSelectExpression           [NEW] query expression tree (logical slots); replaces the shallow
    │                                  MongoQueryExpression as the structured IR
    │   MongoSelectLowerer        [NEW]
    ▼
-IReadOnlyList<MongoStage>       [NEW] typed stage IR (Match/Sort/Skip/Limit/Lookup/Unwind)
-   │   MongoQueryLanguageRenderer [NEW] (+ $expr renderer seam, stubbed)
+IReadOnlyList<MongoPipelineStage>       [NEW] typed stage IR (Match/Sort/Skip/Limit/Lookup/Unwind)
+   │   MongoQueryLanguageRenderer [NEW] (query/$match dialect only; $expr renderer + dialect selection deferred to SP2)
    ▼
 MongoPipelineFactory           [NEW] the B2 template: rendered stages + placeholder table
    │   per execution: factory.Build(parameterValues) → BsonDocument[]
@@ -88,16 +106,17 @@ MongoClientWrapper.Execute  (Storage, unchanged) → IAsyncCursor → streaming/
 
 `NativeTranslation/` is promoted from spike scaffolding to the real translator home.
 
-- `Expressions/MongoSelectExpression` — AST root with logical slots (replaces `MongoQueryExpression`
+- `Expressions/MongoSelectExpression` — query-expression-tree root with logical slots (replaces `MongoQueryExpression`
   as the structured IR).
 - `Expressions/MongoExpression` + subtypes (`MongoFieldExpression`, `MongoConstantExpression`,
   `MongoParameterExpression`, `MongoBinaryExpression`, `MongoUnaryExpression`) — the
   `SqlExpression`-analog hierarchy, **dialect-agnostic**.
 - `Expressions/MongoOrdering` — `(MongoExpression keySelector, bool ascending)`.
 - `NativeTranslation/Stages/Mongo{Match,Sort,Skip,Limit,Lookup,Unwind}Stage` — the typed stage IR.
-- `NativeTranslation/MongoSelectLowerer` — `MongoSelectExpression → MongoStage[]`.
+- `NativeTranslation/MongoSelectLowerer` — `MongoSelectExpression → MongoPipelineStage[]`.
 - `NativeTranslation/MongoQueryLanguageRenderer` — `MongoExpression → $match BSON` (query/match
-  dialect). The `$expr` (aggregation-expression) renderer is a stubbed seam.
+  dialect). Only this one dialect exists at the foundation; an `$expr` (aggregation-expression)
+  renderer and dialect selection are **deferred to SP2 (predicate breadth)** — not built here.
 - `NativeTranslation/MongoExpressionTranslator` — EF predicate/key-selector body → `MongoExpression`
   (replaces the body-walking half of `MongoPredicateTranslator`).
 - `NativeTranslation/MongoPipelineFactory` — holds rendered template + placeholder metadata;
@@ -111,8 +130,8 @@ MongoClientWrapper.Execute  (Storage, unchanged) → IAsyncCursor → streaming/
   the streaming materializer (`MongoStreamingEntityMaterializerRewriter`, `BsonRowReader`,
   `StreamingEligibility`), the DOM shaper, the native execution path (raw `BsonDocument[]` →
   `Aggregate` → cursor → shaper), the `DispatchingQueryingEnumerable` dual-shaper, and the query-mode
-  config option (`Native` / `DriverLinq` / `NativeStrict`). These are reference, not ported code.
-- *Superseded and removed once the AST covers their slice:* `MongoPipelineTranslator` and
+  config option (`Native` / `DriverLinq` / `NativeOnly`). These are reference, not ported code.
+- *Superseded and removed once the native path covers their slice:* `MongoPipelineTranslator` and
   `MongoPredicateTranslator` (the per-execution chain re-walkers). The lowerer + renderer +
   `MongoExpressionTranslator` replace them.
 - *Kept as fallback until full parity (later specs):* `MongoEFToLinqTranslatingExpressionVisitor`
@@ -138,10 +157,16 @@ So the hierarchy here is bespoke and modelled on **EF Core's relational `SqlExpr
 driver. What we *do* reuse is the driver's **low-level BSON layer**: the renderer's output is raw
 `BsonDocument[]` aggregation stages (`MongoDB.Bson` types — `BsonDocument`, `BsonValue`,
 `IBsonSerializer`, `IBsonReader`), executed via `IMongoCollection<…>.Aggregate`. That raw-BSON
-pipeline is the stable, public boundary: **our AST → `BsonDocument[]` → `Aggregate`.** The driver is
+pipeline is the stable, public boundary: **our query expression tree → `BsonDocument[]` → `Aggregate`.** The driver is
 used as a BSON/cursor/protocol library, never as the translation engine.
 
-## AST node taxonomy
+## Query-translation types (expression tree → stage IR)
+
+The query-expression nodes — `MongoSelectExpression` and the `MongoExpression` hierarchy below — are
+**custom subclasses of `System.Linq.Expressions.Expression`** (the EF way; the relational
+`SelectExpression`/`SqlExpression` pattern), so they plug into EF's `ExpressionVisitor` machinery and
+the existing `MongoQueryExpression` / QMTEV plumbing. They *lower to* the `MongoPipelineStage[]` IR
+(plain typed stages, **not** `Expression`s), which renders to `BsonDocument[]`.
 
 ### `MongoSelectExpression` (logical slots; built in the QMTEV)
 
@@ -178,7 +203,7 @@ slots — not the captured chain — become the source of truth for the native p
   set: `==, !=, <, <=, >, >=, &&, ||`.
 - `MongoUnaryExpression(MongoUnaryOperator op, MongoExpression operand)` — `Not`, bare-bool.
 
-### `MongoStage` (typed IR; 1:1 with a rendered pipeline document)
+### `MongoPipelineStage` (typed IR; 1:1 with a rendered pipeline document)
 
 `MongoMatchStage(MongoExpression)`, `MongoSortStage(IReadOnlyList<MongoOrdering>)`,
 `MongoSkipStage(MongoExpression)`, `MongoLimitStage(MongoExpression)`, `MongoLookupStage(…)`,
@@ -228,9 +253,21 @@ verbatim from `NativeExpressionHelpers` / `MongoPredicateTranslator` — they ar
 *where* the native/driver decision is made moves (compile-time slot population vs per-execution chain
 re-walk); the **acceptance set is unchanged**.
 
+**Composite keys.** A composite primary key is stored as a composite `_id` sub-document
+(`{ _id: { OrderID, ProductID } }`), so a key property's field path is `_id.<prop>`, not its plain
+element name. At the foundation, only the single-level reference Include `$lookup`
+(`localField` / `foreignField`) needs the `_id.<prop>` path — `LookupExpression.GetFieldPath`
+handles this and remains `private` to that class. Composite-PK key-based predicates and sort
+are **not** natively representable at the foundation (matching the spike's fallback): the native
+translator rejects any property that is part of a multi-property primary key and lets the query fall
+back to driver-LINQ; expanding native support for composite-PK predicates/sort is deferred to a later
+sub-project. Existing composite-key model-validation limits are unchanged (`MongoModelValidator`
+throws `NotSupportedException` for unsupported composite-key configs — EF-34). This is class-(b):
+MongoDB *can* express composite keys, so it is not an intrinsic limit.
+
 ## Lowering, rendering & the dialect boundary
 
-- **`MongoSelectLowerer`**: `MongoSelectExpression → MongoStage[]`, reading slots in canonical order,
+- **`MongoSelectLowerer`**: `MongoSelectExpression → MongoPipelineStage[]`, reading slots in canonical order,
   dropping empties (no predicate ⇒ no `$match`). Lookups append `$lookup` + `$unwind`: the kept
   `NativeLookupStages` *emission* logic (the `$lookup`/`$unwind` BSON shape + the reference-only /
   no-pipeline-stages / no-`_lookup_`-localField guards) moves here. At the foundation its input is
@@ -240,12 +277,14 @@ re-walk); the **acceptance set is unchanged**.
   (`{field:{$gt:v}}`, `$and`/`$or`, bare-bool, `$ne`). This is the only dialect parity needs
   (`$match` only). The AND-merge / field-collision logic from `MongoPredicateTranslator.CombineAnd`
   (field merge, operator-doc merge, `$and` fallback on collision) carries over.
-- **`$expr` (aggregation-expression) renderer**: a stubbed type that throws "not yet implemented",
-  wired into the lowerer's dialect-selection seam. Establishes the boundary without building it — the
-  entry point for the predicate-breadth spec.
+- **`$expr` (aggregation-expression) renderer**: **deferred to SP2 (predicate breadth)** — not present
+  at the foundation. As built, the foundation has a single (`$match`/query) dialect with no renderer
+  seam and no dialect-selection logic; both the `$expr` renderer and the dialect boundary arrive with
+  the predicate-breadth spec.
 
-Dialect choice (which target a given `MongoExpression` renders to) is made in the lowerer, never in
-the QMTEV or the node types — nodes stay dialect-neutral.
+Because there is only one dialect at the foundation, there is no dialect choice to make. When SP2
+introduces the second dialect, that choice (which target a given `MongoExpression` renders to) will be
+made in the lowerer, never in the QMTEV or the node types — nodes stay dialect-neutral.
 
 ## Parameter binding (B2 mechanics)
 
@@ -267,7 +306,7 @@ a clone-and-substitute.
 ## Pipeline selection, fallback & the gate
 
 The pipeline is chosen by a **user-level config option** on the DbContext options builder — an enum
-(`MongoQueryMode`: `Native` / `DriverLinq` / `NativeStrict` — the public face of the spike's internal
+(`MongoQueryMode`: `Native` / `DriverLinq` / `NativeOnly` — the public face of the spike's internal
 `NativeQueryMode` `Auto` / `Off` / `Force`), **not** an environment variable (this supersedes the
 spike's `MONGODB_EF_NATIVE_QUERY` env var). See the project design's "Pipeline
 selection, fallback & the gate" for the full option semantics and rationale; the foundation just
@@ -277,7 +316,7 @@ time):
 - Under `Native`: if `IsNativeRepresentable` **and** lowering/rendering succeed ⇒ compile the native
   path (pipeline factory + streaming/DOM shaper); else ⇒ compile the driver-LINQ path from
   `CapturedExpression` (the per-query fallback, unchanged).
-- Under `NativeStrict`: a non-representable query throws at compile time (surfacing the gap) — the
+- Under `NativeOnly`: a non-representable query throws at compile time (surfacing the gap) — the
   diagnostic/coverage role the spike's force-mode played, now via the config option.
 - Under `DriverLinq`: the native path is never attempted.
 - The `streaming` / `DispatchingQueryingEnumerable` dual-shaper discipline is preserved unchanged.
@@ -298,14 +337,20 @@ Bar: **zero regressions**. Mirrors the spike's rig.
 
 1. Full FunctionalTests + SpecificationTests green in `Native` mode (fallback covers the non-parity
    remainder), on EF10 **and** EF8.
-2. strict-mode native coverage **must not shrink** vs the spike's current acceptance set
-   (~64% spec / ~82% functional Query): the same shapes go native, via the AST.
+2. native-only-mode coverage **must not shrink** vs the spike's current acceptance set
+   (~64% spec / ~82% functional Query): the same shapes go native, via the query expression tree.
+   **As-built exception (2026-06-27):** native single-level reference Include is deferred (see the
+   *Scope change* note under Goal), so native-only coverage for **reference-Include** shapes is *below*
+   the spike until the Collection Includes sub-project. Filter / sort / paging coverage meets the bar.
 3. New unit tests asserting `MongoSelectExpression` slot population and rendered MQL for the parity
    operators (`AssertMql`), including parameterized queries that prove the template binds correctly
    across executions with different parameter values (the cache-correctness case the spike's
    per-execution model sidesteps).
-4. Benchmark headline re-run (`Release EF10`, InProcess): native alloc/time must be **≥** the spike's,
-   with the B2 translation-off-hot-path improvement as expected (not required) upside.
+4. Benchmark headline re-run (`Release EF10`, InProcess): add the **native** config to EF-324's
+   two-config harness (DriverOnly + EF-current) and re-run the headline set; native alloc/time must be
+   **≥** the spike's, with the B2 translation-off-hot-path improvement as expected (not required)
+   upside. (Runnable on the EF-324-based branch; the recorded numbers append to
+   `results/perf-baseline.md`.)
 
 ## Out of scope (later sub-projects)
 

--- a/docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-overview.md
+++ b/docs/superpowers/specs/2026-06-20-mongo-query-ast-foundation-overview.md
@@ -1,36 +1,38 @@
-# Mongo query AST foundation — overview
+# Native query-translation foundation (sub-project 1) — overview
 
-**Date:** 2026-06-20 · **Branch:** `EF-322-native-query` (off `main`) · **JIRA:** EF-322
+**Date:** 2026-06-20 · **Branch:** `EF-323-ast-foundation` (off `main`) · **JIRA:** EF-323
 **Full detail:** `2026-06-20-mongo-query-ast-foundation-design.md` · **Program:** `2026-06-23-native-query-provider-design.md` (this is sub-project 1)
 
 > **Reviewer:** read this for the *what* and *why*. Use the design doc to drill into the *how*.
 
 ## TL;DR
 
-- Sub-project 1 of the native query rebuild: replace the *translation* half of Query with a real query AST + pipeline generator.
-- Scope is **parity** with what the spike already runs natively — single-collection filter / sort / paging + single-level reference Include over whole-entity results. Nothing more.
-- AST model **A3 (hybrid)**: logical-slot `MongoSelectExpression` → typed `MongoStage[]` IR → `BsonDocument[]`.
+- Sub-project 1 of the native query rebuild: replace the *translation* half of Query with a real query expression tree + pipeline generator.
+- Scope is **parity** with what the spike already runs natively — single-collection filter / sort / paging over whole-entity results. (Native single-level reference Include was in the original target but is **deferred as-built**; see *Scope*.) Nothing more.
+- Query representation **A3 (hybrid)**, custom `Expression` types: logical-slot `MongoSelectExpression` → typed `MongoPipelineStage[]` IR → `BsonDocument[]`.
 - Pipeline generation **B2**: lower/render once at compile time into a cached factory; bind parameters per execution.
 - Consequence of B2: the native-vs-driver decision moves to **compile time** (deterministic), replacing the spike's per-execution try/catch.
 - Driver-LINQ stays the gated fallback; Include is kept as-is, with its clean-up deferred to a later sub-project.
-- Bar: **zero regressions**, strict-mode native coverage **must not shrink**, benchmarks **≥** spike.
+- Bar: **zero regressions**, native-only-mode coverage **must not shrink**, benchmarks **≥** spike (the
+  benchmark yardstick is sub-project 0 — EF-324, in review as PR #321, not yet merged; SP1 builds on
+  that branch and rebases to `main` when it lands).
 
 ## What we are doing
 
 Today the QMTEV returns `null` for `Where` / `OrderBy` / `Skip` / `Take` / …, so those operators
 survive as a raw LINQ chain that the native path re-walks on every execution. Instead, the QMTEV
-populates a structured AST, and a lowerer + renderer consume it to build the pipeline once at compile
+populates a structured query expression tree, and a lowerer + renderer consume it to build the pipeline once at compile
 time.
 
 The spike is **reference only** — nothing is ported. Since no native machinery exists on main yet,
 this sub-project also builds the native execution path, streaming materializer, DOM shaper, and
 config-option gate fresh (spike as reference); the MQL-assertion + spec-conformance test infra already
 on main is reused as-is. The spike's `MongoPipelineTranslator` / `MongoPredicateTranslator` chain
-re-walkers are not reproduced — the AST is the translator from the start.
+re-walkers are not reproduced — the new query translation is in place from the start.
 
 ## Why this shape
 
-- **A3** (over a flat stage-list or direct-to-BSON): a `SelectExpression`-aligned slot model gives the
+- **A3** (over a flat stage-list or direct-to-BSON): a `SelectExpression`-aligned slot model of custom `Expression` types gives the
   future operator set a home and isolates the Mongo-specific concerns — canonicalization, the query vs
   `$expr` dialects, future pushdown — at one lowering boundary.
 - **B2** (over per-execution regeneration): translation leaves the hot path (a real slice of the perf
@@ -40,8 +42,11 @@ re-walkers are not reproduced — the AST is the translator from the start.
 
 ## Scope
 
-- **In:** filter (`$match`), sort (`$sort`), paging (`$skip`/`$limit`), single-level reference Include
-  (`$lookup`/`$unwind`); whole-entity results.
+- **In:** filter (`$match`), sort (`$sort`), paging (`$skip`/`$limit`); whole-entity results.
+- **Deferred (as-built 2026-06-27):** native single-level reference Include (`$lookup`/`$unwind`) — EF
+  expands it to a `LeftJoin`, which the gate treats as non-native, so it falls back to driver-LINQ
+  (correct results; throws under `NativeOnly`). The lookup machinery is built but dormant; the
+  Collection Includes sub-project activates it. So the realized native slice is filter / sort / paging.
 - **Out:** predicate breadth / `$expr`, projection pushdown, scalar cardinality, collection / nested /
   filtered Includes, `GroupBy` / `SelectMany` / set ops / `Distinct` / `OfType` / `VectorSearch`,
   non-canonical paging, and the per-row double-pass materializer fix.
@@ -51,8 +56,8 @@ re-walkers are not reproduced — the AST is the translator from the start.
 | To review… | Read… |
 |---|---|
 | Scope, decisions (A3/B2), parity bar | **this doc** |
-| AST taxonomy + QMTEV slot population | design § *AST node taxonomy*, *Population in the QMTEV* |
+| Query-translation types + QMTEV slot population | design § *Query-translation types*, *Population in the QMTEV* |
 | Lowering / rendering / the dialect boundary | design § *Lowering, rendering & the dialect boundary* |
 | B2 parameter binding | design § *Parameter binding* |
-| Gate / fallback / strict mode | design § *Pipeline selection, fallback & the gate* |
+| Gate / fallback / native-only mode | design § *Pipeline selection, fallback & the gate* |
 | Why Include is kept as-is for now | design § *Include handling (deferred clean-up)* |

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoDbContextOptionsBuilder.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoDbContextOptionsBuilder.cs
@@ -14,6 +14,7 @@
 */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace MongoDB.EntityFrameworkCore.Infrastructure;
 
@@ -38,4 +39,18 @@ public class MongoDbContextOptionsBuilder : IMongoDbContextOptionsBuilderInfrast
     protected virtual DbContextOptionsBuilder OptionsBuilder { get; }
 
     DbContextOptionsBuilder IMongoDbContextOptionsBuilderInfrastructure.OptionsBuilder => OptionsBuilder;
+
+    /// <summary>
+    /// Specifies how the provider translates LINQ queries to MongoDB.
+    /// </summary>
+    /// <param name="queryMode">The <see cref="MongoQueryMode"/> to use.</param>
+    /// <returns>This builder, so that further configuration can be chained.</returns>
+    public virtual MongoDbContextOptionsBuilder UseQueryMode(MongoQueryMode queryMode)
+    {
+        var extension = (OptionsBuilder.Options.FindExtension<MongoOptionsExtension>()
+                         ?? new MongoOptionsExtension())
+            .WithQueryMode(queryMode);
+        ((IDbContextOptionsBuilderInfrastructure)OptionsBuilder).AddOrUpdateExtension(extension);
+        return this;
+    }
 }

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
@@ -21,6 +21,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore;
+using MongoDB.EntityFrameworkCore.Infrastructure;
 
 // ReSharper disable once CheckNamespace (extensions should be in the EF namespace for discovery)
 namespace Microsoft.EntityFrameworkCore;
@@ -53,6 +54,7 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
         CryptProviderPath = copyFrom.CryptProviderPath;
         KeyVaultNamespace = copyFrom.KeyVaultNamespace;
         KmsProviders = copyFrom.KmsProviders;
+        QueryMode = copyFrom.QueryMode;
         _loggableConnectionString = SanitizeConnectionStringForLogging(ConnectionString);
     }
 
@@ -226,6 +228,25 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
     }
 
     /// <summary>
+    /// Obtains the current <see cref="MongoQueryMode"/> that controls how LINQ queries are translated.
+    /// </summary>
+    public MongoQueryMode QueryMode { get; private set; } = MongoQueryMode.Native;
+
+    /// <summary>
+    /// Specifies the <see cref="MongoQueryMode"/> to use when translating LINQ queries.
+    /// </summary>
+    /// <param name="queryMode">The <see cref="MongoQueryMode"/> to use.</param>
+    /// <returns>The <see cref="MongoOptionsExtension"/> to continue chaining configuration.</returns>
+    public virtual MongoOptionsExtension WithQueryMode(MongoQueryMode queryMode)
+    {
+        Check.IsDefinedOrNull<MongoQueryMode>(queryMode);
+
+        var clone = Clone();
+        clone.QueryMode = queryMode;
+        return clone;
+    }
+
+    /// <summary>
     /// Clones the current <see cref="MongoOptionsExtension"/>.
     /// </summary>
     /// <returns>A new clone.</returns>
@@ -283,7 +304,7 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
         /// <inheritdoc/>
         public override int GetServiceProviderHashCode()
         {
-            _serviceProviderHash ??= HashCode.Combine(Extension.ConnectionString, Extension.DatabaseName);
+            _serviceProviderHash ??= HashCode.Combine(Extension.ConnectionString, Extension.DatabaseName, Extension.QueryMode);
             return _serviceProviderHash.Value;
         }
 
@@ -294,7 +315,8 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
                && Extension.MongoClient == otherInfo.Extension.MongoClient
                && (Extension.ClientSettings == otherInfo.Extension.ClientSettings ||
                    Extension.ClientSettings != null && Extension.ClientSettings.Equals(otherInfo.Extension.ClientSettings))
-               && Extension.DatabaseName == otherInfo.Extension.DatabaseName;
+               && Extension.DatabaseName == otherInfo.Extension.DatabaseName
+               && Extension.QueryMode == otherInfo.Extension.QueryMode;
 
         /// <inheritdoc/>
         public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
@@ -303,6 +325,7 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
             AddDebugInfo(debugInfo, nameof(MongoClient), Extension.MongoClient);
             AddDebugInfo(debugInfo, nameof(ClientSettings), Extension.ClientSettings);
             AddDebugInfo(debugInfo, nameof(DatabaseName), Extension.DatabaseName);
+            AddDebugInfo(debugInfo, nameof(QueryMode), Extension.QueryMode);
         }
 
         /// <inheritdoc/>
@@ -335,6 +358,12 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
             }
 
             builder.Append("DatabaseName=").Append(Extension.DatabaseName).Append(' ');
+
+            if (Extension.QueryMode != MongoQueryMode.Native)
+            {
+                builder.Append("QueryMode=").Append(Extension.QueryMode).Append(' ');
+            }
+
             return builder.ToString();
         }
     }

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoQueryMode.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoQueryMode.cs
@@ -1,0 +1,29 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.Infrastructure;
+
+/// <summary>Selects how the provider translates LINQ queries to MongoDB.</summary>
+public enum MongoQueryMode
+{
+    /// <summary>Native translation when representable; driver-LINQ fallback otherwise. (Default.)</summary>
+    Native,
+
+    /// <summary>Always use the driver's LINQ provider (the pre-rebuild behavior).</summary>
+    DriverLinq,
+
+    /// <summary>Native translation only; throw at compile time on an un-representable query (diagnostic).</summary>
+    NativeOnly
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/AGENTS.md
+++ b/src/MongoDB.EntityFrameworkCore/Query/AGENTS.md
@@ -9,53 +9,76 @@ adjacent-areas: [Storage, Metadata, Serializers, "C# driver LINQ v3"]
 
 ## Scope
 
-Translates `IQueryable<T>` against MongoDB-backed DbSets into MongoDB aggregation pipelines. The provider sits **on top of** the MongoDB C# driver's LINQ v3 provider — it does not generate aggregation BSON itself. The provider's job is to take an EF Core expression tree, normalize it, decide what to push to the driver vs. handle client-side (entity materialization, change tracking), and hand a driver-LINQ expression to the driver for compilation.
+Translates `IQueryable<T>` against MongoDB-backed DbSets into MongoDB aggregation pipelines. There are **two translation paths**, chosen at compile time by the `MongoQueryMode` option (see *the gate* below):
 
-In: top-level method-call translators, projection binding, EF-to-driver-LINQ bridge, shaper compilation, vector-search pre-extraction.
-Out: aggregation pipeline generation (driver), BSON encoding/decoding (Serializers area), change-tracking snapshots (ChangeTracking area), index/collection schema (Storage area), `IQueryable<T>` materialization in the runtime sense (driver's `IMongoQueryProvider`).
+1. **Native (default).** For the supported slice — single-collection **filter / sort / paging** over whole-entity results — the provider **generates the aggregation `BsonDocument[]` pipeline itself**, from a structured query expression tree, and runs it via `IMongoCollection<…>.Aggregate`. It does **not** go through the driver's LINQ provider for these.
+2. **Driver-LINQ (gated fallback).** For everything outside the native slice (projections, predicate breadth, cardinality, `GroupBy`/`SelectMany`/set ops/`Distinct`/`OfType`/`VectorSearch`, and — for now — **reference `Include`**, which is deferred), the provider still hands a driver-LINQ expression to the MongoDB C# driver's LINQ v3 provider, exactly as it always did.
+
+> **As-built scope (EF-323 foundation).** Native = filter/sort/paging only. **Reference `Include` is deferred** — it nav-expands to a `LeftJoin` that the gate treats as non-native, so it falls back to driver-LINQ (correct results; throws under `NativeOnly`). The native lookup machinery (lowerer `$lookup`/`$unwind`, `GetStreamingReferenceLookups`, streaming-Include eligibility) is **built but dormant**, awaiting the Collection Includes sub-project. Predicate breadth, projection pushdown, scalar cardinality, etc. are later sub-projects.
+
+In: top-level method-call translators **and native slot population**, the **query expression tree → stage IR → `BsonDocument[]` pipeline generator** (lowerer / renderer / pipeline factory), the compile-time **gate**, projection binding, the EF-to-driver-LINQ bridge (fallback), shaper compilation (native streaming + DOM, and driver-LINQ DOM), vector-search pre-extraction.
+Out: BSON encoding/decoding of *values* (Serializers area — the renderer asks `BsonSerializerFactory` for serializers), change-tracking snapshots (ChangeTracking area), index/collection schema (Storage area), cursor execution itself (`MongoClientWrapper.Execute` in Storage), and aggregation-pipeline generation **for the fallback path** (still the driver's job).
 
 ## Pipeline at a glance
 
 ```
 IQueryable<T>  (EF Core)
    │
-   ▼  MongoQueryCompilationContext           (preserves the original LINQ tree alongside EF's)
+   ▼  MongoQueryCompilationContext           (preserves the original LINQ tree; carries the MongoQueryMode)
    ▼  MongoQueryTranslationPreprocessor      (hoist final predicates; lift VectorSearch out before nav expansion)
-   ▼  MongoQueryableMethodTranslatingExpressionVisitor
+   ▼  MongoQueryableMethodTranslatingExpressionVisitor (QMTEV)
    │      ├─ accepts only Queryable / MongoQueryableExtensions / MongoDB.Driver.Linq.MongoQueryable
-   │      ├─ builds a MongoQueryExpression with a ProjectionMapping
-   │      └─ rejects unsupported shapes (Join / GroupBy / set ops) early
+   │      ├─ POPULATES native slots on MongoQueryExpression (Predicate / Orderings / Offset / Limit / Lookups)
+   │      │     via PopulateNativeSlots + MongoExpressionTranslator; sets IsNativeRepresentable=false for
+   │      │     any operator it does not lower into a slot (catch-all) — see pitfalls
+   │      └─ ALWAYS also captures the raw method chain (CapturedExpression) for the driver-LINQ fallback
    ▼  MongoQueryTranslationPostprocessor     (apply final ProjectionMapping)
-   ▼  MongoShapedQueryCompilingExpressionVisitor
-   │      ├─ ProjectionAnalyzer decides what can push down to driver-LINQ
-   │      ├─ BsonDocumentInjectingExpressionVisitor parameterizes shapers on BsonDocument
-   │      └─ MongoEFToLinqTranslatingExpressionVisitor rewrites the residual EF tree as driver-LINQ
+   ▼  MongoShapedQueryCompilingExpressionVisitor  ── THE GATE (compile time, honors MongoQueryMode) ──
+   │   if Native & IsNativeRepresentable & lower/render succeed → NATIVE PATH:
+   │      MongoSelectLowerer  : slots → MongoPipelineStage[]  (canonical $match→$sort→$skip→$limit→$lookup/$unwind)
+   │      MongoQueryLanguageRenderer + PlaceholderTable : predicate → $match BSON; params → sentinels
+   │      MongoPipelineFactory.Create : render ONCE into a template + placeholder table  (B2)
+   │      compile streaming shaper (MongoStreamingEntityMaterializerRewriter) if StreamingEligibility, else DOM
+   │   else (DriverLinq, or not representable, or NativeOnly→throws) → DRIVER-LINQ FALLBACK:
+   │      MongoEFToLinqTranslatingExpressionVisitor rewrites CapturedExpression as driver-LINQ; DOM shaper
    ▼  MongoExecutableQuery + QueryingEnumerable
-          ├─ MongoClientWrapper.Execute hands the driver-LINQ expression to IMongoQueryProvider
-          └─ driver returns IAsyncCursor<BsonDocument>; shaper turns each doc into the requested CLR shape
+          ├─ NATIVE: factory.Build(parameterValues) → BsonDocument[] set as NativePipeline;
+          │          MongoClientWrapper.Execute runs collection.Aggregate(pipeline) (RawBsonDocument if streaming, else BsonDocument)
+          └─ FALLBACK: MongoClientWrapper.Execute hands the driver-LINQ expression to IMongoQueryProvider
+          → IAsyncCursor; shaper turns each row into the requested CLR shape
 ```
+
+B2 = the pipeline template is built **once at compile time** (lower + render → `MongoPipelineFactory`); only `factory.Build(parameterValues)` (clone-and-substitute the placeholder sentinels) runs per execution. The native-vs-driver and streaming-vs-DOM decisions are therefore **compile-time-deterministic** — there is exactly **one** shaper per query and **no** runtime dual-shaper dispatch.
 
 ## Key entry points
 
 - `MongoQueryCompilationContext` — EF Core hook to preserve the original captured `IQueryable` so post-translation we can recover the user's intent (e.g. for diagnostics).
 - `MongoQueryTranslationPreprocessor` — first phase. Notably, **`VectorSearch(...)` is extracted before EF's nav-expansion and re-inserted after** — nav expansion doesn't know about it.
-- `Visitors/MongoQueryableMethodTranslatingExpressionVisitor` — the central LINQ-method dispatcher. Enforces the allowed-method-source set; captures the final method-chain expression on `MongoQueryExpression`.
-- `Visitors/MongoShapedQueryCompilingExpressionVisitor` — bridges to the C# driver. Splits scalar vs. entity result paths and compiles the shaper.
+- `Visitors/MongoQueryableMethodTranslatingExpressionVisitor` — the central LINQ-method dispatcher. Enforces the allowed-method-source set; **populates the native slots** (`PopulateNativeSlots`, the `Translate*` overrides are inert — see pitfalls); captures the final method-chain expression on `MongoQueryExpression`.
+- `Visitors/MongoShapedQueryCompilingExpressionVisitor` — **the compile-time gate**. Reads `MongoQueryMode`; builds the `MongoPipelineFactory` and compiles the native (streaming/DOM) shaper when representable, else compiles the driver-LINQ fallback shaper. Splits scalar vs. entity result paths.
+- **Native translation (`NativeTranslation/` + `Expressions/`):**
+  - `Expressions/MongoExpression` + subtypes (`MongoFieldExpression`/`MongoConstantExpression`/`MongoParameterExpression`/`MongoBinaryExpression`/`MongoUnaryExpression`) + `MongoOrdering` — the dialect-agnostic `SqlExpression`-analog node hierarchy.
+  - `Expressions/MongoQueryExpression` (+ `.NativeSlots.cs`, `.Lookup.cs`) — the structured query tree: the native slots (`Predicate`/`Orderings`/`Offset`/`Limit`/`Lookups`/`IsNativeRepresentable`) **plus** the retained `CapturedExpression` + `ProjectionMapping` for the fallback. (We extended this type in place rather than adding a separate `MongoSelectExpression`.)
+  - `NativeTranslation/MongoExpressionTranslator` — EF predicate / key-selector body → `MongoExpression` (`TryTranslate` / `TryTranslateField`); returns false for anything outside the spike's basic acceptance set.
+  - `NativeTranslation/MongoSelectLowerer` — slots → `MongoPipelineStage[]` (typed IR under `NativeTranslation/Stages/`), BSON-free; owns canonical order + the lookup eligibility guards.
+  - `NativeTranslation/MongoQueryLanguageRenderer` — `MongoExpression` → `$match`-dialect BSON; `PlaceholderTable` records parameter placeholders. There is only the one (`$match`/query) dialect at the foundation; dialect selection and an `$expr` (aggregation-expression) renderer are **deferred to SP2 (predicate breadth)** — neither is present or wired at the foundation.
+  - `NativeTranslation/MongoPipelineFactory` — the B2 template: `Create(stages, renderer)` walks the stages into a `BsonDocument[]` template (+ placeholder table); `Build(parameterValues)` deep-clones and substitutes per execution. Validates `$limit>0`/`$skip≥0` (throws `ArgumentOutOfRangeException`, matching EF).
+  - `NativeTranslation/MongoStreamingEntityMaterializerRewriter` + `BsonRowReader` + `StreamingEligibility` — forward-only `RawBsonDocument` → POCO materialization for eligible entities (no DOM build).
+  - `Infrastructure/MongoQueryMode` (`Native`/`DriverLinq`/`NativeOnly`) — the user-facing gate option (`UseQueryMode`).
 - `Visitors/MongoEFToLinqTranslatingExpressionVisitor` — converts the residual EF expression into a tree the driver's LINQ v3 provider understands (`Mql.Field`, parameter resolution, `As<T>(serializer)`).
 - `Visitors/MongoProjectionBindingRemovingExpressionVisitor` — replaces `ProjectionBindingExpression` nodes with concrete index-based reads from a `BsonDocument`.
 - `Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor` — sibling of the above used on the mixed path (projection contains entity references LINQ v3 can't handle); `MongoShapedQueryCompilingExpressionVisitor` strips the trailing `Select` and dispatches to this visitor so the shaper runs client-side over full `BsonDocument`s.
-- `Expressions/MongoQueryExpression` — root MongoDB query node; holds `_projectionMapping` and the captured method chain.
 - `Expressions/MongoCollectionExpression`, `EntityProjectionExpression`, `RootReferenceExpression`, `ObjectAccessExpression`, `ObjectArrayProjectionExpression` — provider-specific expression nodes for collection roots, nested-document access, and entity shape.
-- `MongoExecutableQuery` + `QueryingEnumerable` — the compiled-query handoff. `QueryingEnumerable` calls `MongoClientWrapper.Execute(MongoExecutableQuery)` and applies the shaper.
+- `MongoExecutableQuery` + `QueryingEnumerable` — the compiled-query handoff. `QueryingEnumerable` calls `MongoClientWrapper.Execute(MongoExecutableQuery)` and applies the shaper. For the native path `MongoExecutableQuery` carries `NativePipeline` (the built `BsonDocument[]`), `Streaming`, and `Session` (internal); for the fallback it carries the driver-LINQ `Query` expression.
 - `Factories/*` — EF Core DI factories registered in `MongoServiceCollectionExtensions.AddEntityFrameworkMongoDB()`.
 
 ## Boundaries with adjacent areas
 
-- **vs Storage.** Query stops at the executable query. `MongoClientWrapper.Execute(...)` is in Storage; query execution (cursor lifecycle, transaction binding, retries) is owned by the driver and by Storage's wrapper. Never call `IMongoCollection<>.Aggregate(...)` directly from Query.
+- **vs Storage.** Query stops at the executable query — it produces *data*: either a native `BsonDocument[]` pipeline (`MongoExecutableQuery.NativePipeline`) or a driver-LINQ expression. `MongoClientWrapper.Execute(...)` (Storage) owns execution: it runs `collection.Aggregate(nativePipeline)` for the native path and hands the expression to `IMongoQueryProvider` for the fallback. Cursor lifecycle, transaction/session binding, retries are Storage + driver. Never call `IMongoCollection<>.Aggregate(...)` directly from Query — build the `BsonDocument[]` and let the wrapper run it.
 - **vs Storage — bulk `ExecuteUpdate`/`ExecuteDelete` (EF9+) uses a *second*, deliberately different seam.** Reads cross to Storage as **data** (a `MongoExecutableQuery`); bulk crosses as **behavior** — `MongoShapedQueryCompilingExpressionVisitor.CreateBulkPlan<TSource>` builds a `MongoBulkPlan` (Storage) carrying `Func<QueryContext, …>` translation delegates, and `MongoBulkOperationExecutor` (Storage) invokes them at runtime. This is intentional: bulk filter/update translation is parameter-value-dependent, so it must be deferred and re-run per execution. The translation helpers (`BuildFilter`/`BuildUpdate`/`BuildIdDocumentQuery`) stay here in Query; only their rendered results cross the boundary. Don't "fix" the bulk seam to look like the read seam — they differ for this reason.
 - **vs Serializers.** Query needs an `IBsonSerializer` for every materialized projection result — it asks `BsonSerializerFactory` (Serializers area). Query should never instantiate serializers directly.
 - **vs Metadata.** `IEntityType`, `IProperty`, navigation info come from Metadata. Query reads `GetElementName()`, `GetBsonRepresentation()`, `GetDiscriminator*()` etc. — it doesn't write them.
-- **vs the driver's LINQ v3 provider.** Query produces a driver-LINQ expression (using types from `MongoDB.Driver.Linq`) and hands it off. Pipeline-stage construction, server-side `$expr` rendering, and the actual `BsonDocument[]` pipeline are the driver's job.
+- **vs the driver's LINQ v3 provider.** Only the **fallback** path uses it: Query produces a driver-LINQ expression (types from `MongoDB.Driver.Linq`) and hands it off, and the driver builds that pipeline. The **native** path bypasses the driver's LINQ provider entirely — the provider builds the `BsonDocument[]` itself (`MongoSelectLowerer` + `MongoQueryLanguageRenderer` + `MongoPipelineFactory`) and only uses the driver as a BSON/cursor/protocol library via `Aggregate`. The deliberate, stable boundary is **our query tree → `BsonDocument[]` → `Aggregate`**; we do **not** build on the driver's internal AST.
 
 ## Common pitfalls
 
@@ -64,13 +87,21 @@ IQueryable<T>  (EF Core)
 - **ProjectionMapping discipline.** The `_projectionMapping` keys (`ProjectionMember`s) must match exactly what the shaper expects. A mismatch between the post-processor mapping and the shaper compilation produces silent wrong-results, not crashes.
 - **`MongoQueryExpression.CapturedExpression`** must be a *complete* method chain — set once at the tail of `MongoQueryableMethodTranslatingExpressionVisitor.VisitMethodCall`. Setting it mid-chain truncates the query.
 - **Reference-equality on `MethodInfo`.** Translators that match by `MethodInfo` must use canonical constants — `QueryableMethods` for the top-level dispatch in `MongoQueryableMethodTranslatingExpressionVisitor`, `EnumerableMethods` inside the projection-binding visitors, and the driver's `*Method` reflection classes where the bridge to driver-LINQ needs them; open vs. constructed generic methods compare unequal.
-- **Unsupported shapes are detected, not silently translated.** Joins, `GroupBy`, set operations (`Intersect` / `Except`) throw early — see the early-fail branches in `MongoQueryableMethodTranslatingExpressionVisitor`.
+- **Unsupported shapes are detected, not silently translated.** Two layers: the base visitor early-fails truly untranslatable shapes; and for the *native* path, anything the QMTEV does not lower into a slot sets `IsNativeRepresentable = false` so the gate falls back (or throws under `NativeOnly`) rather than emitting a pipeline that silently drops the operator.
+- **The native catch-all whitelist must stay in sync.** `PopulateNativeSlots` lowers exactly seven operators (`Where`/`OrderBy`/`OrderByDescending`/`ThenBy`/`ThenByDescending`/`Skip`/`Take`); `IsNativeRepresentableSlotOperator` lists those same seven, and the `else` catch-all marks **everything else** non-native (correctness-safe: worst case is a missed optimization + fallback, never a wrong result). **Adding a new native operator means updating BOTH** `PopulateNativeSlots` *and* `IsNativeRepresentableSlotOperator` — miss the latter and the operator is silently dropped on the native pipeline.
+- **The QMTEV `Translate{Where,OrderBy,ThenBy,Skip,Take}` overrides are inert (`=> null`).** Native slot population is done inline by `PopulateNativeSlots` at the `VisitMethodCall` fall-through, because routing these through `base.VisitMethodCall` rebuilds a fresh `MongoQueryExpression` per operator (slots don't accumulate). **Do not add these operators to the `VisitMethodCall` switch** without first removing their `PopulateNativeSlots` handling — otherwise slots double-populate.
+- **The lowerer is BSON-free; the renderer/factory own BSON.** `MongoSelectLowerer` produces only typed `MongoPipelineStage`s; all `BsonDocument` construction lives in `MongoQueryLanguageRenderer` (the `$match` body) and `MongoPipelineFactory.Create` (the stage-walk: `{$match}`/`$sort`/`$skip`/`$limit`/`$lookup`/`$unwind`).
+- **Composite-PK key access is NOT native** (strict spike parity) — `MongoExpressionTranslator` rejects multi-property-PK member access, so such predicates/sort fall back. `LookupExpression.GetFieldPath` (`_id.<prop>`) exists for the deferred Include `$lookup` only.
+- **Non-positive paging matches EF's contract.** `MongoPipelineFactory.Build` validates `$limit > 0` / `$skip ≥ 0` and throws `ArgumentOutOfRangeException` (client-side, like the driver) — do not emit `{$limit: 0}` (MongoDB rejects it server-side). Property-less primitive values (Skip/Take counts have `forSerialization == null`) serialize via `BsonValue.Create`, not a property serializer.
+- **MQL shape cannot prove a query went native.** For filter/sort/paging the native and driver-LINQ pipelines are structurally identical (`$match`/`$sort`/`$skip`/`$limit`), so asserting those substrings under `Native` mode passes even on fallback. The **only reliable "goes native" signal is `NativeOnly` mode**: native-capable ⇒ succeeds; otherwise ⇒ throws `NativeTranslationNotSupportedException`. (Several early gate tests were false positives masked by structurally-identical fallback MQL.)
 - **EF Core query cache.** Compiled queries are cached by EF Core by expression-tree shape; if you change a translator's output for a previously-translatable tree, you've quietly invalidated user caches.
 - **Multi-EF guards.** Some visitor signatures changed between EF8/EF9/EF10. For representative guard shapes elsewhere in the tree see `Storage/MongoTypeMappingSource.cs` (`#if EF8 || EF9`), the `ChangeTracking/StringDictionaryComparer*.cs` pair (legacy vs. EF10 split), and the `ChangeTracking/ListOf*Comparer.cs` files (`#if EF8`); in Query itself, `QueryingEnumerable.cs` has a `#if !EF8` block.
 
 ## How to test
 
-Most query tests assert the **rendered MQL pipeline** rather than executing against a server. The functional and specification tests both have helpers (`AssertMql(...)`) that capture the MQL via `TestMqlLoggerFactory`.
+Most query tests assert the **rendered MQL pipeline** rather than executing against a server. The functional and specification tests both have helpers (`AssertMql(...)`) that capture the MQL via `TestMqlLoggerFactory`. Unit tests use **plain xUnit `Assert.*`** (FluentAssertions is not referenced anywhere in the test projects).
+
+**Proving the native path.** `AssertMql` shape does **not** distinguish native from driver-LINQ for filter/sort/paging (identical pipelines) — to assert a query genuinely goes native, run it under `MongoQueryMode.NativeOnly` and assert it **succeeds** (a fallback shape would throw `NativeTranslationNotSupportedException`); to assert a shape falls back, assert it **throws** under `NativeOnly` (or, for `Include`, assert the driver `_outer`/`_inner` shape under `Native`). The spec suite has a **test-only** coverage instrument: `MONGODB_EF_NATIVE_ONLY=1` flips all spec contexts to `NativeOnly` (via `MongoTestStore.AddProviderOptions`), so the pass/fail set is the "what runs native" report. Native unit tests live under `tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/`; the `QueryModeGate*` functional tests exercise the gate end-to-end.
 
 ```bash
 dotnet test MongoDB.EFCoreProvider.sln -c "Debug EF10" --no-build \

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/LookupExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/LookupExpression.cs
@@ -67,7 +67,10 @@ internal sealed class LookupExpression
     /// <param name="navigation">The navigation the lookup supports.</param>
     /// <returns>The <c>_lookup_&lt;NavigationName&gt;</c> field name.</returns>
     public static string GetLookupAlias(IReadOnlyNavigationBase navigation)
-        => $"_lookup_{navigation.Name}";
+        => $"{LookupAliasPrefix}{navigation.Name}";
+
+    /// <summary>The prefix of the synthetic <c>$lookup</c> alias field (see <see cref="GetLookupAlias"/>).</summary>
+    public const string LookupAliasPrefix = "_lookup_";
 
     /// <summary>The navigation this lookup supports.</summary>
     public INavigation Navigation { get; }
@@ -117,6 +120,13 @@ internal sealed class LookupExpression
 
     /// <summary>Whether this lookup is for a single reference (not a collection).</summary>
     public bool IsReference => !Navigation.IsCollection;
+
+    /// <summary>
+    /// A single-level reference Include the native pipeline can emit and the streaming reader can read back:
+    /// a reference nav, no filtered-Include pipeline stages, not a transitive <c>_lookup_</c> local field.
+    /// </summary>
+    public bool IsStreamableReference
+        => IsReference && !HasPipeline && !LocalField.StartsWith(LookupAliasPrefix, System.StringComparison.Ordinal);
 
     /// <summary>Whether $unwind should be applied after $lookup.</summary>
     public bool ShouldUnwind => IsReference || ForceUnwind;

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoBinaryExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoBinaryExpression.cs
@@ -1,0 +1,72 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Represents a binary comparison or logical operation in a MongoDB query expression tree.
+/// Logical operators (<see cref="MongoBinaryOperator.AndAlso"/>, <see cref="MongoBinaryOperator.OrElse"/>)
+/// always produce <see cref="bool"/>; comparison operators take their type from the left operand.
+/// </summary>
+internal sealed class MongoBinaryExpression : MongoExpression
+{
+    /// <summary>
+    /// Creates a <see cref="MongoBinaryExpression"/>.
+    /// </summary>
+    /// <param name="op">The binary operator.</param>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    public MongoBinaryExpression(MongoBinaryOperator op, MongoExpression left, MongoExpression right)
+    {
+        Operator = op;
+        Left = left;
+        Right = right;
+    }
+
+    /// <summary>The binary operator.</summary>
+    public MongoBinaryOperator Operator { get; }
+
+    /// <summary>The left operand.</summary>
+    public MongoExpression Left { get; }
+
+    /// <summary>The right operand.</summary>
+    public MongoExpression Right { get; }
+
+    /// <inheritdoc />
+    public override Type Type
+        => Operator is MongoBinaryOperator.AndAlso or MongoBinaryOperator.OrElse
+            ? typeof(bool)
+            : Left.Type;
+
+    /// <summary>
+    /// Returns a new <see cref="MongoBinaryExpression"/> if either operand changed;
+    /// otherwise returns <see langword="this"/>.
+    /// </summary>
+    public MongoBinaryExpression Update(MongoExpression left, MongoExpression right)
+        => ReferenceEquals(left, Left) && ReferenceEquals(right, Right)
+            ? this
+            : new MongoBinaryExpression(Operator, left, right);
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var newLeft = (MongoExpression)visitor.Visit(Left);
+        var newRight = (MongoExpression)visitor.Visit(Right);
+        return Update(newLeft, newRight);
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoConstantExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoConstantExpression.cs
@@ -1,0 +1,53 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Represents a constant value in a MongoDB query expression tree.
+/// An optional <see cref="ForSerialization"/> property provides the
+/// <see cref="IProperty"/> context for serialization (used by the renderer).
+/// </summary>
+internal sealed class MongoConstantExpression : MongoExpression
+{
+    /// <summary>
+    /// Creates a <see cref="MongoConstantExpression"/> with the given value.
+    /// </summary>
+    /// <param name="value">The constant value.</param>
+    /// <param name="forSerialization">
+    /// Optional <see cref="IProperty"/> that provides serialization context for
+    /// the renderer. May be <see langword="null"/> for untyped constants.
+    /// </param>
+    public MongoConstantExpression(object? value, IProperty? forSerialization)
+    {
+        Value = value;
+        ForSerialization = forSerialization;
+    }
+
+    /// <summary>The constant value.</summary>
+    public object? Value { get; }
+
+    /// <summary>
+    /// Optional property metadata used by the renderer to select the correct serializer.
+    /// </summary>
+    public IProperty? ForSerialization { get; }
+
+    /// <inheritdoc />
+    public override Type Type
+        => Value?.GetType() ?? typeof(object);
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoExpression.cs
@@ -1,0 +1,64 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Abstract base class for all dialect-agnostic MongoDB query expression nodes.
+/// Subclasses of this type plug into the EF Core <see cref="ExpressionVisitor"/> machinery
+/// and are used by the native translator, lowerer, and renderer.
+/// </summary>
+/// <remarks>
+/// Deriving from <see cref="System.Linq.Expressions.Expression"/> (and the <see cref="VisitChildren"/> /
+/// <c>Update</c> plumbing) is forward-looking: it leaves room for visitor-driven transforms / pushdown over
+/// these nodes. That machinery is **not yet exercised at parity** — the renderer walks the tree with a
+/// hand-written <c>switch</c> rather than via a visitor, and <see cref="VisitChildren"/> is a no-op identity.
+/// </remarks>
+internal abstract class MongoExpression : Expression
+{
+    /// <inheritdoc />
+    public override ExpressionType NodeType
+        => ExpressionType.Extension;
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+        => this;
+}
+
+/// <summary>
+/// Binary comparison and logical operators for <see cref="MongoBinaryExpression"/>.
+/// </summary>
+internal enum MongoBinaryOperator
+{
+    Equal,
+    NotEqual,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    AndAlso,
+    OrElse
+}
+
+/// <summary>
+/// Unary operators for <see cref="MongoUnaryExpression"/>.
+/// </summary>
+internal enum MongoUnaryOperator
+{
+    Not
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoFieldExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoFieldExpression.cs
@@ -1,0 +1,48 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Represents a reference to a named document field, identified by its
+/// <see cref="IProperty"/> metadata and serialized element name.
+/// </summary>
+internal sealed class MongoFieldExpression : MongoExpression
+{
+    /// <summary>
+    /// Creates a <see cref="MongoFieldExpression"/> for the given property.
+    /// </summary>
+    /// <param name="property">The EF Core <see cref="IProperty"/> this field corresponds to.</param>
+    /// <param name="elementName">The document element name used in the document.</param>
+    public MongoFieldExpression(IProperty property, string elementName)
+    {
+        Property = property;
+        ElementName = elementName;
+    }
+
+    /// <summary>The EF Core property metadata for this field.</summary>
+    // 'new' hides the inherited static Expression.Property(...) factory; the member name is spec-mandated.
+    public new IProperty Property { get; }
+
+    /// <summary>The document element name for this field in the document.</summary>
+    public string ElementName { get; }
+
+    /// <inheritdoc />
+    public override Type Type
+        => Property.ClrType;
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoOrdering.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoOrdering.cs
@@ -1,0 +1,24 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Represents a single ordering key in a MongoDB query, carrying the key selector
+/// expression and the sort direction.
+/// </summary>
+/// <param name="KeySelector">The expression whose value determines the sort key.</param>
+/// <param name="Ascending"><see langword="true"/> for ascending order; <see langword="false"/> for descending.</param>
+internal readonly record struct MongoOrdering(MongoExpression KeySelector, bool Ascending);

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoParameterExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoParameterExpression.cs
@@ -1,0 +1,55 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Represents a parameterized value placeholder in a MongoDB query expression tree.
+/// Used to carry query-parameter references that will be resolved at execution time
+/// (the B2 placeholder in the native query pipeline).
+/// An optional <see cref="ForSerialization"/> provides the <see cref="IProperty"/>
+/// context needed by the renderer.
+/// </summary>
+internal sealed class MongoParameterExpression : MongoExpression
+{
+    /// <summary>
+    /// Creates a <see cref="MongoParameterExpression"/> with the given name.
+    /// </summary>
+    /// <param name="name">The parameter name.</param>
+    /// <param name="forSerialization">
+    /// Optional <see cref="IProperty"/> that provides serialization context for
+    /// the renderer. May be <see langword="null"/> for untyped parameters.
+    /// </param>
+    public MongoParameterExpression(string name, IProperty? forSerialization)
+    {
+        Name = name;
+        ForSerialization = forSerialization;
+    }
+
+    /// <summary>The parameter name.</summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Optional property metadata used by the renderer to select the correct serializer.
+    /// </summary>
+    public IProperty? ForSerialization { get; }
+
+    /// <inheritdoc />
+    public override Type Type
+        => ForSerialization?.ClrType ?? typeof(object);
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
@@ -79,6 +79,66 @@ internal sealed partial class MongoQueryExpression
     }
 
     /// <summary>
+    /// The single-level reference <c>$lookup</c>s the native streaming path must emit as
+    /// <c>$lookup</c> + <c>$unwind</c> stages (to a root-level <c>_lookup_&lt;Nav&gt;</c> field) and read back
+    /// in the forward-only materializer.
+    /// <para>
+    /// A lone reference Include is translated by the driver-LINQ path as a driver-native LeftJoin
+    /// (<c>_outer</c>/<c>_inner</c>) and registers NO pending <see cref="LookupExpression"/> — see
+    /// <see cref="UsesDriverJoinFields"/>. The native pipeline cannot produce the driver's LeftJoin shape, so
+    /// for that case the reference lookups are synthesized here from <see cref="InnerCollections"/> (each
+    /// inner collection reached by a direct single-reference navigation off the root). This keeps the
+    /// DOM/driver-LINQ join-shape decision untouched (no pending lookup is registered, so the DOM fallback
+    /// still uses the driver-native LeftJoin) while giving the native streaming path the flat
+    /// <c>_lookup_&lt;Nav&gt;</c> shape its materializer reads.
+    /// </para>
+    /// <para>
+    /// When pending reference lookups ARE registered (multi-join flat mode), those are returned directly.
+    /// </para>
+    /// </summary>
+    public IReadOnlyList<LookupExpression> GetStreamingReferenceLookups()
+    {
+        var pending = GetPendingLookups();
+        if (pending.Count > 0)
+        {
+            return pending;
+        }
+
+        if (!UsesDriverJoinFields)
+        {
+            return pending;
+        }
+
+        // Driver-native LeftJoin case: synthesize a reference lookup per inner collection that is the target
+        // of a direct single-reference navigation off the root entity.
+        var rootEntityType = CollectionExpression.EntityType;
+        var synthesized = new List<LookupExpression>();
+        foreach (var innerEntityType in _innerCollections.Keys)
+        {
+            var matches = rootEntityType.GetNavigations()
+                .Where(n => !n.IsCollection
+                            && !n.TargetEntityType.IsOwned()
+                            && n.TargetEntityType == innerEntityType)
+                .ToList();
+
+            // Synthesis matches by target type. If more than one single-reference navigation off the root
+            // targets the same inner collection (e.g. Doc.Author and Doc.Editor both -> Person), we cannot
+            // tell which one this lookup is for by type alone — bail to the driver/DOM fallback rather than
+            // risk resolving to the wrong navigation's element alias.
+            if (matches.Count != 1)
+            {
+                // Zero: not a direct single-reference navigation off the root (e.g. transitive / collection).
+                // More than one: ambiguous by target type. Either way, not streamable here -> fall back.
+                return Array.Empty<LookupExpression>();
+            }
+
+            synthesized.Add(new LookupExpression(matches[0]));
+        }
+
+        return synthesized;
+    }
+
+    /// <summary>
     /// Register a $lookup stage for a cross-collection collection Include.
     /// </summary>
     public void AddLookup(LookupExpression lookup)

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.NativeSlots.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.NativeSlots.cs
@@ -1,0 +1,109 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+// EF-323 SP1 — native-query-translation logical slots.
+// These slots are what the design document calls "MongoSelectExpression". They are implemented
+// in-place on MongoQueryExpression (controller decision) to avoid churning the QMTEV, shaper,
+// and factory plumbing. The existing CapturedExpression + projection machinery is untouched and
+// continues to serve the current fallback path.
+internal sealed partial class MongoQueryExpression
+{
+    private readonly List<MongoOrdering> _orderings = [];
+
+    // ── Predicate ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The conjunction of all <c>Where</c> predicates pushed down so far.
+    /// <see langword="null"/> means no predicate (match-all).
+    /// </summary>
+    public MongoExpression? Predicate { get; set; }
+
+    /// <summary>
+    /// AND-combines <paramref name="conjunct"/> into <see cref="Predicate"/>.
+    /// If <see cref="Predicate"/> is currently <see langword="null"/>, sets it directly;
+    /// otherwise wraps both sides in a <see cref="MongoBinaryExpression"/> with
+    /// <see cref="MongoBinaryOperator.AndAlso"/>.
+    /// </summary>
+    public void AddPredicateConjunct(MongoExpression conjunct)
+        => Predicate = Predicate is null
+            ? conjunct
+            : new MongoBinaryExpression(MongoBinaryOperator.AndAlso, Predicate, conjunct);
+
+    // ── Orderings ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The ordered sequence of sort keys for this query.
+    /// </summary>
+    public IReadOnlyList<MongoOrdering> Orderings => _orderings;
+
+    /// <summary>
+    /// Clears any existing orderings and sets <paramref name="first"/> as the sole ordering.
+    /// </summary>
+    public void ResetOrderings(MongoOrdering first)
+    {
+        _orderings.Clear();
+        _orderings.Add(first);
+    }
+
+    /// <summary>
+    /// Appends <paramref name="next"/> to the end of the orderings list.
+    /// </summary>
+    public void AppendOrdering(MongoOrdering next)
+        => _orderings.Add(next);
+
+    // ── Limit / Offset ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The maximum number of documents to return, or <see langword="null"/> for no limit.
+    /// </summary>
+    public MongoExpression? Limit { get; set; }
+
+    /// <summary>
+    /// The number of documents to skip before returning results, or <see langword="null"/> for no offset.
+    /// </summary>
+    public MongoExpression? Offset { get; set; }
+
+    // ── Native-representable gate ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Whether this query can be rendered to native MongoDB aggregation pipeline stages.
+    /// Starts as <see langword="true"/>; the QMTEV (Task 6) flips it to <see langword="false"/>
+    /// when it encounters a shape the native path cannot handle. The lowerer gate (Task 14)
+    /// reads this to decide whether to attempt native emission.
+    /// </summary>
+    public bool IsNativeRepresentable { get; set; } = true;
+
+    // ── Lookups accessor ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The ordered list of <c>$lookup</c> stages the native pipeline must emit for cross-collection
+    /// Include operations. Surfaces the reference-lookup reconstruction from
+    /// <see cref="GetStreamingReferenceLookups"/>: when no pending lookups are registered (the driver's
+    /// native LeftJoin path), the single-level reference lookups are synthesized from
+    /// <see cref="InnerCollections"/>; otherwise the already-registered pending lookups are returned
+    /// directly. Consumed by the native lowerer (Task 14) to emit <c>$lookup</c> + <c>$unwind</c> stages.
+    /// </summary>
+    /// <remarks>
+    /// This is NOT a stored slot: each access <b>recomputes</b> <see cref="GetStreamingReferenceLookups"/>,
+    /// an O(navigations) reconstruction off <see cref="InnerCollections"/>. Callers should not treat it as a
+    /// cheap field read. It is slated for structural replacement (a populated <c>Lookups</c> slot) in the
+    /// Collection Includes sub-project.
+    /// </remarks>
+    public IReadOnlyList<LookupExpression> Lookups => GetStreamingReferenceLookups();
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoUnaryExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoUnaryExpression.cs
@@ -1,0 +1,63 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.Expressions;
+
+/// <summary>
+/// Represents a unary operation in a MongoDB query expression tree.
+/// Currently only <see cref="MongoUnaryOperator.Not"/> is supported.
+/// </summary>
+internal sealed class MongoUnaryExpression : MongoExpression
+{
+    /// <summary>
+    /// Creates a <see cref="MongoUnaryExpression"/>.
+    /// </summary>
+    /// <param name="op">The unary operator.</param>
+    /// <param name="operand">The operand expression.</param>
+    public MongoUnaryExpression(MongoUnaryOperator op, MongoExpression operand)
+    {
+        Operator = op;
+        Operand = operand;
+    }
+
+    /// <summary>The unary operator.</summary>
+    public MongoUnaryOperator Operator { get; }
+
+    /// <summary>The operand expression.</summary>
+    public MongoExpression Operand { get; }
+
+    /// <inheritdoc />
+    public override Type Type
+        => typeof(bool);
+
+    /// <summary>
+    /// Returns a new <see cref="MongoUnaryExpression"/> if the operand changed;
+    /// otherwise returns <see langword="this"/>.
+    /// </summary>
+    public MongoUnaryExpression Update(MongoExpression operand)
+        => ReferenceEquals(operand, Operand)
+            ? this
+            : new MongoUnaryExpression(Operator, operand);
+
+    /// <inheritdoc />
+    protected override Expression VisitChildren(ExpressionVisitor visitor)
+    {
+        var newOperand = (MongoExpression)visitor.Visit(Operand);
+        return Update(newOperand);
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/Factories/MongoQueryCompilationContextFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Factories/MongoQueryCompilationContextFactory.cs
@@ -13,7 +13,10 @@
  * limitations under the License.
  */
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.EntityFrameworkCore.Infrastructure;
 
 namespace MongoDB.EntityFrameworkCore.Query.Factories;
 
@@ -22,14 +25,19 @@ namespace MongoDB.EntityFrameworkCore.Query.Factories;
 /// </summary>
 public class MongoQueryCompilationContextFactory : IQueryCompilationContextFactory
 {
+    private readonly MongoQueryMode _queryMode;
+
     /// <summary>
     /// Create a <see cref="MongoQueryContextFactory"/>.
     /// </summary>
     /// <param name="dependencies">The <see cref="QueryCompilationContextDependencies"/> passed to each created <see cref="MongoQueryCompilationContext" /> instance.</param>
+    /// <param name="dbContextOptions">The <see cref="IDbContextOptions"/> used to resolve the configured <see cref="MongoQueryMode"/>.</param>
     public MongoQueryCompilationContextFactory(
-        QueryCompilationContextDependencies dependencies)
+        QueryCompilationContextDependencies dependencies,
+        IDbContextOptions dbContextOptions)
     {
         Dependencies = dependencies;
+        _queryMode = dbContextOptions.FindExtension<MongoOptionsExtension>()?.QueryMode ?? MongoQueryMode.Native;
     }
 
     /// <summary>
@@ -43,5 +51,5 @@ public class MongoQueryCompilationContextFactory : IQueryCompilationContextFacto
     /// <param name="async"><see langword="true"/> if the query to process is asynchronous, <see langword="false"/> if it is synchronous.</param>
     /// <returns>The newly created <see cref="MongoQueryCompilationContext"/>.</returns>
     public virtual QueryCompilationContext Create(bool async)
-        => new MongoQueryCompilationContext(Dependencies, async);
+        => new MongoQueryCompilationContext(Dependencies, async, _queryMode);
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoExecutableQuery.cs
@@ -13,9 +13,11 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 
@@ -39,4 +41,13 @@ public record MongoExecutableQuery(
 {
     internal const string VectorQueryProperty = nameof(VectorQueryProperty);
     internal const string VectorQueryIndexName = nameof(VectorQueryIndexName);
+
+    /// <summary>When set, the query is executed as this native aggregation pipeline instead of via the LINQ <see cref="Provider"/>.</summary>
+    internal IReadOnlyList<BsonDocument>? NativePipeline { get; init; }
+
+    /// <summary>The session for native pipeline execution (the ambient transaction's session, if any).</summary>
+    internal IClientSessionHandle? Session { get; init; }
+
+    /// <summary>When true, native rows are RawBsonDocument and materialized by the forward-only streaming reader.</summary>
+    internal bool Streaming { get; init; }
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/MongoQueryCompilationContext.cs
@@ -16,17 +16,33 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.EntityFrameworkCore.Infrastructure;
 
 namespace MongoDB.EntityFrameworkCore.Query;
 
 /// <inheritdoc />
-public class MongoQueryCompilationContext(QueryCompilationContextDependencies dependencies, bool async)
+public class MongoQueryCompilationContext(QueryCompilationContextDependencies dependencies, bool async, MongoQueryMode queryMode)
     : QueryCompilationContext(dependencies, async)
 {
+    /// <summary>
+    /// Creates a <see cref="MongoQueryCompilationContext"/> using the default <see cref="MongoQueryMode.Native"/> query mode.
+    /// </summary>
+    /// <param name="dependencies">The <see cref="QueryCompilationContextDependencies"/> this context depends upon.</param>
+    /// <param name="async">Whether the query is asynchronous.</param>
+    public MongoQueryCompilationContext(QueryCompilationContextDependencies dependencies, bool async)
+        : this(dependencies, async, MongoQueryMode.Native)
+    {
+    }
+
     /// <summary>
     /// The original expression that was passed to the query translator.
     /// </summary>
     public Expression? OriginalExpression { get; internal set; }
+
+    /// <summary>
+    /// The <see cref="MongoQueryMode"/> that controls how LINQ queries are translated for this compilation.
+    /// </summary>
+    public MongoQueryMode QueryMode { get; } = queryMode;
 
     /// <inheritdoc/>
     public override Func<QueryContext, TResult> CreateQueryExecutor<TResult>(Expression query)

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/BsonRowReader.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/BsonRowReader.cs
@@ -1,0 +1,26 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>Opens a forward-only <see cref="IBsonReader"/> over a RawBsonDocument's raw bytes (no DOM build).</summary>
+internal static class BsonRowReader
+{
+    public static BsonBinaryReader Open(RawBsonDocument row)
+        => new(new ByteBufferStream(row.Slice, ownsBuffer: false));
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/BsonValueSerializer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/BsonValueSerializer.cs
@@ -1,0 +1,77 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Globalization;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Shared value-serialization helpers used by both the compile-time renderer
+/// (<see cref="MongoQueryLanguageRenderer"/>, baking inline constants) and the per-execution
+/// parameter binder (<see cref="MongoPipelineFactory"/>). Keeping a single implementation here
+/// guarantees a captured constant and a runtime parameter of the same value serialize identically.
+/// </summary>
+internal static class BsonValueSerializer
+{
+    /// <summary>
+    /// Coerces a CLR value to <paramref name="target"/> so the property/value serializer (which casts hard to
+    /// its exact type) accepts it. Handles <c>Nullable&lt;T&gt;</c> by unwrapping to the underlying type, then
+    /// applies enum and numeric promotion. Returns the value unchanged if no safe coercion applies.
+    /// Ported verbatim from the spike's <c>MongoPredicateTranslator.CoerceToPropertyType</c>.
+    /// </summary>
+    public static object? Coerce(Type target, object? value)
+    {
+        if (value is null)
+            return null;
+
+        var resolved = Nullable.GetUnderlyingType(target) ?? target;
+        var valueType = value.GetType();
+        if (valueType == resolved)
+            return value;
+
+        if (resolved.IsEnum && Enum.GetUnderlyingType(resolved) is var enumBase &&
+            (valueType == enumBase || value is IConvertible))
+            return Enum.ToObject(resolved, value);
+
+        if (value is IConvertible && (resolved.IsPrimitive || resolved == typeof(decimal)))
+            return Convert.ChangeType(value, resolved, CultureInfo.InvariantCulture);
+
+        return value;
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> through <paramref name="serializer"/> using a
+    /// <see cref="BsonDocumentWriter"/> with a <c>"v"</c> wrapper element, returning the wrapped value.
+    /// This is the single serialize-block shared by the compile-time and run-time native paths so the two
+    /// emit identical BSON. The caller is responsible for any coercion (via <see cref="Coerce"/>) beforehand.
+    /// </summary>
+    public static BsonValue SerializeThroughWriter(IBsonSerializer serializer, object? value)
+    {
+        var doc = new BsonDocument();
+        using (var writer = new BsonDocumentWriter(doc))
+        {
+            writer.WriteStartDocument();
+            writer.WriteName("v");
+            serializer.Serialize(BsonSerializationContext.CreateRoot(writer), value);
+            writer.WriteEndDocument();
+        }
+
+        return doc["v"];
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoExpressionTranslator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoExpressionTranslator.cs
@@ -1,0 +1,293 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Translates an EF Core predicate or key-selector lambda body into a dialect-agnostic
+/// <see cref="MongoExpression"/> tree, suitable for later rendering to a MongoDB filter
+/// or sort document.
+/// </summary>
+/// <remarks>
+/// This is a compile-time-only translator: it produces a <em>template</em> tree where
+/// captured constants become <see cref="MongoConstantExpression"/> nodes baked into the
+/// template, and query parameters become <see cref="MongoParameterExpression"/> placeholder
+/// nodes that are resolved per execution (the B2 binding step).
+///
+/// Returns <see langword="false"/> for any shape outside the parity acceptance set rather
+/// than throwing, so callers can fall back to the driver-LINQ path gracefully.
+/// </remarks>
+internal sealed class MongoExpressionTranslator
+{
+    private readonly IEntityType _entityType;
+
+    /// <summary>
+    /// Creates a <see cref="MongoExpressionTranslator"/> for the given entity type.
+    /// </summary>
+    /// <param name="entityType">The entity type whose properties and element names are used during translation.</param>
+    public MongoExpressionTranslator(IEntityType entityType)
+    {
+        _entityType = entityType;
+    }
+
+    /// <summary>
+    /// Attempts to translate an EF Core expression body into a <see cref="MongoExpression"/>.
+    /// </summary>
+    /// <param name="efBody">The expression body (from a predicate or key-selector lambda).</param>
+    /// <param name="result">
+    /// The translated <see cref="MongoExpression"/>, or <see langword="null"/> if the body
+    /// is outside the parity acceptance set.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the body was translated successfully; <see langword="false"/> if
+    /// the shape is not natively representable (the caller should fall back to driver-LINQ).
+    /// </returns>
+    public bool TryTranslate(Expression efBody, [NotNullWhen(true)] out MongoExpression? result)
+    {
+        result = TranslateNode(Unwrap(efBody));
+        return result is not null;
+    }
+
+    /// <summary>
+    /// Attempts to translate a key-selector lambda body to a <see cref="MongoFieldExpression"/>
+    /// suitable for use in an ordering clause.  Unlike <see cref="TryTranslate"/>, this path
+    /// accepts any mapped scalar property — not just booleans — because the intent is to
+    /// produce a sort-key reference, not a predicate.
+    /// </summary>
+    /// <param name="keySelectorBody">The lambda body (e.g. <c>c.Age</c>) from an <c>OrderBy</c> or <c>ThenBy</c> call.</param>
+    /// <param name="result">The translated <see cref="MongoFieldExpression"/>, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the body was translated successfully.</returns>
+    public bool TryTranslateField(Expression keySelectorBody, [NotNullWhen(true)] out MongoFieldExpression? result)
+    {
+        result = null;
+        if (!TryResolveMember(Unwrap(keySelectorBody), out var property, out var path))
+            return false;
+
+        result = new MongoFieldExpression(property, path);
+        return true;
+    }
+
+    // Strip redundant Convert/ConvertChecked wrappers (EF sometimes adds a nullable-widening convert).
+    private static Expression Unwrap(Expression e)
+        => e is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } u
+            ? Unwrap(u.Operand)
+            : e;
+
+    // Returns null for any unsupported node (the caller propagates null → false return).
+    private MongoExpression? TranslateNode(Expression node)
+    {
+        switch (node)
+        {
+            // --- Logical binary operators ---
+
+            case BinaryExpression { NodeType: ExpressionType.AndAlso } andAlso:
+            {
+                var left = TranslateNode(Unwrap(andAlso.Left));
+                if (left is null) return null;
+                var right = TranslateNode(Unwrap(andAlso.Right));
+                if (right is null) return null;
+                return new MongoBinaryExpression(MongoBinaryOperator.AndAlso, left, right);
+            }
+
+            case BinaryExpression { NodeType: ExpressionType.OrElse } orElse:
+            {
+                var left = TranslateNode(Unwrap(orElse.Left));
+                if (left is null) return null;
+                var right = TranslateNode(Unwrap(orElse.Right));
+                if (right is null) return null;
+                return new MongoBinaryExpression(MongoBinaryOperator.OrElse, left, right);
+            }
+
+            // --- Comparison binary operators ---
+
+            case BinaryExpression be when IsComparison(be.NodeType):
+                return TranslateComparison(be);
+
+            // --- Negation of a boolean field ---
+
+            case UnaryExpression { NodeType: ExpressionType.Not } not:
+            {
+                var operand = TranslateNode(Unwrap(not.Operand));
+                if (operand is null) return null;
+                // Only allow Not over a field or further translated expression; nullable bools fall back.
+                if (operand is MongoFieldExpression fieldExpr && fieldExpr.Property.IsNullable)
+                    return null; // conservative: nullable bool Not could diverge from driver rendering
+                return new MongoUnaryExpression(MongoUnaryOperator.Not, operand);
+            }
+
+            // --- Bare boolean member access (c.Active) ---
+
+            default:
+                if (TryResolveMember(node, out var boolProp, out var boolPath))
+                {
+                    // Accept only non-nullable bools; a nullable bool bare access could diverge.
+                    if (boolProp!.ClrType != typeof(bool) || boolProp.IsNullable)
+                        return null;
+                    return new MongoFieldExpression(boolProp, boolPath!);
+                }
+
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Translate a comparison <see cref="BinaryExpression"/> into a <see cref="MongoBinaryExpression"/>
+    /// with <see cref="MongoFieldExpression"/> on the field side and a value node
+    /// (<see cref="MongoConstantExpression"/> or <see cref="MongoParameterExpression"/>) on the other.
+    /// </summary>
+    private MongoBinaryExpression? TranslateComparison(BinaryExpression be)
+    {
+        IProperty? property;
+        string? fieldPath;
+        Expression valueNode;
+        bool memberOnLeft;
+
+        var leftUnwrapped = Unwrap(be.Left);
+        var rightUnwrapped = Unwrap(be.Right);
+
+        if (TryResolveMember(leftUnwrapped, out property, out fieldPath))
+        {
+            valueNode = rightUnwrapped;
+            memberOnLeft = true;
+        }
+        else if (TryResolveMember(rightUnwrapped, out property, out fieldPath))
+        {
+            valueNode = leftUnwrapped;
+            memberOnLeft = false;
+        }
+        else
+        {
+            return null; // no member on either side — not supported
+        }
+
+        // Numeric cast on the member side changes comparison semantics — fall back.
+        if (HasNumericConvert(memberOnLeft ? be.Left : be.Right, property!.ClrType))
+            return null;
+
+        // Equality/inequality on nullable properties can diverge from driver rendering — fall back.
+        if (be.NodeType is ExpressionType.Equal or ExpressionType.NotEqual && property.IsNullable)
+            return null;
+
+        // Mirror the operator when the member is on the right-hand side.
+        var effectiveNodeType = memberOnLeft ? be.NodeType : Mirror(be.NodeType);
+
+        var mongoOp = effectiveNodeType switch
+        {
+            ExpressionType.Equal => MongoBinaryOperator.Equal,
+            ExpressionType.NotEqual => MongoBinaryOperator.NotEqual,
+            ExpressionType.LessThan => MongoBinaryOperator.LessThan,
+            ExpressionType.LessThanOrEqual => MongoBinaryOperator.LessThanOrEqual,
+            ExpressionType.GreaterThan => MongoBinaryOperator.GreaterThan,
+            ExpressionType.GreaterThanOrEqual => MongoBinaryOperator.GreaterThanOrEqual,
+            _ => (MongoBinaryOperator?)null
+        };
+
+        if (mongoOp is null)
+            return null;
+
+        var valueExpr = TranslateValue(valueNode, property);
+        if (valueExpr is null)
+            return null;
+
+        var fieldExpr = new MongoFieldExpression(property, fieldPath!);
+        return new MongoBinaryExpression(mongoOp.Value, fieldExpr, valueExpr);
+    }
+
+    /// <summary>
+    /// Translates a value node (the non-field operand of a comparison) to either a
+    /// <see cref="MongoConstantExpression"/> (baked-in literal) or a
+    /// <see cref="MongoParameterExpression"/> (B2 placeholder for a query parameter).
+    /// Returns <see langword="null"/> for any node that cannot be represented.
+    /// </summary>
+    private static MongoExpression? TranslateValue(Expression node, IProperty forSerialization)
+    {
+        if (node is ConstantExpression constant)
+            return new MongoConstantExpression(constant.Value, forSerialization);
+
+        if (NativeQueryParameter.TryGetQueryParameterName(node, out var parameterName))
+            return new MongoParameterExpression(parameterName, forSerialization);
+
+        return null; // any other node shape (method call, sub-expression, etc.) is not supported
+    }
+
+    /// <summary>
+    /// Attempts to resolve a simple member-access expression to its <see cref="IProperty"/> and
+    /// the MongoDB document element name. Returns <see langword="false"/> for any property that
+    /// cannot be natively addressed, including composite-PK components whose storage path is
+    /// <c>_id.&lt;element&gt;</c> — those fall back to driver-LINQ.
+    /// </summary>
+    private bool TryResolveMember(Expression node, [NotNullWhen(true)] out IProperty? property, [NotNullWhen(true)] out string? fieldPath)
+    {
+        property = null;
+        fieldPath = null;
+
+        if (node is not MemberExpression { Expression: ParameterExpression } me)
+            return false;
+
+        property = _entityType.FindProperty(me.Member.Name);
+        if (property is null)
+            return false;
+
+        // A component of a composite primary key is stored nested under "_id" (e.g. { _id: { Key1, Key2 } }),
+        // so its top-level element name does not address the stored field. The driver-LINQ path resolves the
+        // dotted "_id.<name>" path; the native translator does not, so refuse it here and let the query fall
+        // back rather than emit a $match against a non-existent top-level field (which silently returns nothing).
+        if (property.IsPrimaryKey() && property.FindContainingPrimaryKey()!.Properties.Count > 1)
+            return false;
+
+        fieldPath = property.GetElementName();
+        return true;
+    }
+
+    // True when the operand wraps the member in a Convert/ConvertChecked to a semantically different
+    // type — i.e. a numeric cast that changes the comparison semantics. A nullable<->underlying widening
+    // convert is benign (EF adds it automatically) and is not treated as a cast.
+    private static bool HasNumericConvert(Expression operand, Type propertyClrType)
+    {
+        var underlying = Nullable.GetUnderlyingType(propertyClrType) ?? propertyClrType;
+        while (operand is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } u)
+        {
+            var to = Nullable.GetUnderlyingType(u.Type) ?? u.Type;
+            if (to != underlying)
+                return true;
+            operand = u.Operand;
+        }
+
+        return false;
+    }
+
+    // Mirror a relational operator for the case where the member is on the right-hand side.
+    private static ExpressionType Mirror(ExpressionType nodeType)
+        => nodeType switch
+        {
+            ExpressionType.LessThan => ExpressionType.GreaterThan,
+            ExpressionType.LessThanOrEqual => ExpressionType.GreaterThanOrEqual,
+            ExpressionType.GreaterThan => ExpressionType.LessThan,
+            ExpressionType.GreaterThanOrEqual => ExpressionType.LessThanOrEqual,
+            _ => nodeType
+        };
+
+    private static bool IsComparison(ExpressionType t)
+        => t is ExpressionType.Equal or ExpressionType.NotEqual
+            or ExpressionType.LessThan or ExpressionType.LessThanOrEqual
+            or ExpressionType.GreaterThan or ExpressionType.GreaterThanOrEqual;
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoPipelineFactory.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoPipelineFactory.cs
@@ -1,0 +1,263 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Translates a typed <see cref="MongoPipelineStage"/> list into a cached <see cref="BsonDocument"/>
+/// template and binds per-execution parameter values via <see cref="Build"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Constructed once per compiled query via <see cref="Create"/>. At compile time the stage-walk renders
+/// each stage to a <see cref="BsonDocument"/>, baking constants inline and recording parameter sites as
+/// placeholder sentinels in a shared <see cref="PlaceholderTable"/>. The resulting template is immutable.
+/// </para>
+/// <para>
+/// At execution time <see cref="Build"/> clones the template and substitutes every sentinel with the
+/// serialized runtime value. Constants are already baked — they are never touched by Build.
+/// No EF-version-conditional code appears here; bridging <c>QueryContext.Parameters</c> (EF10) vs
+/// <c>QueryContext.ParameterValues</c> (EF8/EF9) is the caller's responsibility.
+/// </para>
+/// </remarks>
+internal sealed class MongoPipelineFactory
+{
+    private readonly IReadOnlyList<BsonDocument> _template;
+    private readonly PlaceholderTable _placeholders;
+
+    private MongoPipelineFactory(IReadOnlyList<BsonDocument> template, PlaceholderTable placeholders)
+    {
+        _template = template;
+        _placeholders = placeholders;
+    }
+
+    // ------------------------------------------------------------------
+    // Stage-walk: compile-time template construction
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Renders each stage in <paramref name="stages"/> to a <see cref="BsonDocument"/> using one
+    /// shared <see cref="PlaceholderTable"/>, then returns a <see cref="MongoPipelineFactory"/>
+    /// that can bind parameter values per execution.
+    /// </summary>
+    /// <param name="stages">The typed pipeline stages produced by the lowerer (Task 8).</param>
+    /// <param name="renderer">The renderer used to emit <c>$match</c> bodies and scalar values.</param>
+    public static MongoPipelineFactory Create(
+        IReadOnlyList<MongoPipelineStage> stages,
+        MongoQueryLanguageRenderer renderer)
+    {
+        var placeholders = new PlaceholderTable();
+        var template = new BsonDocument[stages.Count];
+
+        for (var i = 0; i < stages.Count; i++)
+            template[i] = RenderStage(stages[i], renderer, placeholders);
+
+        return new MongoPipelineFactory(template, placeholders);
+    }
+
+    private static BsonDocument RenderStage(
+        MongoPipelineStage stage,
+        MongoQueryLanguageRenderer renderer,
+        PlaceholderTable placeholders)
+        => stage switch
+        {
+            MongoMatchStage match => RenderMatch(match, renderer, placeholders),
+            MongoSortStage sort => RenderSort(sort),
+            MongoSkipStage skip => RenderSkip(skip, renderer, placeholders),
+            MongoLimitStage limit => RenderLimit(limit, renderer, placeholders),
+            MongoLookupStage lookup => RenderLookup(lookup.Lookup),
+            MongoUnwindStage unwind => RenderUnwind(unwind.Lookup),
+            _ => throw new NativeTranslationNotSupportedException(
+                $"MongoPipelineFactory does not support stage type '{stage.GetType().Name}'.")
+        };
+
+    private static BsonDocument RenderMatch(
+        MongoMatchStage stage,
+        MongoQueryLanguageRenderer renderer,
+        PlaceholderTable placeholders)
+        => new BsonDocument("$match", renderer.Render(stage.Predicate, placeholders));
+
+    private static BsonDocument RenderSort(MongoSortStage stage)
+    {
+        var body = new BsonDocument();
+        foreach (var ordering in stage.Orderings)
+        {
+            if (ordering.KeySelector is not MongoFieldExpression field)
+                throw new NativeTranslationNotSupportedException(
+                    $"$sort key selector must be a MongoFieldExpression; got '{ordering.KeySelector.GetType().Name}'. "
+                    + "Non-field sort keys should have been rejected by the translator.");
+
+            body.Add(field.ElementName, ordering.Ascending ? BsonInt32.Create(1) : BsonInt32.Create(-1));
+        }
+
+        return new BsonDocument("$sort", body);
+    }
+
+    private static BsonDocument RenderSkip(
+        MongoSkipStage stage,
+        MongoQueryLanguageRenderer renderer,
+        PlaceholderTable placeholders)
+        => new BsonDocument("$skip", renderer.RenderValue(stage.Offset, placeholders));
+
+    private static BsonDocument RenderLimit(
+        MongoLimitStage stage,
+        MongoQueryLanguageRenderer renderer,
+        PlaceholderTable placeholders)
+        => new BsonDocument("$limit", renderer.RenderValue(stage.Limit, placeholders));
+
+    private static BsonDocument RenderLookup(LookupExpression lookup)
+        => new BsonDocument("$lookup", new BsonDocument
+        {
+            { "from", lookup.From },
+            { "localField", lookup.LocalField },
+            { "foreignField", lookup.ForeignField },
+            { "as", lookup.As }
+        });
+
+    private static BsonDocument RenderUnwind(LookupExpression lookup)
+        => new BsonDocument("$unwind", new BsonDocument
+        {
+            { "path", "$" + lookup.As },
+            { "preserveNullAndEmptyArrays", true }
+        });
+
+    // ------------------------------------------------------------------
+    // Per-execution binding
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Clones the compiled template and substitutes every placeholder sentinel with the
+    /// serialized runtime value for the corresponding entry in <see cref="_placeholders"/>.
+    /// </summary>
+    /// <param name="parameterValues">
+    /// The named parameter values for this execution. Must contain an entry for every
+    /// parameter name recorded in <see cref="_placeholders"/>; a missing key is a bug
+    /// in the caller and throws <see cref="InvalidOperationException"/>.
+    /// </param>
+    /// <returns>A freshly materialized <see cref="BsonDocument"/> array ready to send to the server.</returns>
+    public BsonDocument[] Build(IReadOnlyDictionary<string, object?> parameterValues)
+    {
+        var result = new BsonDocument[_template.Count];
+        for (var i = 0; i < _template.Count; i++)
+            result[i] = SubstituteDocument((BsonDocument)_template[i].DeepClone(), parameterValues);
+
+        // Validate paging bounds: MongoDB rejects $limit <= 0 and $skip < 0 server-side;
+        // throw the EF-correct exception (ArgumentOutOfRangeException) client-side to match
+        // driver-LINQ behaviour (which threw it client-side for Take(0)).
+        ValidatePagingStages(result);
+
+        return result;
+    }
+
+    private static void ValidatePagingStages(BsonDocument[] pipeline)
+    {
+        foreach (var stage in pipeline)
+        {
+            if (stage.TryGetValue("$limit", out var limitValue))
+            {
+                var limit = limitValue.ToInt64();
+                if (limit <= 0)
+                    throw new ArgumentOutOfRangeException("count",
+                        $"Take must be positive; got {limit}.");
+            }
+            else if (stage.TryGetValue("$skip", out var skipValue))
+            {
+                var skip = skipValue.ToInt64();
+                if (skip < 0)
+                    throw new ArgumentOutOfRangeException("count",
+                        $"Skip must be non-negative; got {skip}.");
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Deep-walk substitution
+    // ------------------------------------------------------------------
+
+    private BsonDocument SubstituteDocument(
+        BsonDocument doc,
+        IReadOnlyDictionary<string, object?> parameterValues)
+    {
+        // Work on the element list directly so we can replace in place.
+        for (var i = 0; i < doc.ElementCount; i++)
+        {
+            var element = doc.GetElement(i);
+            var newValue = SubstituteValue(element.Value, parameterValues);
+            if (!ReferenceEquals(newValue, element.Value))
+                doc[i] = newValue;
+        }
+
+        return doc;
+    }
+
+    private BsonValue SubstituteValue(
+        BsonValue value,
+        IReadOnlyDictionary<string, object?> parameterValues)
+    {
+        // Test for sentinel BEFORE recursing — a sentinel is a one-element BsonDocument.
+        if (PlaceholderTable.TryGetPlaceholderIndex(value, out var index))
+            return SerializeParameter(index, parameterValues);
+
+        return value switch
+        {
+            BsonDocument doc => SubstituteDocument(doc, parameterValues),
+            BsonArray array => SubstituteArray(array, parameterValues),
+            _ => value   // scalar — already baked constant, no substitution needed
+        };
+    }
+
+    private BsonArray SubstituteArray(
+        BsonArray array,
+        IReadOnlyDictionary<string, object?> parameterValues)
+    {
+        for (var i = 0; i < array.Count; i++)
+            array[i] = SubstituteValue(array[i], parameterValues);
+        return array;
+    }
+
+    // ------------------------------------------------------------------
+    // Parameter value serialization
+    // ------------------------------------------------------------------
+
+    private BsonValue SerializeParameter(
+        int index,
+        IReadOnlyDictionary<string, object?> parameterValues)
+    {
+        var (name, serializer) = _placeholders.Entries[index];
+
+        if (!parameterValues.TryGetValue(name, out var rawValue))
+            throw new InvalidOperationException(
+                $"MongoPipelineFactory.Build: parameter '{name}' (placeholder index {index}) "
+                + "is not present in parameterValues. This is a bug in the query compilation pipeline.");
+
+        // Property-less primitive (e.g. Skip/Take count): serialize via BsonValue.Create.
+        if (serializer is null)
+            return BsonValue.Create(rawValue);
+
+        // Coerce the CLR value to the serializer's expected type, then serialize through the shared
+        // "v"-wrapper block so a run-time parameter and a compile-time constant of the same value emit
+        // identical BSON. The compile-time path (MongoQueryLanguageRenderer.ToBsonValue) coerces to the
+        // property's ClrType; here we coerce to the serializer's ValueType — these differ for
+        // value-converted properties. No try/catch: the value was already validated at translation time.
+        rawValue = BsonValueSerializer.Coerce(serializer.ValueType, rawValue);
+        return BsonValueSerializer.SerializeThroughWriter(serializer, rawValue);
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoQueryLanguageRenderer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoQueryLanguageRenderer.cs
@@ -1,0 +1,340 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Serializers;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Renders a dialect-agnostic <see cref="MongoExpression"/> predicate to the
+/// MongoDB <c>$match</c>-filter body <see cref="BsonValue"/>
+/// (e.g. <c>{ Age: { $gt: 21 } }</c> — without the outer <c>{ $match: … }</c> wrapper,
+/// which is the stage-walker's responsibility).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class is <em>pure</em>: it has no dependency on <c>IEntityType</c> or
+/// <c>QueryContext</c>. All parity guards (nullable-equality rejection, numeric-cast
+/// rejection, etc.) were applied by <see cref="MongoExpressionTranslator"/> upstream;
+/// the renderer simply emits BSON.
+/// </para>
+/// <para>
+/// <see cref="MongoConstantExpression"/> values are serialized inline using the
+/// <see cref="IProperty"/> carried inside the node, and baked into the returned template.
+/// <see cref="MongoParameterExpression"/> sites are recorded as placeholder sentinels in
+/// the supplied <see cref="PlaceholderTable"/> for per-execution substitution by Task 10.
+/// </para>
+/// </remarks>
+internal sealed class MongoQueryLanguageRenderer
+{
+    /// <summary>
+    /// Renders <paramref name="predicate"/> to a <c>$match</c>-filter body.
+    /// </summary>
+    /// <param name="predicate">
+    /// The root <see cref="MongoExpression"/> to render. Must be a predicate-shaped node
+    /// (i.e. its runtime type must be <see cref="bool"/>).
+    /// </param>
+    /// <param name="placeholders">
+    /// Receives one entry per <see cref="MongoParameterExpression"/> encountered.
+    /// Each entry's corresponding sentinel is embedded in the returned <see cref="BsonValue"/>.
+    /// </param>
+    /// <returns>
+    /// A <see cref="BsonDocument"/> representing the filter body, suitable for use as the
+    /// value of a <c>$match</c> pipeline stage document.
+    /// </returns>
+    /// <exception cref="NativeTranslationNotSupportedException">
+    /// Thrown for any node type not handled by this renderer (defensive; should not happen
+    /// for predicates that passed the translator's acceptance set).
+    /// </exception>
+    public BsonValue Render(MongoExpression predicate, PlaceholderTable placeholders)
+        => RenderNode(predicate, placeholders);
+
+    // ------------------------------------------------------------------
+    // Core dispatch
+    // ------------------------------------------------------------------
+
+    private BsonValue RenderNode(MongoExpression node, PlaceholderTable placeholders)
+        => node switch
+        {
+            MongoBinaryExpression binary => RenderBinary(binary, placeholders),
+            MongoUnaryExpression unary => RenderUnary(unary, placeholders),
+            MongoFieldExpression field => RenderBareField(field, placeholders),
+            _ => throw new NativeTranslationNotSupportedException(
+                $"MongoQueryLanguageRenderer does not support node type '{node.GetType().Name}'.")
+        };
+
+    // ------------------------------------------------------------------
+    // Binary nodes (AndAlso / OrElse / comparisons)
+    // ------------------------------------------------------------------
+
+    private BsonDocument RenderBinary(MongoBinaryExpression binary, PlaceholderTable placeholders)
+    {
+        switch (binary.Operator)
+        {
+            case MongoBinaryOperator.AndAlso:
+            {
+                var left = (BsonDocument)RenderNode(binary.Left, placeholders);
+                var right = (BsonDocument)RenderNode(binary.Right, placeholders);
+                return CombineAnd(left, right);
+            }
+
+            case MongoBinaryOperator.OrElse:
+            {
+                var left = (BsonDocument)RenderNode(binary.Left, placeholders);
+                var right = (BsonDocument)RenderNode(binary.Right, placeholders);
+                return CombineOr(left, right);
+            }
+
+            default:
+                return RenderComparison(binary, placeholders);
+        }
+    }
+
+    private BsonDocument RenderComparison(MongoBinaryExpression binary, PlaceholderTable placeholders)
+    {
+        // MongoExpressionTranslator always places the MongoFieldExpression on the Left
+        // with the operator already mirrored when necessary (see TranslateComparison).
+        if (binary.Left is not MongoFieldExpression field)
+            throw new NativeTranslationNotSupportedException(
+                $"Expected MongoFieldExpression on the left side of a comparison; got '{binary.Left.GetType().Name}'.");
+
+        var elementName = field.ElementName;
+        var value = RenderValue(binary.Right, placeholders);
+
+        var op = binary.Operator switch
+        {
+            MongoBinaryOperator.Equal => null,              // bare { field: value }
+            MongoBinaryOperator.NotEqual => "$ne",
+            MongoBinaryOperator.LessThan => "$lt",
+            MongoBinaryOperator.LessThanOrEqual => "$lte",
+            MongoBinaryOperator.GreaterThan => "$gt",
+            MongoBinaryOperator.GreaterThanOrEqual => "$gte",
+            _ => throw new NativeTranslationNotSupportedException(
+                $"Unsupported comparison operator '{binary.Operator}'.")
+        };
+
+        return op is null
+            ? new BsonDocument(elementName, value)
+            : new BsonDocument(elementName, new BsonDocument(op, value));
+    }
+
+    // ------------------------------------------------------------------
+    // Unary nodes (Not)
+    // ------------------------------------------------------------------
+
+    private BsonDocument RenderUnary(MongoUnaryExpression unary, PlaceholderTable placeholders)
+    {
+        if (unary.Operator != MongoUnaryOperator.Not)
+            throw new NativeTranslationNotSupportedException(
+                $"Unsupported unary operator '{unary.Operator}'.");
+
+        if (unary.Operand is not MongoFieldExpression field)
+            throw new NativeTranslationNotSupportedException(
+                "MongoQueryLanguageRenderer only supports Not over a MongoFieldExpression.");
+
+        // !boolProperty → { field: { $ne: true } }
+        // (Matches driver-LINQ rendering; also matches missing/null-field semantics.)
+        var trueValue = ToBsonValue(field.Property, true);
+        return new BsonDocument(field.ElementName, new BsonDocument("$ne", trueValue));
+    }
+
+    // ------------------------------------------------------------------
+    // Bare boolean field (used as a top-level predicate)
+    // ------------------------------------------------------------------
+
+    private BsonDocument RenderBareField(MongoFieldExpression field, PlaceholderTable placeholders)
+    {
+        // A bare bool property used as a predicate → { field: true }
+        var trueValue = ToBsonValue(field.Property, true);
+        return new BsonDocument(field.ElementName, trueValue);
+    }
+
+    // ------------------------------------------------------------------
+    // Value rendering (constants vs. parameters)
+    // ------------------------------------------------------------------
+
+    internal BsonValue RenderValue(MongoExpression node, PlaceholderTable placeholders)
+    {
+        switch (node)
+        {
+            case MongoConstantExpression constant:
+            {
+                if (constant.ForSerialization is null)
+                    return BsonValue.Create(constant.Value);
+                return ToBsonValue(constant.ForSerialization, constant.Value);
+            }
+
+            case MongoParameterExpression parameter:
+            {
+                if (parameter.ForSerialization is null)
+                    return placeholders.CreatePlaceholder(parameter.Name, serializer: null);
+                var info = BsonSerializerFactory.GetPropertySerializationInfo(parameter.ForSerialization);
+                return placeholders.CreatePlaceholder(parameter.Name, info.Serializer);
+            }
+
+            default:
+                throw new NativeTranslationNotSupportedException(
+                    $"Cannot render value node of type '{node.GetType().Name}'.");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Serialization helper (ported verbatim from the spike MongoPredicateTranslator)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> to a <see cref="BsonValue"/> using the property's
+    /// serializer, coercing the CLR type first so the serializer's hard cast succeeds.
+    /// </summary>
+    private static BsonValue ToBsonValue(IProperty property, object? value)
+    {
+        var info = BsonSerializerFactory.GetPropertySerializationInfo(property);
+        try
+        {
+            // Coerce to the property's CLR type (compile-time path); the factory coerces to the
+            // serializer's ValueType — these differ for value-converted properties, so each call site
+            // passes its own target into the shared helper.
+            value = BsonValueSerializer.Coerce(property.ClrType, value);
+            return BsonValueSerializer.SerializeThroughWriter(info.Serializer, value);
+        }
+        catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException
+                                       or InvalidOperationException)
+        {
+            throw new NativeTranslationNotSupportedException(
+                $"Native predicate translation cannot serialize value '{value}' for property '{property.Name}'.");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // AND / OR combining helpers (ported verbatim from the spike MongoPredicateTranslator)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Combines two filter documents with AND, merging fields into a single document when all top-level
+    /// keys are distinct and non-operator. Falls back to an explicit <c>$and</c> array when keys collide
+    /// and operator sub-documents cannot be merged (e.g. two <c>$gt</c> on the same field), or when
+    /// either document contains multiple elements or an operator key at the top level.
+    /// Nested <c>$and</c> operands are flattened so chained predicates do not nest redundantly.
+    /// Ported verbatim from the spike.
+    /// </summary>
+    private static BsonDocument CombineAnd(BsonDocument left, BsonDocument right)
+    {
+        var clauses = new List<BsonDocument>();
+        AddAndOperand(clauses, left);
+        AddAndOperand(clauses, right);
+
+        var merged = new BsonDocument();
+        foreach (var clause in clauses)
+        {
+            // A clause is mergeable only if it is a single-field document whose key is not an operator.
+            if (clause.ElementCount != 1 || clause.GetElement(0).Name.StartsWith('$'))
+                return new BsonDocument("$and", new BsonArray(clauses));
+
+            var element = clause.GetElement(0);
+            if (!merged.Contains(element.Name))
+            {
+                merged.Add(element);
+                continue;
+            }
+
+            // Same field appears twice (e.g. x > a && x < b). Merge the operator sub-documents when
+            // possible: { x: { $gt: a, $lt: b } }. Fall back to $and on conflict or non-operator values.
+            if (TryMergeOperatorDocs(merged[element.Name], element.Value, out var combined))
+                merged[element.Name] = combined;
+            else
+                return new BsonDocument("$and", new BsonArray(clauses));
+        }
+
+        return merged;
+    }
+
+    private static bool TryMergeOperatorDocs(BsonValue existing, BsonValue addition, out BsonValue combined)
+    {
+        combined = BsonNull.Value;
+        if (existing is not BsonDocument ed || addition is not BsonDocument ad)
+            return false;
+        if (!IsAllOperators(ed) || !IsAllOperators(ad))
+            return false;
+
+        var result = new BsonDocument();
+        result.AddRange(ed);
+        foreach (var op in ad)
+        {
+            if (result.Contains(op.Name))
+                return false; // overlapping operator (e.g. two $gt) cannot merge
+            result.Add(op);
+        }
+
+        combined = result;
+        return true;
+    }
+
+    private static bool IsAllOperators(BsonDocument doc)
+    {
+        if (doc.ElementCount == 0)
+            return false;
+        foreach (var e in doc)
+        {
+            if (!e.Name.StartsWith('$'))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static void AddAndOperand(List<BsonDocument> clauses, BsonDocument doc)
+    {
+        if (doc.ElementCount == 1 && doc.GetElement(0).Name == "$and" && doc[0] is BsonArray array)
+        {
+            foreach (var item in array)
+                clauses.Add((BsonDocument)item);
+        }
+        else
+        {
+            clauses.Add(doc);
+        }
+    }
+
+    /// <summary>
+    /// Combines two filter documents with OR into a flat <c>$or</c> array,
+    /// flattening any nested <c>$or</c> operands to match driver-LINQ rendering.
+    /// Ported verbatim from the spike.
+    /// </summary>
+    private static BsonDocument CombineOr(BsonDocument left, BsonDocument right)
+    {
+        var clauses = new BsonArray();
+        AddOrOperand(clauses, left);
+        AddOrOperand(clauses, right);
+        return new BsonDocument("$or", clauses);
+    }
+
+    private static void AddOrOperand(BsonArray clauses, BsonDocument doc)
+    {
+        if (doc.ElementCount == 1 && doc.GetElement(0).Name == "$or" && doc[0] is BsonArray array)
+        {
+            foreach (var item in array)
+                clauses.Add(item);
+        }
+        else
+        {
+            clauses.Add(doc);
+        }
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoSelectLowerer.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoSelectLowerer.cs
@@ -1,0 +1,114 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Converts the native-translation slots on a <see cref="MongoQueryExpression"/> into
+/// a fully-typed <see cref="MongoPipelineStage"/> list in canonical aggregation pipeline order:
+/// <c>$match → $sort → $skip → $limit → $lookup/$unwind</c>.
+/// </summary>
+/// <remarks>
+/// This lowerer is BSON-free. It produces typed stage IR objects only; BSON rendering is the
+/// responsibility of the downstream pipeline renderer (Task 9). Empty slots are dropped (no
+/// predicate means no <see cref="MongoMatchStage"/>, and so on).
+///
+/// Lookup eligibility is guarded here. If the query contains a lookup shape the native pipeline
+/// cannot handle, a <see cref="NativeTranslationNotSupportedException"/> is thrown. The calling
+/// gate (Task 14) catches this and falls back to the driver-LINQ path.
+/// </remarks>
+internal sealed class MongoSelectLowerer
+{
+    /// <summary>
+    /// Lowers the native-translation slots of <paramref name="select"/> into typed pipeline stages.
+    /// </summary>
+    /// <param name="select">The <see cref="MongoQueryExpression"/> whose slots are lowered.</param>
+    /// <returns>
+    /// An ordered, read-only list of <see cref="MongoPipelineStage"/> values in canonical pipeline
+    /// order. Returns an empty list when no slots are populated.
+    /// </returns>
+    /// <exception cref="NativeTranslationNotSupportedException">
+    /// Thrown when the query contains a join or lookup shape that the native pipeline does not support.
+    /// </exception>
+    public IReadOnlyList<MongoPipelineStage> Lower(MongoQueryExpression select)
+    {
+        var stages = new List<MongoPipelineStage>();
+
+        // 1. $match — filter predicate.
+        if (select.Predicate != null)
+        {
+            stages.Add(new MongoMatchStage(select.Predicate));
+        }
+
+        // 2. $sort — orderings.
+        if (select.Orderings.Count > 0)
+        {
+            stages.Add(new MongoSortStage(select.Orderings));
+        }
+
+        // 3. $skip — offset (pagination start).
+        if (select.Offset != null)
+        {
+            stages.Add(new MongoSkipStage(select.Offset));
+        }
+
+        // 4. $limit — result cap.
+        if (select.Limit != null)
+        {
+            stages.Add(new MongoLimitStage(select.Limit));
+        }
+
+        // 5. $lookup/$unwind — cross-collection includes.
+        AppendLookupStages(select, stages);
+
+        return stages;
+    }
+
+    /// <summary>
+    /// Appends <see cref="MongoLookupStage"/> + <see cref="MongoUnwindStage"/> pairs for each lookup,
+    /// after validating that the native pipeline can handle the lookup shape.
+    /// </summary>
+    private static void AppendLookupStages(MongoQueryExpression select, List<MongoPipelineStage> stages)
+    {
+        var lookups = select.Lookups;
+
+        // Join-coverage guard: if this is a join query and there are fewer lookups than inner
+        // collections, emitting a partial pipeline would silently drop a join and return wrong results.
+        if (select.IsJoinQuery && lookups.Count < select.InnerCollections.Count)
+        {
+            throw new NativeTranslationNotSupportedException(
+                "Native pipeline does not support this join shape (only single-level reference includes).");
+        }
+
+        foreach (var lookup in lookups)
+        {
+            // Per-lookup guard: only single-level reference includes with no sub-pipeline and
+            // no transitive _lookup_ local field are supported.
+            if (!lookup.IsStreamableReference)
+            {
+                throw new NativeTranslationNotSupportedException(
+                    $"Native pipeline does not support lookup for navigation '{lookup.Navigation.Name}' " +
+                    "(only single-level reference includes).");
+            }
+
+            stages.Add(new MongoLookupStage(lookup));
+            stages.Add(new MongoUnwindStage(lookup));
+        }
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoStreamingEntityMaterializerRewriter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/MongoStreamingEntityMaterializerRewriter.cs
@@ -1,0 +1,1322 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Storage;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Serializers;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Rewrites EF's post-injection entity-materializer block for a streaming-eligible entity so that each
+/// native-path row is materialized via a single forward <see cref="IBsonReader"/> pass into typed locals —
+/// instead of building a <see cref="BsonDocument"/> DOM. Handles flat (scalar / mapped-array) entities and
+/// entities with single (reference) owned sub-documents, recursively (an owned type may itself own further
+/// reference sub-documents). Owned <em>collections</em> and cross-collection / non-owned navigations are
+/// rejected with <see cref="NativeTranslationNotSupportedException"/>.
+///
+/// EF's construction / tracking blocks are reused verbatim, with their <c>ValueBufferTryReadValue</c> reads
+/// redirected to the typed locals and their <see cref="MaterializationContext"/> value-buffer source replaced
+/// by <see cref="ValueBuffer.Empty"/>. EF's <see cref="IncludeExpression"/> structure (and its navigation
+/// fixup) is preserved; only the value source and the owned null-guard inside each block are replaced.
+/// </summary>
+internal sealed class MongoStreamingEntityMaterializerRewriter
+{
+    private readonly IEntityType _rootEntityType;
+    private readonly BsonSerializerFactory _bsonSerializerFactory;
+    private readonly ParameterExpression _row;
+
+    public MongoStreamingEntityMaterializerRewriter(
+        IEntityType rootEntityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        ParameterExpression row)
+    {
+        _rootEntityType = rootEntityType;
+        _bsonSerializerFactory = bsonSerializerFactory;
+        _row = row;
+    }
+
+    private static readonly MethodInfo OpenMethod =
+        typeof(BsonRowReader).GetMethod(nameof(BsonRowReader.Open))!;
+
+    private static readonly MethodInfo ReadStartDocumentMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.ReadStartDocument))!;
+
+    private static readonly MethodInfo ReadEndDocumentMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.ReadEndDocument))!;
+
+    private static readonly MethodInfo ReadBsonTypeMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.ReadBsonType))!;
+
+    private static readonly MethodInfo ReadNameMethod =
+        typeof(IBsonReaderExtensions).GetMethod(
+            nameof(IBsonReaderExtensions.ReadName), [typeof(IBsonReader)])!;
+
+    private static readonly MethodInfo GetCurrentBsonTypeMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.GetCurrentBsonType))!;
+
+    private static readonly MethodInfo ReadNullMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.ReadNull))!;
+
+    private static readonly MethodInfo SkipValueMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.SkipValue))!;
+
+    private static readonly MethodInfo DisposeMethod =
+        typeof(IDisposable).GetMethod(nameof(IDisposable.Dispose))!;
+
+    private static readonly MethodInfo CreateRootMethod =
+        typeof(BsonDeserializationContext).GetMethod(
+            nameof(BsonDeserializationContext.CreateRoot),
+            [typeof(IBsonReader), typeof(Action<BsonDeserializationContext.Builder>)])!;
+
+    private static readonly MethodInfo DeserializeMethod =
+        typeof(IBsonSerializer).GetMethod(
+            nameof(IBsonSerializer.Deserialize),
+            [typeof(BsonDeserializationContext), typeof(BsonDeserializationArgs)])!;
+
+    private static readonly MethodInfo StringEqualsMethod =
+        typeof(string).GetMethod(nameof(string.Equals), [typeof(string), typeof(string)])!;
+
+    private static readonly MethodInfo IsAssignableFromMethodInfo =
+        typeof(IReadOnlyEntityType).GetMethod(
+            nameof(IReadOnlyEntityType.IsAssignableFrom), [typeof(IReadOnlyEntityType)])!;
+
+    private static readonly MethodInfo IncludeReferenceMethodInfo =
+        typeof(MongoStreamingEntityMaterializerRewriter).GetTypeInfo()
+            .GetDeclaredMethod(nameof(IncludeReference))!;
+
+    /// <summary>
+    /// A per-entity-instance materialization plan: the typed locals for its scalar properties, an optional
+    /// "present" flag local (owned sub-documents only), and the plans for its owned reference navigations.
+    /// </summary>
+    private sealed class EntityPlan
+    {
+        public required IEntityType EntityType { get; init; }
+        public required Dictionary<IProperty, ParameterExpression> Locals { get; init; }
+
+        /// <summary>
+        /// A per-required-non-nullable-scalar-property presence flag. Each is initialized to <c>false</c> and
+        /// set <c>true</c> by the fill loop when the property's element is encountered in the document — even
+        /// when that element's value is an explicit BSON <c>null</c> (a present-but-null required scalar is
+        /// PRESENT, and takes <see cref="BuildTypedRead"/>'s <c>default(T)</c> path; only a <em>missing</em>
+        /// element leaves the flag false). After the fill loop, any flag still <c>false</c> means the required
+        /// element was absent and the materializer throws the same <see cref="InvalidOperationException"/> the
+        /// DOM / driver-LINQ binding path (<c>BsonBinding.GetPropertyValue</c>) throws.
+        /// </summary>
+        public required Dictionary<IProperty, ParameterExpression> RequiredPresence { get; init; }
+
+        public ParameterExpression? Present { get; init; }
+        public required List<(INavigationBase Navigation, EntityPlan Child)> OwnedNavigations { get; init; }
+        public required List<CollectionPlan> OwnedCollections { get; init; }
+        public required List<LookupReferencePlan> LookupReferences { get; init; }
+
+        /// <summary>
+        /// The property→local scope this plan's construction block reads from. The root entity and its owned
+        /// sub-document subtree share ONE scope (so owned-type keys resolve to the principal's local via
+        /// <see cref="ConstructionRewriter.ResolveLocal"/>). A lookup-backed non-owned reference target gets
+        /// its OWN fresh scope: it is an independent entity instance, and — for a self-referential / same-typed
+        /// reference (e.g. <c>Employee.Manager</c>) — sharing the root's scope would alias the target's locals
+        /// onto the root's identical <see cref="IProperty"/> keys and corrupt both reads.
+        /// </summary>
+        public required Dictionary<IProperty, ParameterExpression> AllLocals { get; init; }
+    }
+
+    /// <summary>
+    /// A plan for a non-owned single (reference) navigation materialized from a cross-collection
+    /// <c>$lookup</c> + <c>$unwind</c>. Unlike an owned reference (which descends into an embedded element
+    /// mid-parse), the joined sub-document arrives as a ROOT-level element named
+    /// <see cref="LookupExpression.GetLookupAlias"/> (<c>_lookup_&lt;Nav&gt;</c>) — a sibling of the parent's
+    /// own fields after <c>$unwind</c>. The joined entity reads its OWN primary key as a normal field (no
+    /// owner-key resolution) and does its own tracking. The target plan's present flag is false when the
+    /// lookup field is BSON Null (no match), yielding a null navigation.
+    /// </summary>
+    private sealed class LookupReferencePlan
+    {
+        public required INavigation Navigation { get; init; }
+        public required EntityPlan Target { get; init; }
+        public required string ElementName { get; init; }
+    }
+
+    /// <summary>
+    /// A plan for an owned <em>collection</em> navigation: the element materialization plan, a 1-based loop
+    /// <see cref="Counter"/> local that supplies the synthesized ordinal key, and a <see cref="List"/>
+    /// accumulator local of the element CLR type. Element locals are declared once (in the element plan) and
+    /// reassigned on each array iteration.
+    /// </summary>
+    private sealed class CollectionPlan
+    {
+        public required INavigation Navigation { get; init; }
+        public required EntityPlan Element { get; init; }
+        public required ParameterExpression Counter { get; init; }
+        public required ParameterExpression List { get; init; }
+
+        // The rewritten per-element construction expression (element locals + counter -> CLR element), set by
+        // RewriteMaterializer from the CollectionShaperExpression's inner shaper, consumed by BuildFillLoop to
+        // emit `list.Add(<constructed element>)` inside the array loop.
+        public Expression? ElementConstructor { get; set; }
+    }
+
+    private static readonly MethodInfo ReadStartArrayMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.ReadStartArray))!;
+
+    private static readonly MethodInfo ReadEndArrayMethod =
+        typeof(IBsonReader).GetMethod(nameof(IBsonReader.ReadEndArray))!;
+
+    private static readonly MethodInfo IncludeCollectionMethodInfo =
+        typeof(MongoStreamingEntityMaterializerRewriter).GetTypeInfo()
+            .GetDeclaredMethod(nameof(IncludeCollection))!;
+
+    private readonly ParameterExpression _reader = Expression.Variable(typeof(IBsonReader), "__reader");
+    private readonly ParameterExpression _name = Expression.Variable(typeof(string), "__name");
+
+    /// <summary>
+    /// Rewrite the post-injection materializer into a forward-streaming materializer.
+    /// </summary>
+    public BlockExpression Rewrite(Expression injectedBody)
+    {
+        var resultType = injectedBody.Type;
+
+        // Build the per-entity plans (typed locals + owned-navigation plans), recursively. The root entity
+        // and its owned subtree share one property->local scope; each lookup-reference target gets its own.
+        var rootPlan = BuildPlan(_rootEntityType, present: null, new Dictionary<IProperty, ParameterExpression>());
+
+        // Rewrite the materializer tree: the IncludeExpression structure (and EF's navigation fixup) is
+        // preserved; only each block's value source and the owned-block null guard are replaced.
+        var rewrittenBody = RewriteMaterializer(injectedBody, rootPlan);
+
+        // Build the forward-fill loop over the root document, descending into owned sub-documents.
+        var fillLoop = BuildFillLoop(rootPlan);
+
+        // Collect all locals (reader scratch + every entity's property/present locals).
+        var allLocals = new List<ParameterExpression> { _name };
+        var initializers = new List<Expression>();
+        CollectLocals(rootPlan, allLocals, initializers);
+
+        var prelude = new List<Expression>
+        {
+            Expression.Assign(_reader, Expression.Call(OpenMethod, _row)),
+            Expression.Call(_reader, ReadStartDocumentMethod)
+        };
+        prelude.AddRange(initializers);
+        prelude.Add(fillLoop);
+        prelude.Add(Expression.Call(_reader, ReadEndDocumentMethod));
+        prelude.Add(rewrittenBody);
+
+        var tryBody = Expression.Block(resultType, allLocals, prelude);
+
+        var withFinally = Expression.TryFinally(
+            tryBody,
+            Expression.IfThen(
+                Expression.NotEqual(_reader, Expression.Constant(null, typeof(IBsonReader))),
+                Expression.Call(_reader, DisposeMethod)));
+
+        return Expression.Block(
+            resultType,
+            new[] { _reader },
+            withFinally);
+    }
+
+    /// <summary>
+    /// Build a plan for <paramref name="entityType"/>: one typed local per scalar property, a "present" flag
+    /// (for owned sub-documents), and recursively a plan for each single owned reference navigation. Rejects
+    /// owned collections and any non-owned navigation.
+    /// </summary>
+    private EntityPlan BuildPlan(
+        IEntityType entityType,
+        ParameterExpression? present,
+        Dictionary<IProperty, ParameterExpression> allLocals,
+        bool allowLookupReferences = true)
+    {
+        var locals = new Dictionary<IProperty, ParameterExpression>();
+        var requiredPresence = new Dictionary<IProperty, ParameterExpression>();
+        foreach (var property in entityType.GetProperties())
+        {
+            // Owned-type keys (shadow FKs that share the principal's primary key) live only on the owner
+            // document, not the owned sub-document. They get no local of their own and no fill-loop entry;
+            // reads of them are resolved to the principal's local by ConstructionRewriter.ResolveLocal.
+            if (property.IsOwnedTypeKey())
+            {
+                continue;
+            }
+
+            var local = Expression.Variable(property.ClrType, "__p_" + entityType.ShortName() + "_" + property.Name);
+            locals[property] = local;
+            allLocals[property] = local;
+
+            // A required (non-nullable) scalar gets a presence flag so a MISSING element throws (Bug 1),
+            // matching the DOM / driver-LINQ binding path, rather than silently materializing default(T).
+            if (!property.IsNullable)
+            {
+                requiredPresence[property] =
+                    Expression.Variable(typeof(bool), "__present_p_" + entityType.ShortName() + "_" + property.Name);
+            }
+        }
+
+        var ownedNavigations = new List<(INavigationBase, EntityPlan)>();
+        var ownedCollections = new List<CollectionPlan>();
+        var lookupReferences = new List<LookupReferencePlan>();
+        foreach (var navigation in entityType.GetNavigations())
+        {
+            var target = navigation.TargetEntityType;
+
+            if (!target.IsOwned())
+            {
+                // Non-owned reference navigations are planned ONLY one level deep, off the root entity. A
+                // lookup-backed reference target (or an owned child) does NOT plan its own further non-owned
+                // references: this slice supports a single-level reference Include, and — critically —
+                // bidirectional / self-referential non-owned relationships (Order↔Customer, Staff→Manager)
+                // would otherwise recurse forever here. When a deeper non-owned reference is actually included
+                // (ThenInclude), no LookupReferencePlan exists for it and RewriteLookupReferenceNavigation
+                // rejects the nested IncludeExpression, falling back to the DOM path.
+                if (!allowLookupReferences)
+                {
+                    continue;
+                }
+
+                // A non-owned navigation is only streamable as a single (reference) navigation backed by a
+                // cross-collection $lookup + $unwind. The joined sub-document arrives as a root-level
+                // `_lookup_<Nav>` element (a sibling of this entity's own fields). Its own primary key is a
+                // normal field of the joined document, so the target plan reads it without owner-key
+                // resolution. A non-owned collection is not yet streamable.
+                if (navigation.IsCollection)
+                {
+                    throw new NativeTranslationNotSupportedException(
+                        $"Streaming materialization of navigation '{entityType.DisplayName()}.{navigation.Name}' is not supported "
+                        + "(non-owned collection navigation).");
+                }
+
+                // The joined target is an independent entity instance: it gets its OWN locals scope (a fresh
+                // dictionary), NOT the root's — critical for self-referential references (Employee.Manager)
+                // where target and root share IProperty keys. Non-owned reference recursion is disabled
+                // (single-level only).
+                var lookupPresent = Expression.Variable(typeof(bool), "__present_lookup_" + target.ShortName());
+                var lookupTarget = BuildPlan(
+                    target, lookupPresent, new Dictionary<IProperty, ParameterExpression>(),
+                    allowLookupReferences: false);
+                lookupReferences.Add(new LookupReferencePlan
+                {
+                    Navigation = navigation,
+                    Target = lookupTarget,
+                    ElementName = LookupExpression.GetLookupAlias(navigation)
+                });
+                continue;
+            }
+
+            if (navigation.IsCollection)
+            {
+                // Owned collection: the element plan's locals are reused across iterations (no present flag —
+                // presence is per-array-element, governed by the loop). A 1-based counter local supplies the
+                // synthesized ordinal key; a List<TElement> accumulator collects the materialized elements.
+                var element = BuildPlan(target, present: null, allLocals, allowLookupReferences);
+                var counter = Expression.Variable(typeof(int), "__counter_" + target.ShortName());
+                var listType = typeof(List<>).MakeGenericType(target.ClrType);
+                var list = Expression.Variable(listType, "__list_" + target.ShortName());
+                ownedCollections.Add(new CollectionPlan
+                {
+                    Navigation = navigation,
+                    Element = element,
+                    Counter = counter,
+                    List = list
+                });
+                continue;
+            }
+
+            var childPresent = Expression.Variable(typeof(bool), "__present_" + target.ShortName());
+            var child = BuildPlan(target, childPresent, allLocals, allowLookupReferences);
+            ownedNavigations.Add((navigation, child));
+        }
+
+        return new EntityPlan
+        {
+            EntityType = entityType,
+            Locals = locals,
+            RequiredPresence = requiredPresence,
+            Present = present,
+            OwnedNavigations = ownedNavigations,
+            OwnedCollections = ownedCollections,
+            LookupReferences = lookupReferences,
+            AllLocals = allLocals
+        };
+    }
+
+    private void CollectLocals(EntityPlan plan, List<ParameterExpression> locals, List<Expression> initializers)
+    {
+        if (plan.Present != null)
+        {
+            locals.Add(plan.Present);
+            initializers.Add(Expression.Assign(plan.Present, Expression.Constant(false)));
+        }
+
+        foreach (var local in plan.Locals.Values)
+        {
+            locals.Add(local);
+            initializers.Add(Expression.Assign(local, Expression.Default(local.Type)));
+        }
+
+        // Required-scalar presence flags: declared + reset to false per row (the same locals are reused
+        // across owned-collection iterations, so they must be re-initialized each pass — done in the fill
+        // loop's caller for collections; here for the document-level scope).
+        foreach (var present in plan.RequiredPresence.Values)
+        {
+            locals.Add(present);
+            initializers.Add(Expression.Assign(present, Expression.Constant(false)));
+        }
+
+        foreach (var (_, child) in plan.OwnedNavigations)
+        {
+            CollectLocals(child, locals, initializers);
+        }
+
+        foreach (var lookup in plan.LookupReferences)
+        {
+            // The lookup target's present flag + scalar locals (its PK is a normal field — collected here).
+            CollectLocals(lookup.Target, locals, initializers);
+        }
+
+        foreach (var collection in plan.OwnedCollections)
+        {
+            locals.Add(collection.Counter);
+            initializers.Add(Expression.Assign(collection.Counter, Expression.Constant(0)));
+            locals.Add(collection.List);
+            initializers.Add(Expression.Assign(collection.List, Expression.Default(collection.List.Type)));
+
+            // Element locals are shared across iterations; declare + default-init them once here.
+            CollectLocals(collection.Element, locals, initializers);
+        }
+    }
+
+    /// <summary>
+    /// Build the forward name-dispatch fill loop for a single document level (the reader is already
+    /// positioned after <c>ReadStartDocument</c>). Scalar elements fill their typed locals; an owned
+    /// navigation element descends into the sub-document (recursively) under a present flag + null guard.
+    /// </summary>
+    private Expression BuildFillLoop(EntityPlan plan)
+    {
+        var ifChain = (Expression)Expression.Call(_reader, SkipValueMethod);
+
+        foreach (var property in plan.EntityType.GetProperties())
+        {
+            // Owned-type keys have no local and are not stored in the sub-document; skip them in the loop.
+            if (!plan.Locals.TryGetValue(property, out var local))
+            {
+                continue;
+            }
+
+            // Mark a required scalar PRESENT before reading its value. Setting the flag here (when the
+            // element is encountered) — not inside BuildTypedRead — means a present-but-null required scalar
+            // counts as present: it takes BuildTypedRead's default(T) path (Bug 2) and does NOT trip the
+            // post-loop missing-required throw (Bug 1). Only a genuinely absent element leaves the flag false.
+            Expression read = BuildTypedRead(property, local);
+            if (plan.RequiredPresence.TryGetValue(property, out var presenceFlag))
+            {
+                read = Expression.Block(
+                    Expression.Assign(presenceFlag, Expression.Constant(true)),
+                    read);
+            }
+
+            ifChain = Expression.IfThenElse(
+                Expression.Call(StringEqualsMethod, _name, Expression.Constant(property.GetElementName(), typeof(string))),
+                read,
+                ifChain);
+        }
+
+        foreach (var (navigation, child) in plan.OwnedNavigations)
+        {
+            var elementName = navigation.TargetEntityType.GetContainingElementName()
+                              ?? throw new NativeTranslationNotSupportedException(
+                                  $"Owned navigation '{navigation.DeclaringEntityType.DisplayName()}.{navigation.Name}' has no element name.");
+
+            // If the owned element is BSON Null the sub-document is absent: ReadNull + present=false.
+            // Otherwise: present=true, descend (ReadStartDocument / sub-fill-loop / ReadEndDocument).
+            var descend = Expression.IfThenElse(
+                Expression.Equal(
+                    Expression.Call(_reader, GetCurrentBsonTypeMethod),
+                    Expression.Constant(BsonType.Null, typeof(BsonType))),
+                Expression.Block(
+                    Expression.Call(_reader, ReadNullMethod),
+                    Expression.Assign(child.Present!, Expression.Constant(false))),
+                Expression.Block(
+                    Expression.Assign(child.Present!, Expression.Constant(true)),
+                    Expression.Call(_reader, ReadStartDocumentMethod),
+                    BuildFillLoop(child),
+                    Expression.Call(_reader, ReadEndDocumentMethod)));
+
+            ifChain = Expression.IfThenElse(
+                Expression.Call(StringEqualsMethod, _name, Expression.Constant(elementName, typeof(string))),
+                descend,
+                ifChain);
+        }
+
+        foreach (var lookup in plan.LookupReferences)
+        {
+            // The joined sub-document is a root-level `_lookup_<Nav>` element (post-$unwind sibling of this
+            // entity's own fields). Same null-guarded descent as an owned reference, but the element name is
+            // the lookup alias rather than an embedded containing-element name. BSON Null (no $lookup match,
+            // preserved by preserveNullAndEmptyArrays) -> present=false -> null navigation.
+            var descend = Expression.IfThenElse(
+                Expression.Equal(
+                    Expression.Call(_reader, GetCurrentBsonTypeMethod),
+                    Expression.Constant(BsonType.Null, typeof(BsonType))),
+                Expression.Block(
+                    Expression.Call(_reader, ReadNullMethod),
+                    Expression.Assign(lookup.Target.Present!, Expression.Constant(false))),
+                Expression.Block(
+                    Expression.Assign(lookup.Target.Present!, Expression.Constant(true)),
+                    Expression.Call(_reader, ReadStartDocumentMethod),
+                    BuildFillLoop(lookup.Target),
+                    Expression.Call(_reader, ReadEndDocumentMethod)));
+
+            ifChain = Expression.IfThenElse(
+                Expression.Call(StringEqualsMethod, _name, Expression.Constant(lookup.ElementName, typeof(string))),
+                descend,
+                ifChain);
+        }
+
+        foreach (var collection in plan.OwnedCollections)
+        {
+            var elementName = collection.Navigation.TargetEntityType.GetContainingElementName()
+                              ?? throw new NativeTranslationNotSupportedException(
+                                  $"Owned collection '{collection.Navigation.DeclaringEntityType.DisplayName()}.{collection.Navigation.Name}' has no element name.");
+
+            ifChain = Expression.IfThenElse(
+                Expression.Call(StringEqualsMethod, _name, Expression.Constant(elementName, typeof(string))),
+                BuildCollectionLoop(collection),
+                ifChain);
+        }
+
+        var breakTarget = Expression.Label("__fillDone_" + plan.EntityType.ShortName());
+        var loop = Expression.Loop(
+            Expression.IfThenElse(
+                Expression.NotEqual(
+                    Expression.Call(_reader, ReadBsonTypeMethod),
+                    Expression.Constant(BsonType.EndOfDocument, typeof(BsonType))),
+                Expression.Block(
+                    Expression.Assign(_name, Expression.Call(ReadNameMethod, _reader)),
+                    ifChain),
+                Expression.Break(breakTarget)),
+            breakTarget);
+
+        // No required-scalar presence to enforce: the loop is the whole fill.
+        if (plan.RequiredPresence.Count == 0)
+        {
+            return loop;
+        }
+
+        // Reset every required-scalar presence flag to false BEFORE this fill pass, then enforce them AFTER.
+        // The reset matters for owned-collection element plans, whose locals/flags are reused across array
+        // iterations: a required scalar present in element N but absent in element N+1 must still throw for
+        // N+1. (For the root/owned-reference once-only cases the reset is redundant with CollectLocals but
+        // harmless.) Each flag still false after the loop ⇒ the required element was MISSING ⇒ throw the same
+        // InvalidOperationException the DOM / driver-LINQ binding path throws (BsonBinding.GetPropertyValue).
+        var body = new List<Expression>();
+        foreach (var (_, presenceFlag) in plan.RequiredPresence)
+        {
+            body.Add(Expression.Assign(presenceFlag, Expression.Constant(false)));
+        }
+
+        body.Add(loop);
+
+        foreach (var (property, presenceFlag) in plan.RequiredPresence)
+        {
+            body.Add(
+                Expression.IfThen(
+                    Expression.Not(presenceFlag),
+                    Expression.Throw(
+                        Expression.New(
+                            InvalidOperationExceptionCtor,
+                            Expression.Constant(
+                                $"Document element is missing for required non-nullable property '{property.Name}'.")))));
+        }
+
+        return Expression.Block(body);
+    }
+
+    /// <summary>
+    /// Build the array loop for an owned collection. The reader is positioned at the array value (after the
+    /// element name). If the value is BSON Null the collection is left empty (matching the DOM
+    /// <c>bsonArray == null ? null</c> semantics — IncludeCollection still creates an empty CLR collection).
+    /// Otherwise each array element is read into the element plan's locals (reassigned per iteration), the
+    /// 1-based <c>counter</c> supplies the synthesized ordinal key, and the constructed element is appended.
+    /// </summary>
+    private Expression BuildCollectionLoop(CollectionPlan collection)
+    {
+        var listType = collection.List.Type;
+        var addMethod = listType.GetMethod(nameof(List<object>.Add))!;
+        var elementConstructor = collection.ElementConstructor
+                                 ?? throw new NativeTranslationNotSupportedException(
+                                     $"Owned collection '{collection.Navigation.Name}' element construction was not prepared.");
+
+        var elementBreak = Expression.Label("__elemDone_" + collection.Element.EntityType.ShortName());
+
+        var arrayBody = Expression.Block(
+            Expression.Assign(collection.Counter, Expression.Constant(0)),
+            Expression.Assign(collection.List, Expression.New(listType)),
+            Expression.Call(_reader, ReadStartArrayMethod),
+            Expression.Loop(
+                Expression.IfThenElse(
+                    Expression.NotEqual(
+                        Expression.Call(_reader, ReadBsonTypeMethod),
+                        Expression.Constant(BsonType.EndOfDocument, typeof(BsonType))),
+                    Expression.Block(
+                        Expression.Call(_reader, ReadStartDocumentMethod),
+                        BuildFillLoop(collection.Element),
+                        Expression.Call(_reader, ReadEndDocumentMethod),
+                        // The element's synthesized ordinal key resolves to `counter + 1` (1-based, matching
+                        // the DOM path's `ordinal + 1`); construct, append, then advance the 0-based counter.
+                        Expression.Call(collection.List, addMethod, elementConstructor),
+                        Expression.AddAssign(collection.Counter, Expression.Constant(1))),
+                    Expression.Break(elementBreak)),
+                elementBreak),
+            Expression.Call(_reader, ReadEndArrayMethod));
+
+        // A BSON Null array value: consume the null and leave the list null (IncludeCollection's
+        // GetOrCreate still produces an empty CLR collection on the entity).
+        return Expression.IfThenElse(
+            Expression.Equal(
+                Expression.Call(_reader, GetCurrentBsonTypeMethod),
+                Expression.Constant(BsonType.Null, typeof(BsonType))),
+            Expression.Call(_reader, ReadNullMethod),
+            arrayBody);
+    }
+
+    /// <summary>
+    /// Rewrite the materializer expression, preserving any <see cref="IncludeExpression"/> structure.
+    /// For a plain entity block the value source is redirected to <paramref name="plan"/>'s locals; for an
+    /// <see cref="IncludeExpression"/> the entity block is rewritten with the parent plan and each owned
+    /// navigation block is rewritten with the matching child plan, its <c>bsonDocN == null</c> guard
+    /// replaced by <c>!present</c>.
+    /// </summary>
+    private Expression RewriteMaterializer(Expression body, EntityPlan plan, CollectionPlan? collection = null)
+    {
+        if (body is IncludeExpression include)
+        {
+            // Reduce the IncludeExpression ourselves (it is not a reducible node). EF's binding remover
+            // would normally turn it into a fixup call woven through a BsonDocument; on the streaming path
+            // there is no BsonDocument, so we replicate the reference-include fixup directly, splicing it
+            // into the (recursively rewritten) entity materializer block before its trailing instance.
+            if (include.Navigation is not INavigation navigation)
+            {
+                throw new NativeTranslationNotSupportedException(
+                    $"Streaming materialization of navigation '{include.Navigation.Name}' is not supported.");
+            }
+
+            if (navigation.IsCollection)
+            {
+                var entityBlockForCollection = (BlockExpression)RewriteMaterializer(include.EntityExpression, plan, collection);
+                var collectionPlan = FindCollectionPlan(plan, navigation);
+
+                // Locate the CollectionShaperExpression carried by the navigation expression and build the
+                // per-element construction (stored on the plan for the array loop to emit). What remains is a
+                // collection-include fixup, spliced into the parent block, fed the materialized List<TElement>.
+                BuildCollectionElementConstructor(include.NavigationExpression, collectionPlan);
+
+                return SpliceCollectionInclude(entityBlockForCollection, navigation, collectionPlan.List, include.SetLoaded);
+            }
+
+            var entityBlock = (BlockExpression)RewriteMaterializer(include.EntityExpression, plan, collection);
+
+            // A non-owned single reference is materialized from the cross-collection $lookup result field
+            // (`_lookup_<Nav>`). It uses the SAME generic IncludeExpression / reference-fixup shape as an owned
+            // reference (navigation-kind-agnostic; inverse is null for .WithMany()), so the fixup is spliced in
+            // via SpliceReferenceInclude exactly as for owned. The difference is purely how the joined entity
+            // is materialized: from a root-level lookup field, reading its own PK as a normal field.
+            if (!navigation.TargetEntityType.IsOwned())
+            {
+                var lookupPlan = FindLookupReferencePlan(plan, navigation);
+                var lookupNavExpression =
+                    RewriteLookupReferenceNavigation(include.NavigationExpression, navigation, lookupPlan);
+
+                return SpliceReferenceInclude(entityBlock, navigation, lookupNavExpression, include.SetLoaded);
+            }
+
+            var child = FindChildPlan(plan, navigation);
+            var navExpression = RewriteOwnedNavigation(include.NavigationExpression, navigation, child);
+
+            return SpliceReferenceInclude(entityBlock, navigation, navExpression, include.SetLoaded);
+        }
+
+        // Plain entity block: { bsonDocN; bsonDocN = projection as BsonDocument; bsonDocN == null ? null : <block> }
+        // The root row is always present, so drop the bsonDocN local + null guard and use the materializer
+        // block directly, redirecting its value source to this plan's locals. When building a collection
+        // element, `collection` carries the loop counter so the synthesized ordinal key resolves to counter+1.
+        var materializerBlock = ExtractMaterializerBlock(body, plan.EntityType);
+        return new ConstructionRewriter(plan.AllLocals, collection).Visit(materializerBlock);
+    }
+
+    /// <summary>
+    /// Splice an owned reference-navigation fixup into a rewritten entity materializer block, mirroring EF's
+    /// <c>IncludeReference</c> path. The block's trailing instance expression is preserved; the fixup call is
+    /// inserted just before it, using the block's own <c>entry</c> / <c>entityType</c> / <c>instance</c> locals.
+    /// </summary>
+    private BlockExpression SpliceReferenceInclude(
+        BlockExpression entityBlock,
+        INavigation navigation,
+        Expression navigationExpression,
+        bool setLoaded)
+    {
+        var includingClrType = navigation.DeclaringEntityType.ClrType;
+        var relatedEntityClrType = navigation.TargetEntityType.ClrType;
+
+        var instanceVariable = entityBlock.Variables.Single(v => v.Type == includingClrType);
+        var concreteEntityTypeVariable = entityBlock.Variables.Single(v => v.Type == typeof(IEntityType));
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var entryVariable = entityBlock.Variables.SingleOrDefault(v => v.Type == typeof(InternalEntityEntry));
+        Expression entityEntryExpression =
+            entryVariable ?? (Expression)Expression.Constant(null, typeof(InternalEntityEntry));
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        var inverseNavigation = navigation.Inverse;
+        var fixup = GenerateReferenceFixup(includingClrType, relatedEntityClrType, navigation, inverseNavigation);
+
+        var includeCall = Expression.IfThen(
+            Expression.Call(
+                Expression.Constant(navigation.DeclaringEntityType, typeof(IReadOnlyEntityType)),
+                IsAssignableFromMethodInfo,
+                Expression.Convert(concreteEntityTypeVariable, typeof(IReadOnlyEntityType))),
+            Expression.Call(
+                IncludeReferenceMethodInfo.MakeGenericMethod(includingClrType, relatedEntityClrType),
+                entityEntryExpression,
+                instanceVariable,
+                concreteEntityTypeVariable,
+                navigationExpression,
+                Expression.Constant(navigation),
+                Expression.Constant(inverseNavigation, typeof(INavigation)),
+                Expression.Constant(fixup),
+                Expression.Constant(setLoaded)));
+
+        // Insert the include call just before the block's trailing instance expression.
+        var expressions = new List<Expression>(entityBlock.Expressions);
+        var trailing = expressions[^1];
+        expressions[^1] = includeCall;
+        expressions.Add(trailing);
+
+        return entityBlock.Update(entityBlock.Variables, expressions);
+    }
+
+    /// <summary>
+    /// Splice an owned collection-navigation fixup into a rewritten entity materializer block, mirroring EF's
+    /// <c>IncludeCollection</c> path. <paramref name="collectionExpression"/> is the materialized
+    /// <c>List&lt;TElement&gt;</c> local filled by the array loop; <see cref="IncludeCollection"/> wires each
+    /// element onto the principal collection navigation (and, when tracking, marks it loaded).
+    /// </summary>
+    private BlockExpression SpliceCollectionInclude(
+        BlockExpression entityBlock,
+        INavigation navigation,
+        Expression collectionExpression,
+        bool setLoaded)
+    {
+        var includingClrType = navigation.DeclaringEntityType.ClrType;
+        var relatedEntityClrType = navigation.TargetEntityType.ClrType;
+
+        var instanceVariable = entityBlock.Variables.Single(v => v.Type == includingClrType);
+        var concreteEntityTypeVariable = entityBlock.Variables.Single(v => v.Type == typeof(IEntityType));
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var entryVariable = entityBlock.Variables.SingleOrDefault(v => v.Type == typeof(InternalEntityEntry));
+        Expression entityEntryExpression =
+            entryVariable ?? (Expression)Expression.Constant(null, typeof(InternalEntityEntry));
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        var inverseNavigation = navigation.Inverse;
+        var fixup = GenerateCollectionFixup(includingClrType, relatedEntityClrType, navigation, inverseNavigation);
+
+        // IncludeCollection<TIncluding,TIncluded> expects IEnumerable<TIncluded>; List<TElement> qualifies.
+        var includeCall = Expression.IfThen(
+            Expression.Call(
+                Expression.Constant(navigation.DeclaringEntityType, typeof(IReadOnlyEntityType)),
+                IsAssignableFromMethodInfo,
+                Expression.Convert(concreteEntityTypeVariable, typeof(IReadOnlyEntityType))),
+            Expression.Call(
+                IncludeCollectionMethodInfo.MakeGenericMethod(includingClrType, relatedEntityClrType),
+                entityEntryExpression,
+                instanceVariable,
+                concreteEntityTypeVariable,
+                collectionExpression,
+                Expression.Constant(navigation),
+                Expression.Constant(inverseNavigation, typeof(INavigation)),
+                Expression.Constant(fixup),
+                Expression.Constant(setLoaded)));
+
+        var expressions = new List<Expression>(entityBlock.Expressions);
+        var trailing = expressions[^1];
+        expressions[^1] = includeCall;
+        expressions.Add(trailing);
+
+        return entityBlock.Update(entityBlock.Variables, expressions);
+    }
+
+    /// <summary>
+    /// Locate the <see cref="CollectionShaperExpression"/> inside an owned-collection navigation expression and
+    /// build the per-element construction expression (element locals + 1-based ordinal counter -> CLR element),
+    /// storing it on <paramref name="collectionPlan"/> for the array loop to emit as <c>list.Add(...)</c>.
+    /// </summary>
+    private void BuildCollectionElementConstructor(Expression navExpression, CollectionPlan collectionPlan)
+    {
+        var shaper = FindCollectionShaper(navExpression)
+                     ?? throw new NativeTranslationNotSupportedException(
+                         $"Unexpected owned-collection materializer shape for '{collectionPlan.Element.EntityType.DisplayName()}'.");
+
+        // The inner shaper is the per-element StructuralType materializer. It may itself be an
+        // IncludeExpression (the element owns further references/collections) — RewriteMaterializer handles
+        // that recursively, redirecting reads to the element plan's locals. The collection context is threaded
+        // through so the element's synthesized ordinal key resolves to `counter + 1`.
+        collectionPlan.ElementConstructor =
+            RewriteMaterializer(shaper.InnerShaper, collectionPlan.Element, collectionPlan);
+    }
+
+    private static CollectionShaperExpression? FindCollectionShaper(Expression expression)
+    {
+        switch (expression)
+        {
+            case CollectionShaperExpression shaper:
+                return shaper;
+            case ConditionalExpression { IfFalse: { } ifFalse } conditional:
+                return FindCollectionShaper(ifFalse) ?? FindCollectionShaper(conditional.IfTrue);
+            case BlockExpression block:
+                for (var i = block.Expressions.Count - 1; i >= 0; i--)
+                {
+                    if (FindCollectionShaper(block.Expressions[i]) is { } found)
+                    {
+                        return found;
+                    }
+                }
+
+                return null;
+            case UnaryExpression unary:
+                return FindCollectionShaper(unary.Operand);
+            default:
+                return null;
+        }
+    }
+
+    private static CollectionPlan FindCollectionPlan(EntityPlan parent, INavigationBase navigation)
+    {
+        foreach (var collection in parent.OwnedCollections)
+        {
+            if (collection.Navigation == navigation || collection.Navigation.Name == navigation.Name)
+            {
+                return collection;
+            }
+        }
+
+        throw new NativeTranslationNotSupportedException(
+            $"No streaming plan for owned collection '{navigation.DeclaringEntityType.DisplayName()}.{navigation.Name}'.");
+    }
+
+    /// <summary>
+    /// Collection-include fixup, mirroring EF's binding remover <c>IncludeCollection</c>: adds each
+    /// materialized related entity onto the principal's collection navigation (and sets the loaded flag).
+    /// </summary>
+    private static void IncludeCollection<TIncludingEntity, TIncludedEntity>(
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        InternalEntityEntry? entry,
+#pragma warning restore EF1001 // Internal EF Core API usage.
+        object? entity,
+        IEntityType entityType,
+        IEnumerable<TIncludedEntity>? relatedEntities,
+        INavigation navigation,
+        INavigation? inverseNavigation,
+        Action<TIncludingEntity, TIncludedEntity> fixup,
+        bool setLoaded)
+    {
+        if (entity == null
+            || !navigation.DeclaringEntityType.IsAssignableFrom(entityType))
+        {
+            return;
+        }
+
+        if (entry == null)
+        {
+            var includingEntity = (TIncludingEntity)entity;
+            navigation.SetIsLoadedWhenNoTracking(includingEntity);
+
+            if (relatedEntities != null)
+            {
+                foreach (var relatedEntity in relatedEntities)
+                {
+                    fixup(includingEntity, relatedEntity);
+                    inverseNavigation?.SetIsLoadedWhenNoTracking(relatedEntity!);
+                }
+            }
+        }
+        else
+        {
+            if (setLoaded)
+            {
+#pragma warning disable EF1001 // Internal EF Core API usage.
+                entry.SetIsLoaded(navigation);
+#pragma warning restore EF1001 // Internal EF Core API usage.
+            }
+
+            if (relatedEntities != null)
+            {
+                using var enumerator = relatedEntities.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                }
+            }
+        }
+
+        // Ensure empty collections still initialize a new CLR object for them.
+        if (relatedEntities != null && !navigation.IsShadowProperty())
+        {
+            navigation.GetCollectionAccessor()!.GetOrCreate(entity, forMaterialization: true);
+        }
+    }
+
+    private static Delegate GenerateCollectionFixup(
+        Type entityType,
+        Type relatedEntityType,
+        INavigation navigation,
+        INavigation? inverseNavigation)
+    {
+        var entityParameter = Expression.Parameter(entityType);
+        var relatedEntityParameter = Expression.Parameter(relatedEntityType);
+        var expressions = new List<Expression>
+        {
+            AssignCollectionNavigation(entityParameter, relatedEntityParameter, navigation)
+        };
+
+        if (inverseNavigation != null)
+        {
+            expressions.Add(
+                inverseNavigation.IsCollection
+                    ? AssignCollectionNavigation(relatedEntityParameter, entityParameter, inverseNavigation)
+                    : AssignReferenceNavigation(relatedEntityParameter, entityParameter, inverseNavigation));
+        }
+
+        return Expression.Lambda(
+                Expression.Block(typeof(void), expressions), entityParameter, relatedEntityParameter)
+            .Compile();
+    }
+
+    private static Expression AssignCollectionNavigation(
+        ParameterExpression entity,
+        ParameterExpression relatedEntity,
+        INavigation navigation)
+        => Expression.Call(
+            Expression.Constant(navigation.GetCollectionAccessor()),
+            CollectionAccessorAddMethodInfo,
+            entity,
+            relatedEntity,
+            Expression.Constant(true));
+
+    private static readonly MethodInfo CollectionAccessorAddMethodInfo =
+        typeof(IClrCollectionAccessor).GetTypeInfo().GetDeclaredMethod(nameof(IClrCollectionAccessor.Add))!;
+
+    /// <summary>
+    /// Rewrite an owned reference navigation's expression. The owned-entity block has the shape
+    /// <c>{ bsonDocN; bsonDocN = projection as BsonDocument; return bsonDocN == null ? null : &lt;block&gt;; }</c>;
+    /// when the owned type itself owns further references the expression is an <see cref="IncludeExpression"/>
+    /// wrapping that block. The materializer block's value source is redirected to the child plan's locals,
+    /// any nested owned-reference fixup is spliced in, and the <c>bsonDocN == null</c> presence test is
+    /// replaced with <c>!present</c> so an absent owned sub-document yields the null navigation.
+    /// </summary>
+    private Expression RewriteOwnedNavigation(Expression navExpression, INavigation navigation, EntityPlan child)
+    {
+        // Locate the owned-entity block carrying the `bsonDocN == null ? null : <block>` guard. When the
+        // owned type has its own owned references the navigation is an IncludeExpression whose EntityExpression
+        // is that block; otherwise the navigation expression is the block directly.
+        var entityExpression = navExpression is IncludeExpression nestedInclude
+            ? nestedInclude.EntityExpression
+            : navExpression;
+
+        if (entityExpression is not BlockExpression block
+            || block.Expressions[^1] is not ConditionalExpression { IfFalse: BlockExpression materializerBlock } conditional)
+        {
+            throw new NativeTranslationNotSupportedException(
+                $"Unexpected owned-navigation materializer shape for '{child.EntityType.DisplayName()}'.");
+        }
+
+        // Rewrite the owned materializer block's value source to the child's locals (the owned subtree
+        // shares the root's scope, so owned-type keys still resolve to the principal's local).
+        var rewrittenBlock = (BlockExpression)new ConstructionRewriter(child.AllLocals).Visit(materializerBlock);
+
+        // Splice in any nested owned-reference fixup (recursively rewriting the nested navigation).
+        if (navExpression is IncludeExpression include)
+        {
+            if (include.Navigation is not INavigation nestedNavigation || nestedNavigation.IsCollection)
+            {
+                throw new NativeTranslationNotSupportedException(
+                    $"Streaming materialization of navigation '{include.Navigation.Name}' is not supported "
+                    + "(only single owned reference sub-documents are supported).");
+            }
+
+            var nestedChild = FindChildPlan(child, nestedNavigation);
+            var nestedNavExpression = RewriteOwnedNavigation(include.NavigationExpression, nestedNavigation, nestedChild);
+            rewrittenBlock = SpliceReferenceInclude(rewrittenBlock, nestedNavigation, nestedNavExpression, include.SetLoaded);
+        }
+
+        // Replace the whole `{ bsonDocN; bsonDocN = ... as BsonDocument; bsonDocN == null ? null : <block> }`
+        // with `!present ? <absent> : <rewrittenBlock>`. The outer block's bsonDocN local + assignment are
+        // dropped entirely: their RHS is an unreduced EntityProjectionExpression (bsonDoc["Address"]) that has
+        // no streaming equivalent — presence is tracked by the `present` flag instead.
+        //
+        // For a REQUIRED owned reference an absent sub-document is an error, exactly as the DOM path's
+        // required-field guard throws (BsonBinding.GetBsonDocument): reproduce that throw rather than
+        // yielding null, so required-navigation semantics match the DOM path.
+        var absent = navigation.ForeignKey.IsRequiredDependent
+            ? (Expression)Expression.Block(
+                conditional.Type,
+                Expression.Throw(
+                    Expression.New(
+                        InvalidOperationExceptionCtor,
+                        Expression.Constant(
+                            $"Field '{navigation.TargetEntityType.GetContainingElementName()}' required but not present "
+                            + $"in BsonDocument for a '{navigation.DeclaringEntityType.DisplayName()}'."))),
+                Expression.Default(conditional.Type))
+            : Expression.Constant(null, conditional.Type);
+
+        return Expression.Condition(
+            Expression.Not(child.Present!),
+            absent,
+            Expression.Convert(rewrittenBlock, conditional.Type));
+    }
+
+    /// <summary>
+    /// Rewrite a non-owned single (reference) navigation's expression. The joined entity arrives from the
+    /// root-level <c>_lookup_&lt;Nav&gt;</c> field (a sibling element of the parent, post-<c>$unwind</c>), so it
+    /// is materialized from the target plan's own locals — its primary key read normally as a field of the
+    /// joined document (NO owner-key resolution; the joined entity does its own <c>TryGetEntry</c> /
+    /// <c>StartTracking</c>). The block has the same EF shape as an owned reference
+    /// (<c>{ bsonDocN; bsonDocN = projection as BsonDocument; bsonDocN == null ? null : &lt;block&gt; }</c>),
+    /// so the materializer block is extracted the same way; the <c>bsonDocN == null</c> guard is replaced by
+    /// <c>!present</c> (present=false when the lookup field is BSON Null — no match — yielding a null
+    /// navigation). Nested includes (ThenInclude) are not yet streamable.
+    /// </summary>
+    private Expression RewriteLookupReferenceNavigation(
+        Expression navExpression,
+        INavigation navigation,
+        LookupReferencePlan lookup)
+    {
+        // A nested include (ThenInclude off this reference) wraps the joined block in another
+        // IncludeExpression — not yet streamable.
+        if (navExpression is IncludeExpression)
+        {
+            throw new NativeTranslationNotSupportedException(
+                $"Streaming materialization of nested include on navigation "
+                + $"'{navigation.DeclaringEntityType.DisplayName()}.{navigation.Name}' is not supported.");
+        }
+
+        if (navExpression is not BlockExpression block
+            || block.Expressions[^1] is not ConditionalExpression { IfFalse: BlockExpression materializerBlock } conditional)
+        {
+            throw new NativeTranslationNotSupportedException(
+                $"Unexpected lookup-reference materializer shape for '{lookup.Target.EntityType.DisplayName()}'.");
+        }
+
+        // Redirect the joined block's value source to the target's OWN isolated locals scope. Its PK is a
+        // normal local (NOT an owned-type key), so ConstructionRewriter.ResolveLocal finds it directly — no
+        // owner-key resolution. Using the target's own scope (not the root's) is what keeps a self-referential
+        // reference (Employee.Manager) from aliasing the root's identical-IProperty locals.
+        var rewrittenBlock = (BlockExpression)new ConstructionRewriter(lookup.Target.AllLocals).Visit(materializerBlock);
+
+        // `!present ? null : <rewrittenBlock>` — an absent (BSON Null) lookup field yields a null navigation.
+        return Expression.Condition(
+            Expression.Not(lookup.Target.Present!),
+            Expression.Constant(null, conditional.Type),
+            Expression.Convert(rewrittenBlock, conditional.Type));
+    }
+
+    private static readonly ConstructorInfo InvalidOperationExceptionCtor =
+        typeof(InvalidOperationException).GetConstructor([typeof(string)])!;
+
+    private static LookupReferencePlan FindLookupReferencePlan(EntityPlan parent, INavigationBase navigation)
+    {
+        foreach (var lookup in parent.LookupReferences)
+        {
+            if (lookup.Navigation == navigation || lookup.Navigation.Name == navigation.Name)
+            {
+                return lookup;
+            }
+        }
+
+        throw new NativeTranslationNotSupportedException(
+            $"No streaming plan for lookup reference navigation '{navigation.DeclaringEntityType.DisplayName()}.{navigation.Name}'.");
+    }
+
+    private static EntityPlan FindChildPlan(EntityPlan parent, INavigationBase navigation)
+    {
+        foreach (var (nav, child) in parent.OwnedNavigations)
+        {
+            if (nav == navigation || nav.Name == navigation.Name)
+            {
+                return child;
+            }
+        }
+
+        throw new NativeTranslationNotSupportedException(
+            $"No streaming plan for owned navigation '{navigation.DeclaringEntityType.DisplayName()}.{navigation.Name}'.");
+    }
+
+    /// <summary>
+    /// Extract the always-present materializer block from EF's injected
+    /// <c>{ bsonDocN; bsonDocN = projection as BsonDocument; bsonDocN == null ? null : &lt;block&gt; }</c>.
+    /// </summary>
+    private BlockExpression ExtractMaterializerBlock(Expression body, IEntityType entityType)
+    {
+        if (body is not BlockExpression injectedBlock)
+        {
+            throw new NativeTranslationNotSupportedException(
+                $"Unexpected materializer shape for entity '{entityType.DisplayName()}'.");
+        }
+
+        var last = injectedBlock.Expressions[^1];
+        if (last is ConditionalExpression { IfFalse: BlockExpression materializerBlock })
+        {
+            return materializerBlock;
+        }
+
+        if (last is BlockExpression directBlock)
+        {
+            return directBlock;
+        }
+
+        // Collection-element materializer block: always present (no DOM `bsonDocN == null ? null` guard), so
+        // EF's injected block is itself the materializer block — it declares a MaterializationContext and ends
+        // with the instance variable rather than a conditional. Use it directly.
+        if (injectedBlock.Variables.Any(v => v.Type == typeof(MaterializationContext)))
+        {
+            return injectedBlock;
+        }
+
+        throw new NativeTranslationNotSupportedException(
+            $"Unexpected materializer shape for entity '{entityType.DisplayName()}'.");
+    }
+
+    /// <summary>
+    /// Build a typed read for <paramref name="property"/>: deserialize the value at the reader's current
+    /// position via the property's serializer and assign it to <paramref name="local"/>.
+    /// <para>
+    /// An explicit BSON <c>null</c> at the element is consumed (<see cref="IBsonReader.ReadNull"/>) and the
+    /// local left at <c>default(T)</c> — for ALL property types, nullable or not. This matches the driver-LINQ
+    /// entity-materialization oracle, whose entity path tolerates an explicit null on a non-nullable property
+    /// and yields <c>default(T)</c> rather than letting the value flow into the property serializer (which
+    /// would throw <c>FormatException: Cannot deserialize 'Int32' from BsonType 'Null'</c>). The presence of
+    /// the element is what distinguishes this case from a <em>missing</em> required field (handled by the
+    /// fill-loop presence tracking, which throws): a present-but-null required scalar is treated as PRESENT
+    /// here and takes this <c>default(T)</c> path.
+    /// </para>
+    /// </summary>
+    private Expression BuildTypedRead(IProperty property, ParameterExpression local)
+    {
+        var serializer = BsonSerializerFactory.GetPropertySerializationInfo(property).Serializer;
+
+        var context = Expression.Call(
+            CreateRootMethod,
+            _reader,
+            Expression.Constant(null, typeof(Action<BsonDeserializationContext.Builder>)));
+
+        Expression deserialize = Expression.Call(
+            Expression.Constant(serializer, typeof(IBsonSerializer)),
+            DeserializeMethod,
+            context,
+            Expression.Default(typeof(BsonDeserializationArgs)));
+
+        var readAssign = Expression.Assign(local, Expression.Convert(deserialize, local.Type));
+
+        return Expression.IfThenElse(
+            Expression.Equal(
+                Expression.Call(_reader, GetCurrentBsonTypeMethod),
+                Expression.Constant(BsonType.Null, typeof(BsonType))),
+            Expression.Block(
+                Expression.Call(_reader, ReadNullMethod),
+                Expression.Assign(local, Expression.Default(local.Type))),
+            readAssign);
+    }
+
+    /// <summary>
+    /// Reference-include fixup, mirroring EF's binding remover <c>IncludeReference</c>: wires the materialized
+    /// related entity onto the principal via <paramref name="fixup"/> (and sets the navigation loaded flag).
+    /// </summary>
+    private static void IncludeReference<TIncludingEntity, TIncludedEntity>(
+        InternalEntityEntry? entry,
+        object? entity,
+        IEntityType entityType,
+        TIncludedEntity relatedEntity,
+        INavigation navigation,
+        INavigation? inverseNavigation,
+        Action<TIncludingEntity, TIncludedEntity> fixup,
+        bool _)
+    {
+        if (entity == null
+            || !navigation.DeclaringEntityType.IsAssignableFrom(entityType))
+        {
+            return;
+        }
+
+        if (entry == null)
+        {
+            var includingEntity = (TIncludingEntity)entity;
+            navigation.SetIsLoadedWhenNoTracking(includingEntity);
+            if (relatedEntity != null)
+            {
+                fixup(includingEntity, relatedEntity);
+                if (inverseNavigation != null
+                    && !inverseNavigation.IsCollection)
+                {
+                    inverseNavigation.SetIsLoadedWhenNoTracking(relatedEntity);
+                }
+            }
+        }
+        // For non-null relatedEntity the StateManager sets the flag.
+        else if (relatedEntity == null)
+        {
+            entry.SetIsLoaded(navigation);
+        }
+    }
+
+    private static Delegate GenerateReferenceFixup(
+        Type entityType,
+        Type relatedEntityType,
+        INavigation navigation,
+        INavigation? inverseNavigation)
+    {
+        var entityParameter = Expression.Parameter(entityType);
+        var relatedEntityParameter = Expression.Parameter(relatedEntityType);
+        var expressions = new List<Expression>
+        {
+            AssignReferenceNavigation(entityParameter, relatedEntityParameter, navigation)
+        };
+
+        if (inverseNavigation != null)
+        {
+            // A single owned reference can only have a single inverse (back to the principal); collection
+            // inverses do not occur for the owned-reference shapes this rewriter accepts.
+            expressions.Add(
+                AssignReferenceNavigation(relatedEntityParameter, entityParameter, inverseNavigation));
+        }
+
+        return Expression.Lambda(
+                Expression.Block(typeof(void), expressions), entityParameter, relatedEntityParameter)
+            .Compile();
+    }
+
+    private static Expression AssignReferenceNavigation(
+        ParameterExpression entity,
+        ParameterExpression relatedEntity,
+        INavigation navigation)
+        => entity.MakeMemberAccess(navigation.GetMemberInfo(forMaterialization: true, forSet: true))
+            .Assign(relatedEntity);
+
+    /// <summary>
+    /// Rewrites an EF construction/tracking block to consume the streaming locals instead of a ValueBuffer:
+    /// <list type="bullet">
+    /// <item><c>ValueBufferTryReadValue&lt;TClr&gt;(mc.ValueBuffer, i, property)</c> → the property's local
+    /// (wrapped in <c>Convert(local, node.Type)</c> where the requested type differs).</item>
+    /// <item><c>new MaterializationContext(&lt;source&gt;, ctx)</c> → <c>new MaterializationContext(ValueBuffer.Empty, ctx)</c>.</item>
+    /// </list>
+    /// </summary>
+    private sealed class ConstructionRewriter : System.Linq.Expressions.ExpressionVisitor
+    {
+        private readonly Dictionary<IProperty, ParameterExpression> _locals;
+        private readonly CollectionPlan? _collection;
+
+        public ConstructionRewriter(Dictionary<IProperty, ParameterExpression> locals, CollectionPlan? collection = null)
+        {
+            _locals = locals;
+            _collection = collection;
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            var method = node.Method;
+            if (method.IsGenericMethod
+                && method.GetGenericMethodDefinition() == ExpressionExtensions.ValueBufferTryReadValueMethod)
+            {
+                var property = node.Arguments[2].GetConstantValue<IProperty>();
+
+                // The synthesized owned-collection ordinal key is not stored in BSON; it is the 1-based array
+                // index supplied by the loop counter (`counter + 1`, matching the DOM path's `ordinal + 1`).
+                if (_collection != null
+                    && property.DeclaringType == _collection.Element.EntityType
+                    && property.IsOwnedTypeOrdinalKey())
+                {
+                    Expression ordinal = Expression.Add(_collection.Counter, Expression.Constant(1));
+                    return node.Type == ordinal.Type ? ordinal : Expression.Convert(ordinal, node.Type);
+                }
+
+                var local = ResolveLocal(property);
+                if (local != null)
+                {
+                    if (node.Type == local.Type)
+                    {
+                        return local;
+                    }
+
+                    return Expression.Convert(local, node.Type);
+                }
+
+                throw new NativeTranslationNotSupportedException(
+                    $"Streaming materializer found a value read for property '{property.Name}' with no streaming local.");
+            }
+
+            return base.VisitMethodCall(node);
+        }
+
+        /// <summary>
+        /// Resolve a read property to its streaming local. An owned-type key (e.g. a shadow FK that shares
+        /// the principal's primary key, and so is stored only on the owner document, not in the owned
+        /// sub-document) is redirected to its principal property's local — exactly as the DOM binding remover
+        /// reads such keys from the owner via <c>FindFirstPrincipal</c>.
+        /// </summary>
+        private ParameterExpression? ResolveLocal(IProperty property)
+        {
+            if (_locals.TryGetValue(property, out var local))
+            {
+                return local;
+            }
+
+            var current = property;
+            while (current.IsOwnedTypeKey() && current.FindFirstPrincipal() is { } principal && principal != current)
+            {
+                if (_locals.TryGetValue(principal, out var principalLocal))
+                {
+                    return principalLocal;
+                }
+
+                current = principal;
+            }
+
+            return null;
+        }
+
+        protected override Expression VisitNew(NewExpression node)
+        {
+            if (node.Type == typeof(MaterializationContext))
+            {
+                return Expression.New(
+                    node.Constructor!,
+                    Expression.Constant(ValueBuffer.Empty),
+                    Visit(node.Arguments[1]));
+            }
+
+            return base.VisitNew(node);
+        }
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/NativeQueryParameter.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/NativeQueryParameter.cs
@@ -1,0 +1,57 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Helpers for recognizing EF Core query parameters in an expression tree across EF versions.
+/// </summary>
+internal static class NativeQueryParameter
+{
+    /// <summary>
+    /// Recognizes an EF Core query-parameter node and extracts its name. In EF8/EF9 a query parameter is a
+    /// <see cref="ParameterExpression"/> whose name carries <c>QueryCompilationContext.QueryParameterPrefix</c>;
+    /// in EF10 it is a typed <c>QueryParameterExpression</c>. The version difference is encapsulated here so
+    /// the native translator's call sites stay version-agnostic.
+    /// </summary>
+    /// <param name="expr">The candidate expression.</param>
+    /// <param name="name">The query-parameter name when <paramref name="expr"/> is a query parameter.</param>
+    /// <returns><see langword="true"/> if <paramref name="expr"/> is an EF query parameter.</returns>
+    public static bool TryGetQueryParameterName(Expression expr, [NotNullWhen(true)] out string? name)
+    {
+#if EF8 || EF9
+        if (expr is ParameterExpression param
+            && param.Name?.StartsWith(QueryCompilationContext.QueryParameterPrefix, StringComparison.Ordinal) == true)
+        {
+            name = param.Name;
+            return true;
+        }
+#else
+        if (expr is QueryParameterExpression queryParam)
+        {
+            name = queryParam.Name;
+            return true;
+        }
+#endif
+
+        name = null;
+        return false;
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/NativeTranslationNotSupportedException.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/NativeTranslationNotSupportedException.cs
@@ -1,0 +1,32 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Thrown by the native MQL translator when it encounters a query shape it does not yet support.
+/// Under <see cref="MongoDB.EntityFrameworkCore.Infrastructure.MongoQueryMode.Native"/> the compile-time
+/// gate catches this and falls back to the driver-LINQ path; under
+/// <see cref="MongoDB.EntityFrameworkCore.Infrastructure.MongoQueryMode.NativeOnly"/> it propagates,
+/// surfacing the unsupported query shape to the caller.
+/// </summary>
+internal sealed class NativeTranslationNotSupportedException : Exception
+{
+    public NativeTranslationNotSupportedException(string message) : base(message)
+    {
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/PlaceholderTable.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/PlaceholderTable.cs
@@ -1,0 +1,91 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>
+/// Accumulates <c>MongoParameterExpression</c> sites encountered during rendering.
+/// Each entry records the parameter name and its <see cref="IBsonSerializer"/>, keyed by
+/// the zero-based index of the sentinel placeholder that was embedded in the rendered BSON
+/// template. Task 10's pipeline builder substitutes actual parameter values at per-execution
+/// time using these entries.
+/// </summary>
+internal sealed class PlaceholderTable
+{
+    /// <summary>
+    /// The reserved key used to identify a placeholder sentinel document.
+    /// A sentinel is a <see cref="BsonDocument"/> of the form <c>{ __mongoef_param__: &lt;index&gt; }</c>.
+    /// This key is reserved and will never appear in server-sent BSON.
+    /// </summary>
+    internal const string SentinelKey = "__mongoef_param__";
+
+    private readonly List<(string Name, IBsonSerializer? Serializer)> _entries = [];
+
+    /// <summary>
+    /// A read-only view of all accumulated placeholder entries, in insertion order.
+    /// </summary>
+    public IReadOnlyList<(string Name, IBsonSerializer? Serializer)> Entries => _entries;
+
+    /// <summary>
+    /// Appends a placeholder entry and returns a sentinel <see cref="BsonValue"/> to embed
+    /// in the rendered BSON template at the parameter-value position.
+    /// </summary>
+    /// <param name="parameterName">The EF query-parameter name (e.g. <c>__p_0</c>).</param>
+    /// <param name="serializer">
+    /// The <see cref="IBsonSerializer"/> that will serialize the run-time value, or <see langword="null"/>
+    /// for property-less primitives (e.g. Skip/Take counts) that are serialized via <c>BsonValue.Create</c>.
+    /// </param>
+    /// <returns>
+    /// A sentinel <see cref="BsonDocument"/> of the form <c>{ __mongoef_param__: &lt;index&gt; }</c>
+    /// where <c>index</c> is the zero-based position in <see cref="Entries"/>.
+    /// </returns>
+    public BsonValue CreatePlaceholder(string parameterName, IBsonSerializer? serializer)
+    {
+        var index = _entries.Count;
+        _entries.Add((parameterName, serializer));
+        return new BsonDocument(SentinelKey, new BsonInt32(index));
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="value"/> is a placeholder sentinel, and if so
+    /// extracts the zero-based <paramref name="index"/> it encodes.
+    /// </summary>
+    /// <param name="value">The <see cref="BsonValue"/> to inspect.</param>
+    /// <param name="index">
+    /// When this method returns <see langword="true"/>, the zero-based placeholder index.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is a sentinel document produced
+    /// by <see cref="CreatePlaceholder"/>; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetPlaceholderIndex(BsonValue value, out int index)
+    {
+        index = 0;
+        if (value is BsonDocument doc
+            && doc.ElementCount == 1
+            && doc.TryGetValue(SentinelKey, out var indexValue)
+            && indexValue is BsonInt32 bsonInt)
+        {
+            index = bsonInt.Value;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoLimitStage.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoLimitStage.cs
@@ -1,0 +1,38 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+/// <summary>
+/// Represents a <c>$limit</c> aggregation stage that limits the number of documents passed to the next stage.
+/// </summary>
+internal sealed class MongoLimitStage : MongoPipelineStage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoLimitStage"/> class.
+    /// </summary>
+    /// <param name="limit">The expression that evaluates to the maximum number of documents to pass through.</param>
+    public MongoLimitStage(MongoExpression limit)
+    {
+        Limit = limit;
+    }
+
+    /// <summary>
+    /// Gets the expression that evaluates to the maximum number of documents to pass through.
+    /// </summary>
+    public MongoExpression Limit { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoLookupStage.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoLookupStage.cs
@@ -1,0 +1,38 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+/// <summary>
+/// Represents a <c>$lookup</c> aggregation stage that performs a join with another collection.
+/// </summary>
+internal sealed class MongoLookupStage : MongoPipelineStage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoLookupStage"/> class.
+    /// </summary>
+    /// <param name="lookup">The lookup expression that specifies the join parameters.</param>
+    public MongoLookupStage(LookupExpression lookup)
+    {
+        Lookup = lookup;
+    }
+
+    /// <summary>
+    /// Gets the lookup expression that specifies the join parameters.
+    /// </summary>
+    public LookupExpression Lookup { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoMatchStage.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoMatchStage.cs
@@ -1,0 +1,38 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+/// <summary>
+/// Represents a <c>$match</c> aggregation stage that filters documents based on a predicate.
+/// </summary>
+internal sealed class MongoMatchStage : MongoPipelineStage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoMatchStage"/> class.
+    /// </summary>
+    /// <param name="predicate">The predicate expression that filters documents.</param>
+    public MongoMatchStage(MongoExpression predicate)
+    {
+        Predicate = predicate;
+    }
+
+    /// <summary>
+    /// Gets the predicate expression that filters documents.
+    /// </summary>
+    public MongoExpression Predicate { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoPipelineStage.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoPipelineStage.cs
@@ -1,0 +1,25 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+/// <summary>
+/// Abstract base class for typed MongoDB aggregation pipeline stages.
+/// Each subclass represents a single stage in a MongoDB aggregation pipeline
+/// and carries the dialect-agnostic expressions needed to render it.
+/// </summary>
+internal abstract class MongoPipelineStage
+{
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoSkipStage.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoSkipStage.cs
@@ -1,0 +1,38 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+/// <summary>
+/// Represents a <c>$skip</c> aggregation stage that skips a specified number of documents.
+/// </summary>
+internal sealed class MongoSkipStage : MongoPipelineStage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoSkipStage"/> class.
+    /// </summary>
+    /// <param name="offset">The expression that evaluates to the number of documents to skip.</param>
+    public MongoSkipStage(MongoExpression offset)
+    {
+        Offset = offset;
+    }
+
+    /// <summary>
+    /// Gets the expression that evaluates to the number of documents to skip.
+    /// </summary>
+    public MongoExpression Offset { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoSortStage.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoSortStage.cs
@@ -1,0 +1,39 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+/// <summary>
+/// Represents a <c>$sort</c> aggregation stage that orders documents by one or more keys.
+/// </summary>
+internal sealed class MongoSortStage : MongoPipelineStage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoSortStage"/> class.
+    /// </summary>
+    /// <param name="orderings">The orderings that specify the sort keys and directions.</param>
+    public MongoSortStage(IReadOnlyList<MongoOrdering> orderings)
+    {
+        Orderings = orderings;
+    }
+
+    /// <summary>
+    /// Gets the orderings that specify the sort keys and directions.
+    /// </summary>
+    public IReadOnlyList<MongoOrdering> Orderings { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoUnwindStage.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/Stages/MongoUnwindStage.cs
@@ -1,0 +1,38 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+/// <summary>
+/// Represents an <c>$unwind</c> aggregation stage that deconstructs array fields into separate documents.
+/// </summary>
+internal sealed class MongoUnwindStage : MongoPipelineStage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MongoUnwindStage"/> class.
+    /// </summary>
+    /// <param name="lookup">The lookup expression that specifies which array field to unwind.</param>
+    public MongoUnwindStage(LookupExpression lookup)
+    {
+        Lookup = lookup;
+    }
+
+    /// <summary>
+    /// Gets the lookup expression that specifies which array field to unwind.
+    /// </summary>
+    public LookupExpression Lookup { get; }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/StreamingEligibility.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/NativeTranslation/StreamingEligibility.cs
@@ -1,0 +1,101 @@
+﻿/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+/// <summary>Decides whether an entity type can be materialized by the forward-only streaming reader.</summary>
+internal static class StreamingEligibility
+{
+    /// <summary>
+    /// Eligible: a simple single-property primary key; navigations are only single (reference) owned
+    /// sub-documents whose target types are themselves eligible. No owned collections, no
+    /// cross-collection / non-owned navigations, no TPH discriminator hierarchy. Scalar and mapped-array
+    /// properties are always fine (read via their serializers).
+    /// </summary>
+    public static bool IsEligible(IEntityType entityType)
+        => IsEligible(entityType, new HashSet<IEntityType>());
+
+    private static bool IsEligible(IEntityType entityType, HashSet<IEntityType> visiting)
+    {
+        if (!visiting.Add(entityType))
+        {
+            return true; // already validating this type (avoid cycles)
+        }
+
+        // No discriminator hierarchy (single concrete type only).
+        if (entityType.BaseType != null || entityType.GetDirectlyDerivedTypes().Any())
+        {
+            return false;
+        }
+
+        // Primary key. A document-root entity needs a simple single-property primary key. An owned
+        // collection element type legitimately carries a composite key (the owner FK + a synthesized
+        // ordinal); those extra properties are owned-type keys, resolved against the owner / loop counter
+        // by the rewriter, so allow a composite key whose non-leaf properties are all owned-type keys.
+        var pk = entityType.FindPrimaryKey();
+        if (pk == null)
+        {
+            return false;
+        }
+
+        var nonOwnedKeyProps = pk.Properties.Count(p => !p.IsOwnedTypeKey());
+        if (nonOwnedKeyProps > 1)
+        {
+            return false;
+        }
+
+        // Only single (reference) owned navigations, to eligible owned types. (A required owned reference is
+        // still eligible — the rewriter reproduces EF's "required but missing" throw via the present flag;
+        // see MongoStreamingEntityMaterializerRewriter.RewriteOwnedNavigation.)
+        foreach (var navigation in entityType.GetNavigations())
+        {
+            // The navigation's target type must itself be streaming-eligible (recursively; the
+            // `visiting` cycle-guard prevents infinite recursion on bidirectional relationships).
+            if (!IsEligible(navigation.TargetEntityType, visiting))
+            {
+                return false;
+            }
+
+            // Non-owned navigations are only supported as single references (materialized via
+            // $lookup + $unwind). A non-owned collection navigation is not yet streamable.
+            if (!navigation.TargetEntityType.IsOwned() && navigation.IsCollection)
+            {
+                return false;
+            }
+
+            // The rewriter cannot yet stream a collection whose element type itself owns a collection
+            // (collection-of-collection). Single owned references nested in a collection element, and
+            // nested single references, remain allowed.
+            if (navigation.IsCollection
+                && navigation.TargetEntityType.GetNavigations().Any(n => n.IsCollection))
+            {
+                return false;
+            }
+        }
+
+        // Skip-navigations make it ineligible.
+        if (entityType.GetSkipNavigations().Any())
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/QueryingEnumerable.cs
@@ -77,6 +77,7 @@ internal sealed class QueryingEnumerable<TSource, TTarget> : IAsyncEnumerable<TT
         private bool _gotResults;
 
         private IEnumerator<TSource>? _enumerator;
+        private TSource? _currentRow;
 
         public Enumerator(QueryingEnumerable<TSource, TTarget> queryingEnumerable, CancellationToken cancellationToken = default)
         {
@@ -187,7 +188,14 @@ internal sealed class QueryingEnumerable<TSource, TTarget> : IAsyncEnumerable<TT
                 // single null by the scalar path) must not be passed to the entity shaper, which would
                 // dereference a null BsonDocument. Yield default(TTarget); a projected identity shaper
                 // would produce the same null, so scalar/aggregate results are unaffected.
-                Current = _enumerator.Current is null ? default! : _shaper(_queryContext, _enumerator.Current);
+                var row = _enumerator.Current;
+                _currentRow = row;
+                Current = row is null ? default! : _shaper(_queryContext, row);
+
+                // Native streaming rows are IDisposable RawBsonDocuments backed by a byte buffer; the shaper
+                // has consumed them, so release immediately. No-op for the plain-BsonDocument paths. Releasing
+                // nulls out the tracked field so an abandoned-enumeration Dispose doesn't dispose it again.
+                ReleaseCurrentRow();
 
                 if (!_gotResults)
                 {
@@ -207,14 +215,33 @@ internal sealed class QueryingEnumerable<TSource, TTarget> : IAsyncEnumerable<TT
             return hasNext;
         }
 
+        // Releases a fetched-but-not-yet-released streaming row (a RawBsonDocument byte buffer); nulls the
+        // tracked field afterwards so a subsequent Dispose / DisposeAsync does not double-dispose it. No-op
+        // for the plain-BsonDocument paths (the row is not IDisposable).
+        private void ReleaseCurrentRow()
+        {
+            if (_currentRow is IDisposable disposableRow)
+            {
+                disposableRow.Dispose();
+            }
+
+            _currentRow = default;
+        }
+
         public void Dispose()
         {
+            // Release a fetched-but-not-yet-released streaming row (enumeration abandoned early or threw
+            // mid-stream) before disposing the enumerator.
+            ReleaseCurrentRow();
+
             _enumerator?.Dispose();
             _enumerator = null;
         }
 
         public ValueTask DisposeAsync()
         {
+            ReleaseCurrentRow();
+
             var enumerator = _enumerator;
             _enumerator = null;
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -26,6 +26,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 
@@ -145,6 +146,10 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                     }
             }
 
+            // Native-slot population (Option B): inline, using the already-visited source so we
+            // always operate on the correct MongoQueryExpression instance — never re-traverse.
+            PopulateNativeSlots(shapedQueryExpression, methodDefinition, methodCallExpression);
+
             var newCardinality = GetResultCardinality(method);
             if (newCardinality != shapedQueryExpression.ResultCardinality)
                 shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(newCardinality);
@@ -164,14 +169,38 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             return source;
         }
 
-        // TransparentIdentifier types are used by Join/LeftJoin/GroupJoin - allow them through
-
+        // TransparentIdentifier types are used by Join/LeftJoin/GroupJoin - allow them through.
+        // Any other (projecting) Select cannot be expressed as a native pipeline stage (SP3 work),
+        // so mark the query as no longer natively representable.
         var mongoQueryExpression = (MongoQueryExpression)source.QueryExpression;
+        if (!IsTransparentIdentifierSelector(selector))
+        {
+            mongoQueryExpression.IsNativeRepresentable = false;
+        }
+
         var newSelectorBody =
             ReplacingExpressionVisitor.Replace(selector.Parameters.Single(), source.ShaperExpression, selector.Body);
         var newShaper = _projectionBindingExpressionVisitor.Translate(mongoQueryExpression, newSelectorBody);
 
         return source.UpdateShaperExpression(newShaper);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="selector"/> is a transparent-identifier
+    /// selector produced by a Join/GroupJoin/LeftJoin rewrite — i.e. the body constructs an anonymous
+    /// object whose fields are the outer and inner parameters without further transformation.
+    /// Projecting selects (e.g. <c>Select(c =&gt; c.Name)</c>) return <see langword="false"/>.
+    /// </summary>
+    private static bool IsTransparentIdentifierSelector(LambdaExpression selector)
+    {
+        // EF generates transparent-identifier selectors as NewExpression nodes constructing an
+        // anonymous "TransparentIdentifier" type.  All other selectors project or transform.
+        if (selector.Body is not NewExpression newExpr)
+            return false;
+
+        var typeName = newExpr.Type.Name;
+        return typeName.StartsWith("TransparentIdentifier", StringComparison.Ordinal)
+               || typeName.StartsWith("<>f__AnonymousType", StringComparison.Ordinal);
     }
 
     protected override ShapedQueryExpression CreateShapedQueryExpression(IEntityType entityType)
@@ -504,6 +533,11 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             var resultEntityType = entityType.Model.FindEntityType(resultType);
             if (resultEntityType != null)
             {
+                // OfType<TDerived>() narrows a TPH hierarchy by a discriminator predicate that is applied by
+                // the driver-LINQ path (via the captured chain / shaper), not captured into the native Predicate
+                // slot. The native pipeline would therefore return every document and the DOM shaper would fail
+                // to materialize a sibling type, so the query is not natively representable.
+                ((MongoQueryExpression)source.QueryExpression).IsNativeRepresentable = false;
                 return source.UpdateShaperExpression(entityShaperExpression.WithType(resultEntityType));
             }
         }
@@ -551,6 +585,137 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                     source.QueryExpression, new ProjectionMember(), returnType.MakeNullable()), returnType));
 
     #endregion
+
+    // ── Native-slot population (Option B: inline in VisitMethodCall) ─────────────
+    //
+    // These helpers operate on the already-visited `source` so they always address
+    // the correct MongoQueryExpression instance.  They are called from the shared
+    // fall-through in VisitMethodCall AFTER the switch, before the CapturedExpression
+    // is set.  The Translate* overrides below remain dead code (never called via base)
+    // but are kept as clean implementations for potential future use.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Populates the native-translation slots on the <see cref="MongoQueryExpression"/> for the
+    /// seven slot-bearing operators: Where, OrderBy, OrderByDescending, ThenBy, ThenByDescending,
+    /// Skip, and Take.  Called from <see cref="VisitMethodCall"/> on the already-evaluated source.
+    /// </summary>
+    private static void PopulateNativeSlots(
+        ShapedQueryExpression shapedQuery,
+        MethodInfo methodDefinition,
+        MethodCallExpression call)
+    {
+        var mongoQ = (MongoQueryExpression)shapedQuery.QueryExpression;
+        var translator = new MongoExpressionTranslator(mongoQ.CollectionExpression.EntityType);
+
+        if (methodDefinition == QueryableMethods.Where)
+        {
+            // Canonical-order guard: the native lowerer emits $match → $sort → $skip → $limit. A Where
+            // (→ $match) applied AFTER any paging (Skip → Offset, or Take → Limit) has already been
+            // recorded would be hoisted ahead of that paging on the native pipeline, silently returning
+            // the wrong rows. Such a query is not natively representable; fall back to driver-LINQ.
+            if (PagingAlreadyApplied(mongoQ))
+            {
+                mongoQ.IsNativeRepresentable = false;
+                return;
+            }
+
+            var predicate = call.Arguments[1].UnwrapLambdaFromQuote();
+            if (translator.TryTranslate(predicate.Body, out var predicateNode))
+                mongoQ.AddPredicateConjunct(predicateNode);
+            else
+                mongoQ.IsNativeRepresentable = false;
+        }
+        else if (methodDefinition == QueryableMethods.OrderBy || methodDefinition == QueryableMethods.OrderByDescending)
+        {
+            // Canonical-order guard: a $sort emitted after paging ($skip/$limit) has been recorded would
+            // be hoisted ahead of it on the native pipeline, sorting the full set instead of the page and
+            // returning the wrong rows. Not natively representable; fall back to driver-LINQ.
+            if (PagingAlreadyApplied(mongoQ))
+            {
+                mongoQ.IsNativeRepresentable = false;
+                return;
+            }
+
+            var keySelector = call.Arguments[1].UnwrapLambdaFromQuote();
+            var ascending = methodDefinition == QueryableMethods.OrderBy;
+            if (translator.TryTranslateField(keySelector.Body, out var keyNode))
+                mongoQ.ResetOrderings(new MongoOrdering(keyNode, ascending));
+            else
+                mongoQ.IsNativeRepresentable = false;
+        }
+        else if (methodDefinition == QueryableMethods.ThenBy || methodDefinition == QueryableMethods.ThenByDescending)
+        {
+            // Same canonical-order guard as OrderBy: a $sort after paging is not natively representable.
+            if (PagingAlreadyApplied(mongoQ))
+            {
+                mongoQ.IsNativeRepresentable = false;
+                return;
+            }
+
+            var keySelector = call.Arguments[1].UnwrapLambdaFromQuote();
+            var ascending = methodDefinition == QueryableMethods.ThenBy;
+            if (translator.TryTranslateField(keySelector.Body, out var keyNode))
+                mongoQ.AppendOrdering(new MongoOrdering(keyNode, ascending));
+            else
+                mongoQ.IsNativeRepresentable = false;
+        }
+        else if (methodDefinition == QueryableMethods.Skip)
+        {
+            // Enforce canonical order: Skip once, before Take.
+            if (mongoQ.Offset != null || mongoQ.Limit != null)
+            {
+                mongoQ.IsNativeRepresentable = false;
+            }
+            else
+            {
+                mongoQ.Offset = TranslateCountExpression(call.Arguments[1]);
+                if (mongoQ.Offset is null)
+                    mongoQ.IsNativeRepresentable = false;
+            }
+        }
+        else if (methodDefinition == QueryableMethods.Take)
+        {
+            if (mongoQ.Limit != null)
+            {
+                mongoQ.IsNativeRepresentable = false;
+            }
+            else
+            {
+                mongoQ.Limit = TranslateCountExpression(call.Arguments[1]);
+                if (mongoQ.Limit is null)
+                    mongoQ.IsNativeRepresentable = false;
+            }
+        }
+        else if (!IsNativeRepresentableSlotOperator(methodDefinition))
+        {
+            // Any other top-level operator (Distinct, Cast, DefaultIfEmpty, scalar aggregates, cardinality
+            // reducers, Any/All, …) is not lowered into a native slot. Leaving the query "native-representable"
+            // would silently drop the operator on the native pipeline (e.g. a Distinct executed as the bare
+            // collection scan), so it is conservatively marked non-native. Select / OfType set the flag in their
+            // own Translate overrides. This is correctness-safe: the worst case is a missed native optimization
+            // and a fall back to the driver-LINQ path, never a wrong result.
+            mongoQ.IsNativeRepresentable = false;
+        }
+    }
+
+    // Canonical-order guard shared by the Where / OrderBy / OrderByDescending / ThenBy / ThenByDescending
+    // arms: once any paging ($skip → Offset, or $take → Limit) has been recorded, a later $match/$sort would
+    // be hoisted ahead of it on the canonical native pipeline and silently return the wrong rows, so the
+    // query is not natively representable.
+    private static bool PagingAlreadyApplied(MongoQueryExpression mongoQ)
+        => mongoQ.Offset != null || mongoQ.Limit != null;
+
+    // The operators PopulateNativeSlots lowers into a native slot. Everything else either sets the flag in its
+    // own Translate override (Select/OfType) or must drop off the native path (handled by the catch-all above).
+    private static bool IsNativeRepresentableSlotOperator(MethodInfo methodDefinition)
+        => methodDefinition == QueryableMethods.Where
+           || methodDefinition == QueryableMethods.OrderBy
+           || methodDefinition == QueryableMethods.OrderByDescending
+           || methodDefinition == QueryableMethods.ThenBy
+           || methodDefinition == QueryableMethods.ThenByDescending
+           || methodDefinition == QueryableMethods.Skip
+           || methodDefinition == QueryableMethods.Take;
 
     #region Never called by visit as translation is handled by C# Driver LINQ (with some minor tweaks)
 
@@ -764,6 +929,12 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         Type returnType, bool returnDefault)
         => null;
 
+    // These QMTEV overrides are intentionally inert: native slot population is done inline in
+    // PopulateNativeSlots (see VisitMethodCall), because routing Where/OrderBy/ThenBy/Skip/Take
+    // through base.VisitMethodCall rebuilds a fresh MongoQueryExpression per operator (slots don't
+    // accumulate). Do NOT add these operators to the VisitMethodCall switch without first removing
+    // their PopulateNativeSlots handling, or slots will be double-populated.
+
     protected override ShapedQueryExpression? TranslateOrderBy(ShapedQueryExpression source, LambdaExpression keySelector,
         bool ascending)
         => null;
@@ -791,11 +962,28 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
     protected override ShapedQueryExpression? TranslateTake(ShapedQueryExpression source, Expression count)
         => null;
 
+    /// <summary>
+    /// Translates a Skip/Take count expression to a <see cref="MongoExpression"/>
+    /// (either a <see cref="MongoConstantExpression"/> or a <see cref="MongoParameterExpression"/>).
+    /// Returns <see langword="null"/> if the expression cannot be represented natively.
+    /// </summary>
+    private static MongoExpression? TranslateCountExpression(Expression count)
+    {
+        if (count is ConstantExpression constant)
+            return new MongoConstantExpression(constant.Value, forSerialization: null);
+
+        if (NativeQueryParameter.TryGetQueryParameterName(count, out var parameterName))
+            return new MongoParameterExpression(parameterName, forSerialization: null);
+
+        return null;
+    }
+
     protected override ShapedQueryExpression? TranslateTakeWhile(ShapedQueryExpression source, LambdaExpression predicate)
         => null;
 
     protected override ShapedQueryExpression? TranslateThenBy(ShapedQueryExpression source, LambdaExpression keySelector,
-        bool ascending) => null;
+        bool ascending)
+        => null;
 
     protected override ShapedQueryExpression? TranslateUnion(ShapedQueryExpression source1, ShapedQueryExpression source2)
         => null;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -31,7 +31,9 @@ using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 using MongoDB.EntityFrameworkCore.Diagnostics;
+using MongoDB.EntityFrameworkCore.Infrastructure;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
 using MongoDB.EntityFrameworkCore.Query.Visitors.Dependencies;
 using MongoDB.EntityFrameworkCore.Serializers;
 using MongoDB.EntityFrameworkCore.Storage;
@@ -159,6 +161,20 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
     {
         VerifyNoClientConstant(shapedQueryExpression.ShaperExpression);
 
+        // A projected query (anonymous/scalar projection, scalar aggregate, or a mixed projection containing
+        // entity references) is never shaped from a full native document — it runs through the driver-LINQ
+        // push-down path or the mixed client-side shaper. The native pipeline only covers full-entity results,
+        // so a projected query is outside the native parity slice. Under NativeOnly the driver fallback is
+        // forbidden, so any projected query is a compile-time coverage failure. (The QMTEV does not always flip
+        // IsNativeRepresentable for a pushed-down projection — the projection can be realized entirely in the
+        // shaper without a translated Select node — so the projected-path gate keys off routing here, not the
+        // representable flag.)
+        if (((MongoQueryCompilationContext)QueryCompilationContext).QueryMode == MongoQueryMode.NativeOnly)
+        {
+            throw new NativeTranslationNotSupportedException(
+                "Query projects a non-entity result and MongoQueryMode.NativeOnly forbids the driver-LINQ fallback.");
+        }
+
         if (ProjectionAnalyzer.CanPushDown(shapedQueryExpression.ShaperExpression))
         {
             // Push-down path: scalar/anonymous projections handled entirely by LINQ V3
@@ -230,64 +246,269 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
     {
         var bsonDocParameter = Expression.Parameter(typeof(BsonDocument), "bsonDoc");
         var trackingBehavior = QueryCompilationContext.QueryTrackingBehavior;
+        var mode = ((MongoQueryCompilationContext)QueryCompilationContext).QueryMode;
+
+        // ── The native-vs-driver gate (EF-323 B2) ──────────────────────────────────────────────
+        // Unlike the spike (B1), which builds the native pipeline per execution inside TranslateQuery
+        // and falls back to driver-LINQ at run time, this decision is made deterministically here at
+        // COMPILE time. A native query that can be lowered/rendered yields a MongoPipelineFactory captured
+        // into the executor; per execution it is only re-bound (factory.Build(parameterValues)) — never
+        // re-translated. Because fallback happens here (not at run time), we compile EXACTLY ONE shaper
+        // (streaming, DOM-native, or driver-DOM) and need no run-time dual-shaper dispatch.
+        var nativeFactory = TryBuildNativeFactory(mode, mongoQueryExpression, shapedQueryExpression.ResultCardinality);
+
+        // Streaming is only chosen when the native factory was built, the entity shape is streaming-eligible,
+        // and every cross-collection join is a streamable single-level reference lookup the streaming reader
+        // can read back. Otherwise the native pipeline (if any) returns full BsonDocuments shaped by the DOM
+        // shaper, exactly as the driver-LINQ path does.
+        var streaming = nativeFactory != null
+            && shapedQueryExpression.ResultCardinality == ResultCardinality.Enumerable
+            && StreamingEligibility.IsEligible(rootEntityType)
+            && AllPendingLookupsAreStreamableReferences(mongoQueryExpression);
 
         var shaperBody = shapedQueryExpression.ShaperExpression;
         var bsonInjector = new BsonDocumentInjectingExpressionVisitor();
         shaperBody = bsonInjector.Visit(shaperBody);
 #if EF8 || EF9
-        shaperBody = InjectEntityMaterializers(shaperBody);
+        var injectedBody = InjectEntityMaterializers(shaperBody);
 #else
-        shaperBody = InjectStructuralTypeMaterializers(shaperBody);
+        var injectedBody = InjectStructuralTypeMaterializers(shaperBody);
 #endif
-        shaperBody = createBindingRemover(bsonDocParameter, trackingBehavior).Visit(shaperBody);
+
+        var standAloneStateManager = QueryCompilationContext.QueryTrackingBehavior ==
+                                     QueryTrackingBehavior.NoTrackingWithIdentityResolution;
+
+        if (streaming)
+        {
+            // Forward-only streaming materialization: rewrite the post-injection materializer to read each
+            // native-path RawBsonDocument row via a single forward IBsonReader pass into typed locals. The
+            // rewriter throws on any shape it cannot stream; because the native factory is fixed at compile
+            // time, an un-streamable shape is a compile-time decision — fall back to the DOM shaper over the
+            // (still native) BsonDocument pipeline rather than to a run-time dual-shaper, except under
+            // NativeOnly where the un-streamable shape must surface.
+            var rawRowParameter = Expression.Parameter(typeof(RawBsonDocument), "rawRow");
+            try
+            {
+                var streamingBody = new MongoStreamingEntityMaterializerRewriter(
+                        rootEntityType, _bsonSerializerFactory, rawRowParameter)
+                    .Rewrite(injectedBody);
+                var streamingLambda = Expression.Lambda(
+                    streamingBody,
+                    QueryCompilationContext.QueryContextParameter,
+                    rawRowParameter);
+                var compiledStreamingShaper = streamingLambda.Compile();
+
+                return BuildExecuteCall(
+                    typeof(RawBsonDocument),
+                    Expression.Constant(compiledStreamingShaper),
+                    streamingLambda.ReturnType,
+                    streaming: true);
+            }
+            catch (Exception) when (mode != MongoQueryMode.NativeOnly)
+            {
+                // The entity shape itself isn't streamable; fall through to the DOM path (still native).
+                streaming = false;
+            }
+        }
+
+        var domShaperBody = createBindingRemover(bsonDocParameter, trackingBehavior).Visit(injectedBody);
 
         // Lift all BsonDocument/BsonArray variables to the lambda level so they are
         // accessible across entity boundaries in join projections.
         if (bsonInjector.AllVariables.Count > 0)
         {
-            shaperBody = Expression.Block(
-                shaperBody.Type,
+            domShaperBody = Expression.Block(
+                domShaperBody.Type,
                 bsonInjector.AllVariables,
-                shaperBody);
+                domShaperBody);
         }
 
         var shaperLambda = Expression.Lambda(
-            shaperBody,
+            domShaperBody,
             QueryCompilationContext.QueryContextParameter,
             bsonDocParameter);
         var compiledShaper = shaperLambda.Compile();
 
         var projectedType = shaperLambda.ReturnType;
-        var standAloneStateManager = QueryCompilationContext.QueryTrackingBehavior ==
-                                     QueryTrackingBehavior.NoTrackingWithIdentityResolution;
 
-        return Expression.Call(null,
-            ExecuteShapedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType, projectedType),
-            QueryCompilationContext.QueryContextParameter,
-            Expression.Constant(rootEntityType),
-            Expression.Constant(_bsonSerializerFactory),
-            Expression.Constant(mongoQueryExpression),
+        // Both the native DOM path and the driver-LINQ path produce full BsonDocuments shaped by this lambda;
+        // they differ only in whether nativeFactory is non-null (native pipeline) or null (driver-LINQ).
+        return BuildExecuteCall(
+            typeof(BsonDocument),
             Expression.Constant(compiledShaper),
-            Expression.Constant(_contextType),
-            Expression.Constant(standAloneStateManager),
-            Expression.Constant(_threadSafetyChecksEnabled),
-            Expression.Constant(shapedQueryExpression.ResultCardinality));
+            projectedType,
+            streaming: false);
+
+        // Builds the ExecuteShapedQuery call. Every argument is shared across the streaming and DOM paths
+        // except the row generic type, the compiled shaper, the return-type generic, and the trailing
+        // streaming flag — those four vary; the rest are baked in here.
+        MethodCallExpression BuildExecuteCall(Type rowType, Expression compiledShaper, Type returnType, bool streaming)
+            => Expression.Call(null,
+                ExecuteShapedQueryMethodInfo.MakeGenericMethod(
+                    rowType, rootEntityType.ClrType, returnType),
+                QueryCompilationContext.QueryContextParameter,
+                Expression.Constant(rootEntityType),
+                Expression.Constant(_bsonSerializerFactory),
+                Expression.Constant(mongoQueryExpression),
+                compiledShaper,
+                Expression.Constant(_contextType),
+                Expression.Constant(standAloneStateManager),
+                Expression.Constant(_threadSafetyChecksEnabled),
+                Expression.Constant(shapedQueryExpression.ResultCardinality),
+                Expression.Constant(nativeFactory, typeof(MongoPipelineFactory)),
+                Expression.Constant(streaming));
     }
 
-    private static (MongoQueryContext, MongoExecutableQuery) TranslateQuery<TSource>(
+    /// <summary>
+    /// The compile-time native-vs-driver gate honoring <see cref="MongoQueryMode"/>. Returns a
+    /// <see cref="MongoPipelineFactory"/> when the query should execute as a native aggregation pipeline,
+    /// or <see langword="null"/> to use the driver-LINQ path.
+    /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item><see cref="MongoQueryMode.DriverLinq"/>: never native (returns null).</item>
+    /// <item><see cref="MongoQueryMode.Native"/> (default): native when the query is representable and
+    /// lowers/renders without throwing <see cref="NativeTranslationNotSupportedException"/>; otherwise null
+    /// (driver fallback).</item>
+    /// <item><see cref="MongoQueryMode.NativeOnly"/>: native, or throw at compile time for a non-representable
+    /// query (the coverage instrument) — never falls back.</item>
+    /// </list>
+    /// The native pipeline returns full BsonDocuments (or RawBsonDocuments when streamed); the push-down
+    /// projection path (ExecuteProjectedQuery) is never routed here. A cardinality reducer (First/Single/…)
+    /// stays on the driver-LINQ path — the native path covers enumerable results.
+    /// </remarks>
+    private static MongoPipelineFactory? TryBuildNativeFactory(
+        MongoQueryMode mode,
+        MongoQueryExpression mongoQueryExpression,
+        ResultCardinality resultCardinality)
+    {
+        if (mode == MongoQueryMode.DriverLinq)
+        {
+            return null;
+        }
+
+        // The native pipeline shapes from full documents via the client-side entity/mixed shaper, which only
+        // runs for an enumerable result. A cardinality reducer uses the driver-LINQ path. Under NativeOnly the
+        // gate still measures representability (below) — a representable reducer is not a coverage failure.
+        if (resultCardinality != ResultCardinality.Enumerable)
+        {
+            if (mode == MongoQueryMode.NativeOnly && !mongoQueryExpression.IsNativeRepresentable)
+            {
+                throw new NativeTranslationNotSupportedException(
+                    "Query is not natively representable and MongoQueryMode.NativeOnly forbids the driver-LINQ fallback.");
+            }
+
+            return null;
+        }
+
+        // A VectorSearch query is realized by the driver-LINQ path ($vectorSearch stage built from the captured
+        // VectorSearch call) and carries the index-resolution / zero-results diagnostics. The native lowerer
+        // reads only the logical slots and never the captured chain, so it would silently drop the vector
+        // search. Vector search is therefore not natively representable; keep it on the driver path.
+        if (!mongoQueryExpression.IsNativeRepresentable || ContainsVectorSearch(mongoQueryExpression.CapturedExpression))
+        {
+            if (mode == MongoQueryMode.NativeOnly)
+            {
+                throw new NativeTranslationNotSupportedException(
+                    "Query is not natively representable and MongoQueryMode.NativeOnly forbids the driver-LINQ fallback.");
+            }
+
+            return null;
+        }
+
+        try
+        {
+            var stages = new MongoSelectLowerer().Lower(mongoQueryExpression);
+            return MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+        }
+        catch (NativeTranslationNotSupportedException) when (mode != MongoQueryMode.NativeOnly)
+        {
+            // A representable query whose lookup shape (or other stage) the native pipeline can't emit:
+            // fall back to the driver-LINQ path. Under NativeOnly this rethrows as the coverage instrument.
+            return null;
+        }
+    }
+
+    // Walks the captured Queryable method chain looking for a VectorSearch call. VectorSearch sits at the root
+    // (optionally under a single pre-Where), so this descends through the source argument of each call.
+    private static bool ContainsVectorSearch(Expression? captured)
+    {
+        while (captured is MethodCallExpression call)
+        {
+            if (call.IsVectorSearch())
+            {
+                return true;
+            }
+
+            captured = call.Arguments.Count > 0 ? call.Arguments[0] : null;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether every cross-collection join on <paramref name="mongoQueryExpression"/> is a single-level
+    /// reference lookup the native pipeline can emit and the streaming materializer can read back from a
+    /// root-level <c>_lookup_&lt;Nav&gt;</c> field — the same set the native lowerer emits. A query with no
+    /// joins is trivially streamable; a query whose joins cannot ALL be expressed as such reference lookups
+    /// (a collection include, a filtered include with pipeline stages, a transitive/nested lookup, or any
+    /// join shape not mappable to a direct root reference navigation) stays on the DOM / driver-LINQ path.
+    /// </summary>
+    private static bool AllPendingLookupsAreStreamableReferences(MongoQueryExpression mongoQueryExpression)
+    {
+        var referenceLookups = mongoQueryExpression.GetStreamingReferenceLookups();
+
+        // Every join must be covered by a streamable reference lookup; otherwise a join would be silently
+        // dropped on the native path.
+        if (mongoQueryExpression.IsJoinQuery
+            && referenceLookups.Count < mongoQueryExpression.InnerCollections.Count)
+        {
+            return false;
+        }
+
+        return referenceLookups.All(lookup => lookup.IsStreamableReference);
+    }
+
+    private static (MongoQueryContext, MongoExecutableQuery) TranslateQuery<TEntity>(
         QueryContext queryContext,
         IReadOnlyEntityType entityType,
         BsonSerializerFactory bsonSerializerFactory,
         MongoQueryExpression queryExpression,
         ResultCardinality resultCardinality,
+        MongoPipelineFactory? nativeFactory,
+        bool streaming,
         Func<MongoEFToLinqTranslatingExpressionVisitor, Expression?, Expression> translate)
     {
         var mongoQueryContext = (MongoQueryContext)queryContext;
-        var collection = mongoQueryContext.MongoClient.GetCollection<TSource>(queryExpression.CollectionExpression.CollectionName);
+        var collection = mongoQueryContext.MongoClient.GetCollection<TEntity>(queryExpression.CollectionExpression.CollectionName);
 
         var transaction = mongoQueryContext.Context.Database.CurrentTransaction as MongoTransaction;
-        var queryable = transaction == null ? collection.AsQueryable() : collection.AsQueryable(transaction.Session);
-        var source = queryable.As((IBsonSerializer<TSource>)bsonSerializerFactory.GetEntitySerializer(entityType));
+
+        // Native path (EF-323 B2): the factory was built once at compile time. Per execution we only bind the
+        // current parameter values into the cached template (factory.Build) and run the resulting pipeline via
+        // MongoClientWrapper.Execute. The driver-LINQ Query is left as Expression.Empty() — it is never used.
+        if (nativeFactory != null)
+        {
+            var pipeline = nativeFactory.Build(GetParameterValues(queryContext));
+
+            var queryable = transaction == null ? collection.AsQueryable() : collection.AsQueryable(transaction.Session);
+            var nativeExecutable = new MongoExecutableQuery(
+                Expression.Empty(),
+                resultCardinality,
+                (IMongoQueryProvider)queryable.Provider,
+                collection.CollectionNamespace,
+                new(new Dictionary<string, object>()))
+            {
+                NativePipeline = pipeline,
+                Session = transaction?.Session,
+                Streaming = streaming
+            };
+
+            return (mongoQueryContext, nativeExecutable);
+        }
+
+        var driverQueryable = transaction == null ? collection.AsQueryable() : collection.AsQueryable(transaction.Session);
+        var source = driverQueryable.As((IBsonSerializer<TEntity>)bsonSerializerFactory.GetEntitySerializer(entityType));
 
         var innerSources = new Dictionary<IEntityType, Expression>();
         if (queryExpression.IsJoinQuery)
@@ -312,6 +533,15 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
 
         return (mongoQueryContext, executableQuery);
     }
+
+    // Bridges QueryContext's per-execution parameter values to MongoPipelineFactory.Build, which takes an
+    // IReadOnlyDictionary<string, object?>. EF8/EF9 expose ParameterValues; EF10 renamed this to Parameters.
+    private static IReadOnlyDictionary<string, object?> GetParameterValues(QueryContext queryContext)
+#if EF8 || EF9
+        => queryContext.ParameterValues;
+#else
+        => queryContext.Parameters;
+#endif
 
     private static Action<MongoQueryContext, MongoExecutableQuery>? GetOnZeroResultsAction(MongoQueryExpression queryExpression)
     {
@@ -344,6 +574,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
     {
         var (mongoQueryContext, executableQuery) = TranslateQuery<TSource>(
             queryContext, entityType, bsonSerializerFactory, queryExpression, resultCardinality,
+            nativeFactory: null, streaming: false,
             (translator, expression) => translator.TranslateProjected(expression));
 
         return new QueryingEnumerable<TResult, TResult>(
@@ -356,22 +587,31 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             GetOnZeroResultsAction(queryExpression));
     }
 
-    private static QueryingEnumerable<BsonDocument, TResult> ExecuteShapedQuery<TSource, TResult>(
+    // TSource is the driver row type: RawBsonDocument when streaming, BsonDocument otherwise (the native-DOM
+    // and driver-LINQ paths both produce BsonDocument). TEntity is the root entity CLR type; TResult is the
+    // shaped result. When nativeFactory is non-null the query runs as a native aggregation pipeline (bound per
+    // execution via factory.Build); otherwise it runs through the driver-LINQ provider. The decision was made
+    // deterministically at compile time (see CompileShapedQuery / TryBuildNativeFactory), so exactly one shaper
+    // — matching this TSource — was compiled, and MongoClientWrapper.Execute reads the matching collection type.
+    private static QueryingEnumerable<TSource, TResult> ExecuteShapedQuery<TSource, TEntity, TResult>(
         QueryContext queryContext,
         IReadOnlyEntityType entityType,
         BsonSerializerFactory bsonSerializerFactory,
         MongoQueryExpression queryExpression,
-        Func<QueryContext, BsonDocument, TResult> shaper,
+        Func<QueryContext, TSource, TResult> shaper,
         Type contextType,
         bool standAloneStateManager,
         bool threadSafetyChecksEnabled,
-        ResultCardinality resultCardinality)
+        ResultCardinality resultCardinality,
+        MongoPipelineFactory? nativeFactory,
+        bool streaming)
     {
-        var (mongoQueryContext, executableQuery) = TranslateQuery<TSource>(
+        var (mongoQueryContext, executableQuery) = TranslateQuery<TEntity>(
             queryContext, entityType, bsonSerializerFactory, queryExpression, resultCardinality,
+            nativeFactory, streaming,
             (translator, expression) => translator.Translate(expression, resultCardinality));
 
-        return new QueryingEnumerable<BsonDocument, TResult>(
+        return new QueryingEnumerable<TSource, TResult>(
             mongoQueryContext,
             executableQuery,
             shaper,
@@ -430,6 +670,7 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
     {
         var (_, executableQuery) = TranslateQuery<TSource>(
             queryContext, entityType, bsonSerializerFactory, nonQuery.SourceQuery, ResultCardinality.Enumerable,
+            nativeFactory: null, streaming: false,
             (translator, expression) =>
                 translator.Translate(MongoNonQueryExpression.UnwrapBulkOperator(expression)!, ResultCardinality.Enumerable));
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -15,12 +15,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Infrastructure;
@@ -89,6 +91,33 @@ public class MongoClientWrapper : IMongoClientWrapper
 
         if (executableQuery.Cardinality != ResultCardinality.Enumerable)
             return ExecuteScalar<T>(executableQuery);
+
+        if (executableQuery.NativePipeline is { } stages)
+        {
+            // The native pipeline is already known here, so set the log action before issuing the aggregate.
+            // This mirrors the driver-LINQ path (whose stages are captured at build time) and ensures the MQL
+            // is logged even when execution against the server throws. Unlike the driver-LINQ path, the native
+            // stages are logged directly (the driver Provider was never asked to translate, so its LoggedStages
+            // would be empty) — this surfaces the real $match/$sort/$lookup pipeline in the MQL log.
+            var loggedStages = stages as BsonDocument[] ?? stages.ToArray();
+            log = () => _commandLogger.ExecutedMqlQuery(executableQuery.CollectionNamespace, loggedStages);
+            if (executableQuery.Streaming)
+            {
+                var rawCollection = Database.GetCollection<RawBsonDocument>(executableQuery.CollectionNamespace.CollectionName);
+                PipelineDefinition<RawBsonDocument, RawBsonDocument> rawPipeline = loggedStages;
+                var rawCursor = executableQuery.Session is { } rawSession
+                    ? rawCollection.Aggregate(rawSession, rawPipeline)
+                    : rawCollection.Aggregate(rawPipeline);
+                return (IEnumerable<T>)rawCursor.ToEnumerable();
+            }
+
+            var collection = Database.GetCollection<BsonDocument>(executableQuery.CollectionNamespace.CollectionName);
+            PipelineDefinition<BsonDocument, BsonDocument> pipeline = loggedStages;
+            var cursor = executableQuery.Session is { } session
+                ? collection.Aggregate(session, pipeline)
+                : collection.Aggregate(pipeline);
+            return (IEnumerable<T>)cursor.ToEnumerable();
+        }
 
         var queryable = executableQuery.Provider.CreateQuery<T>(executableQuery.Query);
         log = () => _commandLogger.ExecutedMqlQuery(executableQuery);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeCombinationQueryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeCombinationQueryTests.cs
@@ -1,0 +1,183 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-323 end-to-end coverage of the canonical multi-key + paging native shape:
+/// <c>Where(predicate).OrderBy(A).ThenByDescending(B).Skip(skip).Take(take)</c> (and the inverse
+/// direction). Most existing native-gate coverage probes a single operator at a time; this exercises
+/// the full filter → multi-key sort → skip → limit pipeline in one query.
+/// <para>
+/// The data is seeded with deliberately-tied primary sort keys so the secondary key is load-bearing:
+/// if the native pipeline dropped or reordered the <c>ThenBy</c> stage the asserted order would change.
+/// <c>skip</c>/<c>take</c> are captured variables, so they bind as query parameters (compiled-query path).
+/// </para>
+/// Each shape is asserted three ways: (1) under <see cref="MongoQueryMode.NativeOnly"/> it must succeed —
+/// proving it went native rather than falling back — AND return the exact expected order; (2) under
+/// <see cref="MongoQueryMode.Native"/> and (3) <see cref="MongoQueryMode.DriverLinq"/> it returns the
+/// identical ordered sequence (parity).
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class NativeCombinationQueryTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Item
+    {
+        public ObjectId Id { get; set; }
+        public string Label { get; set; } = "";
+        public int A { get; set; }
+        public int B { get; set; }
+        public bool Active { get; set; }
+    }
+
+    // Seed rows where the primary key A is heavily tied, so ThenBy(B) decides the order within a group.
+    // Labels are unique and used as the distinguishing field for ordered comparison.
+    //
+    // Active rows (Active == true), grouped by A then by B:
+    //   A=1: B=30 "a1b30", B=10 "a1b10", B=20 "a1b20"
+    //   A=2: B=15 "a2b15", B=5  "a2b5"
+    //   A=3: B=7  "a3b7"
+    // Plus inactive rows that the predicate must exclude.
+    private IMongoCollection<Item> Seed(string name)
+    {
+        var collectionName = TemporaryDatabaseFixtureBase.CreateCollectionName(name) + Guid.NewGuid().ToString("N")[..8];
+        var bson = database.MongoDatabase.GetCollection<BsonDocument>(collectionName);
+
+        BsonDocument Row(string label, int a, int b, bool active) => new()
+        {
+            { "_id", ObjectId.GenerateNewId() }, { "Label", label }, { "A", a }, { "B", b }, { "Active", active }
+        };
+
+        // Insert in an order that is NOT the target sort order, so a missing sort stage would be detected.
+        bson.InsertMany([
+            Row("a1b10", 1, 10, true),
+            Row("a2b5", 2, 5, true),
+            Row("a1b30", 1, 30, true),
+            Row("dead1", 1, 99, false), // excluded by predicate
+            Row("a3b7", 3, 7, true),
+            Row("a1b20", 1, 20, true),
+            Row("a2b15", 2, 15, true),
+            Row("dead2", 2, 99, false), // excluded by predicate
+        ]);
+        return database.MongoDatabase.GetCollection<Item>(collectionName);
+    }
+
+    private SingleEntityDbContext<Item> CreateContext(IMongoCollection<Item> collection, MongoQueryMode mode)
+        => SingleEntityDbContext.Create(
+            collection,
+            optionsBuilderAction: b =>
+            {
+                b.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+                new MongoDbContextOptionsBuilder(b).UseQueryMode(mode);
+            });
+
+    // ── Ascending-then-descending: OrderBy(A).ThenByDescending(B) ─────────────────────────────────
+
+    [Fact]
+    public void Asc_then_desc_with_paging_goes_native_with_correct_order_and_parity()
+    {
+        var collection = Seed(nameof(Asc_then_desc_with_paging_goes_native_with_correct_order_and_parity));
+
+        // Full active set ordered by A asc, then B desc:
+        //   A=1: B30,B20,B10 → a1b30, a1b20, a1b10
+        //   A=2: B15,B5       → a2b15, a2b5
+        //   A=3: B7           → a3b7
+        // => [a1b30, a1b20, a1b10, a2b15, a2b5, a3b7]
+        // Skip(1).Take(3) => [a1b20, a1b10, a2b15]
+        var skip = 1;
+        var take = 3;
+        var expected = new[] { "a1b20", "a1b10", "a2b15" };
+
+        List<string> RunAscDesc(MongoQueryMode mode)
+        {
+            using var db = CreateContext(collection, mode);
+            return db.Entities
+                .Where(x => x.Active)
+                .OrderBy(x => x.A)
+                .ThenByDescending(x => x.B)
+                .Skip(skip)
+                .Take(take)
+                .ToList()
+                .Select(x => x.Label)
+                .ToList();
+        }
+
+        // (1) NativeOnly must succeed (goes native, no fallback) AND return the exact order.
+        var nativeOnly = RunAscDesc(MongoQueryMode.NativeOnly);
+        Assert.Equal(expected, nativeOnly);
+
+        // (2)/(3) Parity: Native and DriverLinq return the same ordered results.
+        var native = RunAscDesc(MongoQueryMode.Native);
+        var driver = RunAscDesc(MongoQueryMode.DriverLinq);
+        Assert.Equal(expected, native);
+        Assert.Equal(expected, driver);
+        Assert.Equal(driver, native);
+        Assert.Equal(driver, nativeOnly);
+    }
+
+    // ── Descending-then-ascending: OrderByDescending(A).ThenBy(B) ─────────────────────────────────
+
+    [Fact]
+    public void Desc_then_asc_with_paging_goes_native_with_correct_order_and_parity()
+    {
+        var collection = Seed(nameof(Desc_then_asc_with_paging_goes_native_with_correct_order_and_parity));
+
+        // Full active set ordered by A desc, then B asc:
+        //   A=3: B7            → a3b7
+        //   A=2: B5,B15        → a2b5, a2b15
+        //   A=1: B10,B20,B30   → a1b10, a1b20, a1b30
+        // => [a3b7, a2b5, a2b15, a1b10, a1b20, a1b30]
+        // Skip(2).Take(3) => [a2b15, a1b10, a1b20]
+        var skip = 2;
+        var take = 3;
+        var expected = new[] { "a2b15", "a1b10", "a1b20" };
+
+        List<string> RunDescAsc(MongoQueryMode mode)
+        {
+            using var db = CreateContext(collection, mode);
+            return db.Entities
+                .Where(x => x.Active)
+                .OrderByDescending(x => x.A)
+                .ThenBy(x => x.B)
+                .Skip(skip)
+                .Take(take)
+                .ToList()
+                .Select(x => x.Label)
+                .ToList();
+        }
+
+        var nativeOnly = RunDescAsc(MongoQueryMode.NativeOnly);
+        Assert.Equal(expected, nativeOnly);
+
+        var native = RunDescAsc(MongoQueryMode.Native);
+        var driver = RunDescAsc(MongoQueryMode.DriverLinq);
+        Assert.Equal(expected, native);
+        Assert.Equal(expected, driver);
+        Assert.Equal(driver, native);
+        Assert.Equal(driver, nativeOnly);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeGateRoutingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeGateRoutingTests.cs
@@ -1,0 +1,390 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-323 native-gate <b>parity</b> regression tests. Each test probes the branch's real risk class —
+/// <em>mis-routing</em>: the compile-time gate claiming a query is native-eligible when the native
+/// pipeline cannot faithfully reproduce the driver-LINQ semantics.
+/// <para>
+/// Every shape is exercised three ways:
+/// <list type="number">
+///   <item><b>Parity</b> — run the SAME query under <see cref="MongoQueryMode.Native"/> and under
+///   <see cref="MongoQueryMode.DriverLinq"/>; assert the results are equal (catches a divergence whether
+///   the query went native or fell back).</item>
+///   <item><b>Routing probe</b> — run it under <see cref="MongoQueryMode.NativeOnly"/> and assert whichever
+///   is the actual current behavior (succeeds = went native; throws
+///   <see cref="NativeTranslationNotSupportedException"/> = fell back), documenting + locking the routing.</item>
+/// </list>
+/// </para>
+/// MQL shape cannot prove a query went native (native and driver-LINQ filter/sort/paging pipelines are
+/// structurally identical), so <see cref="MongoQueryMode.NativeOnly"/> is the only reliable routing signal.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class NativeGateRoutingTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    // ── Shared helpers ────────────────────────────────────────────────────────────────────────────
+
+    private static SingleEntityDbContext<T> CreateContext<T>(
+        IMongoCollection<T> collection, MongoQueryMode mode, Action<ModelBuilder>? modelBuilderAction = null)
+        where T : class
+        => SingleEntityDbContext.Create(
+            collection,
+            modelBuilderAction: modelBuilderAction,
+            optionsBuilderAction: b =>
+            {
+                b.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+                new MongoDbContextOptionsBuilder(b).UseQueryMode(mode);
+            });
+
+    /// <summary>
+    /// Runs <paramref name="query"/> under <see cref="MongoQueryMode.Native"/> and under
+    /// <see cref="MongoQueryMode.DriverLinq"/> against the same collection and asserts the two
+    /// result sequences are equal (order-sensitive). This is the core mis-routing check.
+    /// </summary>
+    private void AssertParity<T, TResult>(
+        IMongoCollection<T> collection,
+        Func<IQueryable<T>, IEnumerable<TResult>> query,
+        Action<ModelBuilder>? modelBuilderAction = null)
+        where T : class
+    {
+        List<TResult> native;
+        using (var db = CreateContext(collection, MongoQueryMode.Native, modelBuilderAction))
+            native = query(db.Entities).ToList();
+
+        List<TResult> driver;
+        using (var db = CreateContext(collection, MongoQueryMode.DriverLinq, modelBuilderAction))
+            driver = query(db.Entities).ToList();
+
+        Assert.Equal(driver, native);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="query"/> under <see cref="MongoQueryMode.NativeOnly"/> and reports whether it
+    /// went native (returns <see langword="true"/>) or fell back (throws
+    /// <see cref="NativeTranslationNotSupportedException"/>, returns <see langword="false"/>).
+    /// </summary>
+    private bool WentNative<T, TResult>(
+        IMongoCollection<T> collection,
+        Func<IQueryable<T>, IEnumerable<TResult>> query,
+        Action<ModelBuilder>? modelBuilderAction = null)
+        where T : class
+    {
+        using var db = CreateContext(collection, MongoQueryMode.NativeOnly, modelBuilderAction);
+        try
+        {
+            _ = query(db.Entities).ToList();
+            return true;
+        }
+        catch (NativeTranslationNotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private string UniqueCollectionName(string name)
+        => TemporaryDatabaseFixtureBase.CreateCollectionName(name) + Guid.NewGuid().ToString("N")[..8];
+
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+    //  Shape A — value-converter / BsonRepresentation-backed properties in Where / OrderBy
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+
+    // A.1 — string property stored as ObjectId via [BsonRepresentation] / HasBsonRepresentation.
+    //       The native renderer must serialize the string constant through the property serializer so it
+    //       becomes an ObjectId in the $match (not a string), matching driver-LINQ.
+
+    private class StringIdEntity
+    {
+        public ObjectId Id { get; set; }
+        public string StringId { get; set; } = "";
+        public string Name { get; set; } = "";
+    }
+
+    private IMongoCollection<StringIdEntity> SeedStringId(string name, out string targetStringId)
+    {
+        var coll = database.MongoDatabase.GetCollection<BsonDocument>(UniqueCollectionName(name));
+        var target = ObjectId.GenerateNewId();
+        targetStringId = target.ToString();
+        coll.InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "StringId", target }, { "Name", "Alice" } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "StringId", ObjectId.GenerateNewId() }, { "Name", "Bob" } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "StringId", ObjectId.GenerateNewId() }, { "Name", "Carol" } },
+        ]);
+        return database.MongoDatabase.GetCollection<StringIdEntity>(coll.CollectionNamespace.CollectionName);
+    }
+
+    private static readonly Action<ModelBuilder> StringIdModel = mb =>
+        mb.Entity<StringIdEntity>().Property(e => e.StringId).HasBsonRepresentation(BsonType.ObjectId);
+
+    [Fact]
+    public void A_string_as_objectId_where_equals_parity()
+    {
+        var collection = SeedStringId(nameof(A_string_as_objectId_where_equals_parity), out var target);
+        AssertParity(collection, q => q.Where(e => e.StringId == target).Select(e => e.Name), StringIdModel);
+    }
+
+    [Fact]
+    public void A_string_as_objectId_where_equals_routing()
+    {
+        var collection = SeedStringId(nameof(A_string_as_objectId_where_equals_routing), out var target);
+        // Locked routing: a string-as-ObjectId equality predicate over the whole entity goes native.
+        Assert.True(WentNative(collection, q => q.Where(e => e.StringId == target).ToList(), StringIdModel));
+    }
+
+    // A.2 — enum stored as string via HasConversion<string>(), in Where and OrderBy.
+
+    private enum Status { Active, Suspended, Closed }
+
+    private class EnumEntity
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+        public Status Status { get; set; }
+    }
+
+    private IMongoCollection<EnumEntity> SeedEnum(string name)
+    {
+        var coll = database.MongoDatabase.GetCollection<BsonDocument>(UniqueCollectionName(name));
+        coll.InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Alice" }, { "Status", "Active" } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Bob" }, { "Status", "Closed" } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Carol" }, { "Status", "Suspended" } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Dave" }, { "Status", "Active" } },
+        ]);
+        return database.MongoDatabase.GetCollection<EnumEntity>(coll.CollectionNamespace.CollectionName);
+    }
+
+    private static readonly Action<ModelBuilder> EnumModel = mb =>
+        mb.Entity<EnumEntity>().Property(e => e.Status).HasConversion<string>();
+
+    [Fact]
+    public void A_enum_as_string_where_equals_parity()
+    {
+        var collection = SeedEnum(nameof(A_enum_as_string_where_equals_parity));
+        AssertParity(collection,
+            q => q.Where(e => e.Status == Status.Active).OrderBy(e => e.Name).Select(e => e.Name), EnumModel);
+    }
+
+    [Fact]
+    public void A_enum_as_string_order_by_parity()
+    {
+        var collection = SeedEnum(nameof(A_enum_as_string_order_by_parity));
+        // OrderBy a string-converted enum: native sorts on the stored string ("Active" < "Closed" < "Suspended"),
+        // which must match the driver-LINQ ordering. ThenBy Name to make the order deterministic for ties.
+        AssertParity(collection,
+            q => q.OrderBy(e => e.Status).ThenBy(e => e.Name).Select(e => e.Name), EnumModel);
+    }
+
+    [Fact]
+    public void A_enum_as_string_where_equals_routing()
+    {
+        var collection = SeedEnum(nameof(A_enum_as_string_where_equals_routing));
+        // Locked routing: an enum equality predicate falls BACK to driver-LINQ. EF emits the comparison as
+        // `(int)e.Status == (int)Status.Active`, i.e. a Convert of the member to the enum's underlying type;
+        // MongoExpressionTranslator.HasNumericConvert treats that cast as semantically significant and refuses
+        // the shape (conservative — worst case is a fallback, never a wrong result). Parity holds via fallback
+        // (see A_enum_as_string_where_equals_parity).
+        Assert.False(WentNative(collection, q => q.Where(e => e.Status == Status.Active).ToList(), EnumModel));
+    }
+
+    [Fact]
+    public void A_enum_as_string_order_by_routing()
+    {
+        var collection = SeedEnum(nameof(A_enum_as_string_order_by_routing));
+        Assert.True(WentNative(collection,
+            q => q.OrderBy(e => e.Status).ThenBy(e => e.Name).ToList(), EnumModel));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+    //  Shape B — owned / nested navigation sub-property predicate (e.Address.City)
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+
+    private class PersonWithAddress
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+        public Address Address { get; set; } = null!;
+    }
+
+    private class Address
+    {
+        public string City { get; set; } = "";
+        public string Zip { get; set; } = "";
+    }
+
+    private IMongoCollection<PersonWithAddress> SeedAddress(string name)
+    {
+        var coll = database.MongoDatabase.GetCollection<BsonDocument>(UniqueCollectionName(name));
+        coll.InsertMany([
+            new BsonDocument
+            {
+                { "_id", ObjectId.GenerateNewId() }, { "Name", "Alice" },
+                { "Address", new BsonDocument { { "City", "NYC" }, { "Zip", "10001" } } }
+            },
+            new BsonDocument
+            {
+                { "_id", ObjectId.GenerateNewId() }, { "Name", "Bob" },
+                { "Address", new BsonDocument { { "City", "LA" }, { "Zip", "90001" } } }
+            },
+            new BsonDocument
+            {
+                { "_id", ObjectId.GenerateNewId() }, { "Name", "Carol" },
+                { "Address", new BsonDocument { { "City", "NYC" }, { "Zip", "10002" } } }
+            },
+        ]);
+        return database.MongoDatabase.GetCollection<PersonWithAddress>(coll.CollectionNamespace.CollectionName);
+    }
+
+    private static readonly Action<ModelBuilder> AddressModel = mb =>
+        mb.Entity<PersonWithAddress>().OwnsOne(p => p.Address);
+
+    [Fact]
+    public void B_owned_subproperty_where_equals_parity()
+    {
+        var collection = SeedAddress(nameof(B_owned_subproperty_where_equals_parity));
+        AssertParity(collection,
+            q => q.Where(e => e.Address.City == "NYC").OrderBy(e => e.Name).Select(e => e.Name), AddressModel);
+    }
+
+    [Fact]
+    public void B_owned_subproperty_order_by_parity()
+    {
+        var collection = SeedAddress(nameof(B_owned_subproperty_order_by_parity));
+        AssertParity(collection,
+            q => q.OrderBy(e => e.Address.City).ThenBy(e => e.Name).Select(e => e.Name), AddressModel);
+    }
+
+    [Fact]
+    public void B_owned_subproperty_where_equals_routing()
+    {
+        var collection = SeedAddress(nameof(B_owned_subproperty_where_equals_routing));
+        // Locked routing: an owned sub-property predicate is NOT natively representable (the translator
+        // only resolves members rooted directly on the parameter), so it falls back to driver-LINQ.
+        Assert.False(WentNative(collection, q => q.Where(e => e.Address.City == "NYC").ToList(), AddressModel));
+    }
+
+    [Fact]
+    public void B_owned_subproperty_order_by_routing()
+    {
+        var collection = SeedAddress(nameof(B_owned_subproperty_order_by_routing));
+        Assert.False(WentNative(collection,
+            q => q.OrderBy(e => e.Address.City).ThenBy(e => e.Name).ToList(), AddressModel));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+    //  Shape C — TPH discriminator filtering
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+    //  Highest mis-routing risk: if the native pipeline drops the implicit discriminator $match for a
+    //  derived-type query, it returns sibling-type rows.
+
+    private class Animal
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private class Cat : Animal
+    {
+        public int Whiskers { get; set; }
+    }
+
+    private class Dog : Animal
+    {
+        public string Breed { get; set; } = "";
+    }
+
+    private IMongoCollection<Animal> SeedTph(string name)
+    {
+        var coll = database.MongoDatabase.GetCollection<BsonDocument>(UniqueCollectionName(name));
+        coll.InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "_t", "Cat" }, { "Name", "Felix" }, { "Whiskers", 12 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "_t", "Dog" }, { "Name", "Rex" }, { "Breed", "Lab" } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "_t", "Cat" }, { "Name", "Whiskers" }, { "Whiskers", 8 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "_t", "Dog" }, { "Name", "Felix" }, { "Breed", "Pug" } },
+        ]);
+        return database.MongoDatabase.GetCollection<Animal>(coll.CollectionNamespace.CollectionName);
+    }
+
+    private static readonly Action<ModelBuilder> TphModel = mb =>
+    {
+        mb.Entity<Animal>().HasDiscriminator<string>("_t")
+            .HasValue<Animal>("Animal")
+            .HasValue<Cat>("Cat")
+            .HasValue<Dog>("Dog");
+        mb.Entity<Cat>();
+        mb.Entity<Dog>();
+    };
+
+    [Fact]
+    public void C_tph_base_predicate_parity()
+    {
+        var collection = SeedTph(nameof(C_tph_base_predicate_parity));
+        // Query over the base set with a predicate: the base set returns ALL discriminator values, so the
+        // only filter is on Name. Both "Felix" rows (one Cat, one Dog) must come back, in the same order.
+        // Materialize whole entities (a server-side projection of GetType()/string-concat is not supported on
+        // either path) and compute the type tag client-side so the comparison still distinguishes Cat from Dog.
+        AssertParity(collection,
+            q => q.Where(b => b.Name == "Felix").OrderBy(b => b.Id).AsEnumerable()
+                .Select(b => b.Name + ":" + b.GetType().Name),
+            TphModel);
+    }
+
+    [Fact]
+    public void C_tph_base_predicate_routing()
+    {
+        var collection = SeedTph(nameof(C_tph_base_predicate_routing));
+        // Locked routing: a base-set predicate carries no implicit discriminator, so the native $match on
+        // Name is faithful — it goes native.
+        Assert.True(WentNative(collection,
+            q => q.Where(b => b.Name == "Felix").OrderBy(b => b.Id).ToList(), TphModel));
+    }
+
+    [Fact]
+    public void C_tph_oftype_derived_parity()
+    {
+        var collection = SeedTph(nameof(C_tph_oftype_derived_parity));
+        // OfType<Cat>() narrows by the implicit discriminator predicate. If the native pipeline dropped that
+        // predicate it would return Dog rows (and the shaper would mis-materialize). Parity must hold: only
+        // the two Cats come back, never a Dog. Compute the projection client-side (AsEnumerable) so the test
+        // probes routing/discriminator correctness, not server-side projection support.
+        AssertParity(collection,
+            q => q.OfType<Cat>().OrderBy(c => c.Name).AsEnumerable().Select(c => c.Name + ":" + c.Whiskers),
+            TphModel);
+    }
+
+    [Fact]
+    public void C_tph_oftype_derived_routing()
+    {
+        var collection = SeedTph(nameof(C_tph_oftype_derived_routing));
+        // Locked routing: OfType<TDerived>() explicitly marks IsNativeRepresentable=false (the discriminator
+        // narrowing is applied by the driver-LINQ path, not the native Predicate slot), so it falls back.
+        Assert.False(WentNative(collection,
+            q => q.OfType<Cat>().OrderBy(c => c.Name).ToList(), TphModel));
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeMaterializerNullabilityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeMaterializerNullabilityTests.cs
@@ -1,0 +1,275 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-323 streaming-materializer nullability/missing regression tests. The streaming materializer
+/// (<c>MongoStreamingEntityMaterializerRewriter</c>) must match the driver-LINQ entity-materialization
+/// semantics — the oracle — for schema-drifted documents:
+/// <list type="bullet">
+///   <item>a document MISSING a required non-nullable scalar element → throw
+///   <see cref="InvalidOperationException"/> (Bug 1, matching <c>BsonBinding</c>);</item>
+///   <item>a document with an explicit BSON <c>null</c> on a non-nullable property → materialize
+///   <c>default(T)</c> (Bug 2).</item>
+/// </list>
+/// Queries use <c>.ToList()</c> (<see cref="Microsoft.EntityFrameworkCore.Query.ResultCardinality.Enumerable"/>)
+/// so the streaming materializer is genuinely exercised (scalar-cardinality operators such as
+/// <c>.Single()</c> are never streaming-eligible and would silently take the DOM path). Each case is run
+/// under <see cref="MongoQueryMode.Native"/> and <see cref="MongoQueryMode.DriverLinq"/> and asserted equal
+/// (parity), and the flat-entity shape is confirmed to genuinely go native via <see cref="MongoQueryMode.NativeOnly"/>.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class NativeMaterializerNullabilityTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Scored
+    {
+        public ObjectId Id { get; set; }
+        public int Score { get; set; }       // required non-nullable scalar
+        public int? Bonus { get; set; }       // nullable scalar
+    }
+
+    private class WithOwned
+    {
+        public ObjectId Id { get; set; }
+        public Stats Stats { get; set; } = null!;
+    }
+
+    private class Stats
+    {
+        public int Score { get; set; }        // required non-nullable scalar on owned sub-document
+    }
+
+    private static SingleEntityDbContext<T> CreateContext<T>(
+        IMongoCollection<T> collection, MongoQueryMode mode, Action<ModelBuilder>? model = null)
+        where T : class
+        => SingleEntityDbContext.Create(
+            collection,
+            modelBuilderAction: model,
+            optionsBuilderAction: b =>
+            {
+                b.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+                new MongoDbContextOptionsBuilder(b).UseQueryMode(mode);
+            });
+
+    // ── Bug 1: missing required non-nullable scalar → throw InvalidOperationException ──────────────
+
+    [Fact]
+    public void Missing_required_scalar_throws_under_native_matching_driver()
+    {
+        var collection = database.CreateCollection<Scored>();
+        var raw = database.GetCollection<BsonDocument>(collection.CollectionNamespace);
+        // Document is MISSING the required "Score" element entirely.
+        raw.InsertOne(new BsonDocument { { "_id", ObjectId.GenerateNewId() } });
+
+        // Driver-LINQ (the oracle) throws InvalidOperationException with a specific message.
+        InvalidOperationException driverEx;
+        using (var driver = CreateContext(collection, MongoQueryMode.DriverLinq))
+        {
+            driverEx = Assert.Throws<InvalidOperationException>(() => driver.Entities.ToList());
+        }
+
+        // Native (streaming) must throw the same type AND the same message (some spec tests assert it).
+        InvalidOperationException nativeEx;
+        using (var native = CreateContext(collection, MongoQueryMode.Native))
+        {
+            nativeEx = Assert.Throws<InvalidOperationException>(() => native.Entities.ToList());
+        }
+
+        Assert.Equal(driverEx.Message, nativeEx.Message);
+
+        // And it must genuinely go native (not silently fall back to DOM).
+        using (var nativeOnly = CreateContext(collection, MongoQueryMode.NativeOnly))
+        {
+            Assert.Throws<InvalidOperationException>(() => nativeOnly.Entities.ToList());
+        }
+    }
+
+    // ── Bug 2: explicit BSON null on a non-nullable scalar → default(T) ───────────────────────────
+
+    [Fact]
+    public void Explicit_null_on_non_nullable_scalar_materializes_default_matching_driver()
+    {
+        var collection = database.CreateCollection<Scored>();
+        var raw = database.GetCollection<BsonDocument>(collection.CollectionNamespace);
+        // "Score" is present but explicitly BSON null.
+        raw.InsertOne(new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Score", BsonNull.Value } });
+
+        int driverScore;
+        using (var driver = CreateContext(collection, MongoQueryMode.DriverLinq))
+        {
+            driverScore = driver.Entities.ToList().Single().Score;
+        }
+
+        int nativeScore;
+        using (var native = CreateContext(collection, MongoQueryMode.Native))
+        {
+            nativeScore = native.Entities.ToList().Single().Score;
+        }
+
+        Assert.Equal(default, driverScore);
+        Assert.Equal(driverScore, nativeScore);
+    }
+
+    // Confirm the flat-entity Enumerable query genuinely goes streaming (NativeOnly succeeds → native path;
+    // a fallback would throw NativeTranslationNotSupportedException). Locks in that Bug 2 is exercised on the
+    // streaming materializer, not silently on the DOM path.
+    [Fact]
+    public void Explicit_null_on_non_nullable_scalar_goes_native()
+    {
+        var collection = database.CreateCollection<Scored>();
+        var raw = database.GetCollection<BsonDocument>(collection.CollectionNamespace);
+        raw.InsertOne(new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Score", BsonNull.Value } });
+
+        using var native = CreateContext(collection, MongoQueryMode.NativeOnly);
+        var score = native.Entities.ToList().Single().Score;
+        Assert.Equal(default, score);
+    }
+
+    // ── #3: present-but-null required is distinct from missing (this vs the Bug-1 test) ───────────
+
+    // ── Nullable scalar present-but-null still works (sanity / no regression) ─────────────────────
+
+    [Fact]
+    public void Explicit_null_on_nullable_scalar_materializes_null_matching_driver()
+    {
+        var collection = database.CreateCollection<Scored>();
+        var raw = database.GetCollection<BsonDocument>(collection.CollectionNamespace);
+        raw.InsertOne(new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Score", 7 }, { "Bonus", BsonNull.Value } });
+
+        int? driverBonus;
+        using (var driver = CreateContext(collection, MongoQueryMode.DriverLinq))
+        {
+            driverBonus = driver.Entities.ToList().Single().Bonus;
+        }
+
+        int? nativeBonus;
+        using (var native = CreateContext(collection, MongoQueryMode.Native))
+        {
+            nativeBonus = native.Entities.ToList().Single().Bonus;
+        }
+
+        Assert.Null(driverBonus);
+        Assert.Equal(driverBonus, nativeBonus);
+    }
+
+    // ── Happy path: complete document materializes correctly under both modes ─────────────────────
+
+    [Fact]
+    public void Complete_document_materializes_correctly_matching_driver()
+    {
+        var collection = database.CreateCollection<Scored>();
+        collection.InsertOne(new Scored { Id = ObjectId.GenerateNewId(), Score = 42, Bonus = 5 });
+
+        Scored driverEntity;
+        using (var driver = CreateContext(collection, MongoQueryMode.DriverLinq))
+        {
+            driverEntity = driver.Entities.ToList().Single();
+        }
+
+        Scored nativeEntity;
+        using (var native = CreateContext(collection, MongoQueryMode.Native))
+        {
+            nativeEntity = native.Entities.ToList().Single();
+        }
+
+        Assert.Equal(42, driverEntity.Score);
+        Assert.Equal(driverEntity.Score, nativeEntity.Score);
+        Assert.Equal(driverEntity.Bonus, nativeEntity.Bonus);
+    }
+
+    // ── Owned sub-property: missing required scalar on owned reference ────────────────────────────
+    //
+    // NOTE: at the EF-323 foundation an owned-reference query is NOT yet routed to the native/streaming
+    // path (the gate marks it non-representable and falls back to driver-LINQ even under Native mode — see
+    // Query/AGENTS.md "Reference Include is deferred"). So today these owned cases assert driver-LINQ↔native
+    // PARITY while both run the DOM/driver path. The streaming materializer's recursion still applies the
+    // same missing/null handling to owned sub-documents (RequiredPresence is built for every EntityPlan,
+    // including owned children, and BuildFillLoop(child) enforces it) — so when owned-reference streaming is
+    // enabled in a later sub-project these tests already pin the correct (parity) behavior.
+
+    [Fact]
+    public void Missing_required_scalar_on_owned_subdocument_matches_driver()
+    {
+        var collection = database.CreateCollection<WithOwned>();
+        var raw = database.GetCollection<BsonDocument>(collection.CollectionNamespace);
+        // Owned "Stats" sub-document is present but MISSING its required "Score".
+        raw.InsertOne(new BsonDocument
+        {
+            { "_id", ObjectId.GenerateNewId() },
+            { "Stats", new BsonDocument() }
+        });
+
+        Action<ModelBuilder> model = mb => mb.Entity<WithOwned>().OwnsOne(e => e.Stats);
+
+        Exception? driverEx = Record.Exception(() =>
+        {
+            using var driver = CreateContext(collection, MongoQueryMode.DriverLinq, model);
+            _ = driver.Entities.ToList();
+        });
+
+        Exception? nativeEx = Record.Exception(() =>
+        {
+            using var native = CreateContext(collection, MongoQueryMode.Native, model);
+            _ = native.Entities.ToList();
+        });
+
+        // Parity: native must match driver-LINQ — same throw-or-not, same type if thrown.
+        Assert.Equal(driverEx?.GetType(), nativeEx?.GetType());
+    }
+
+    [Fact]
+    public void Explicit_null_required_scalar_on_owned_subdocument_matches_driver()
+    {
+        var collection = database.CreateCollection<WithOwned>();
+        var raw = database.GetCollection<BsonDocument>(collection.CollectionNamespace);
+        // Owned "Stats.Score" present but explicit BSON null.
+        raw.InsertOne(new BsonDocument
+        {
+            { "_id", ObjectId.GenerateNewId() },
+            { "Stats", new BsonDocument { { "Score", BsonNull.Value } } }
+        });
+
+        Action<ModelBuilder> model = mb => mb.Entity<WithOwned>().OwnsOne(e => e.Stats);
+
+        int? driverScore = null;
+        Exception? driverEx = Record.Exception(() =>
+        {
+            using var driver = CreateContext(collection, MongoQueryMode.DriverLinq, model);
+            driverScore = driver.Entities.ToList().Single().Stats.Score;
+        });
+
+        int? nativeScore = null;
+        Exception? nativeEx = Record.Exception(() =>
+        {
+            using var native = CreateContext(collection, MongoQueryMode.Native, model);
+            nativeScore = native.Entities.ToList().Single().Stats.Score;
+        });
+
+        Assert.Equal(driverEx?.GetType(), nativeEx?.GetType());
+        Assert.Equal(driverScore, nativeScore);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativePipelineExecutionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativePipelineExecutionTests.cs
@@ -1,0 +1,87 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using MongoDB.EntityFrameworkCore.Query;
+using MongoDB.EntityFrameworkCore.Storage;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+[XUnitCollection("QueryTests")]
+public class NativePipelineExecutionTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Customer
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+        public int Score { get; set; }
+    }
+
+    [Fact]
+    public void NativePipeline_match_stage_returns_correct_BsonDocuments()
+    {
+        // Arrange: seed a collection with a few entities
+        var collection = database.CreateCollection<Customer>();
+        collection.InsertMany([
+            new Customer { Id = ObjectId.GenerateNewId(), Name = "Alice", Score = 10 },
+            new Customer { Id = ObjectId.GenerateNewId(), Name = "Bob",   Score = 20 },
+            new Customer { Id = ObjectId.GenerateNewId(), Name = "Carol", Score = 30 },
+        ]);
+
+        using var db = SingleEntityDbContext.Create(collection);
+
+        // Obtain IMongoClientWrapper from the context's service provider
+        var clientWrapper = db.GetService<IMongoClientWrapper>();
+        var collectionNamespace = collection.CollectionNamespace;
+
+        // Build a placeholder Provider/Query from collection.AsQueryable() — the native path does
+        // not use them, but MongoExecutableQuery's constructor requires non-null values.
+        var bsonCollection = database.MongoDatabase.GetCollection<BsonDocument>(collectionNamespace.CollectionName);
+        var queryable = bsonCollection.AsQueryable();
+        var provider = (IMongoQueryProvider)queryable.Provider;
+        Expression placeholderQuery = queryable.Expression;
+
+        var nativePipeline = new[] { BsonDocument.Parse("{ $match: { Score: { $gt: 15 } } }") };
+
+        var executableQuery = new MongoExecutableQuery(
+            placeholderQuery,
+            ResultCardinality.Enumerable,
+            provider,
+            collectionNamespace,
+            new ReadOnlyDictionary<string, object>(new Dictionary<string, object>()))
+        {
+            NativePipeline = nativePipeline,
+            Streaming = false,
+        };
+
+        // Act
+        var results = clientWrapper.Execute<BsonDocument>(executableQuery, out _).ToList();
+
+        // Assert: only Bob (20) and Carol (30) have Score > 15
+        Assert.Equal(2, results.Count);
+        Assert.All(results, doc => Assert.True(doc["Score"].AsInt32 > 15));
+        Assert.Contains(results, doc => doc["Name"].AsString == "Bob");
+        Assert.Contains(results, doc => doc["Name"].AsString == "Carol");
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeTransactionAndCancellationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NativeTransactionAndCancellationTests.cs
@@ -1,0 +1,182 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-323 coverage for the native query path in two runtime contexts that the unit/MQL-shape tests
+/// cannot exercise:
+/// <list type="bullet">
+///   <item><b>Inside an explicit transaction.</b> A native query run while a <see cref="IDbContextTransaction"/>
+///   is open must bind the ambient driver session, so it sees the transaction's view and returns the correct
+///   rows. Asserted under <see cref="MongoQueryMode.Native"/>, with a parity check against
+///   <see cref="MongoQueryMode.DriverLinq"/> inside a transaction.</item>
+///   <item><b>Async cancellation mid-stream.</b> The native enumerator must observe a cancelled
+///   <see cref="CancellationToken"/> per <c>MoveNext</c>, so a token cancelled partway through async
+///   enumeration stops the stream with an <see cref="OperationCanceledException"/>.</item>
+/// </list>
+/// Both require a replica set; the <c>mongodb/mongodb-atlas-local</c> testcontainer provides a single-node
+/// replica set (transactions enabled).
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class NativeTransactionAndCancellationTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Item
+    {
+        public ObjectId Id { get; set; }
+        public string Label { get; set; } = "";
+        public int Value { get; set; }
+    }
+
+    private IMongoCollection<Item> SeedRange(string name, int count)
+    {
+        var collectionName = TemporaryDatabaseFixtureBase.CreateCollectionName(name) + Guid.NewGuid().ToString("N")[..8];
+        var bson = database.MongoDatabase.GetCollection<BsonDocument>(collectionName);
+        var rows = Enumerable.Range(0, count).Select(i => new BsonDocument
+        {
+            { "_id", ObjectId.GenerateNewId() }, { "Label", $"L{i:D5}" }, { "Value", i }
+        }).ToList();
+        bson.InsertMany(rows);
+        return database.MongoDatabase.GetCollection<Item>(collectionName);
+    }
+
+    private SingleEntityDbContext<Item> CreateContext(IMongoCollection<Item> collection, MongoQueryMode mode)
+        => SingleEntityDbContext.Create(
+            collection,
+            optionsBuilderAction: b =>
+            {
+                b.ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+                new MongoDbContextOptionsBuilder(b).UseQueryMode(mode);
+            });
+
+    // ── (a) Native query executes correctly inside an explicit transaction ────────────────────────
+
+    [Fact]
+    public void Native_query_inside_transaction_returns_correct_rows_and_parity()
+    {
+        var collection = SeedRange(nameof(Native_query_inside_transaction_returns_correct_rows_and_parity), 6);
+
+        // Values 0..5; Where(Value >= 2) ordered ascending => L00002, L00003, L00004, L00005.
+        var expected = new[] { "L00002", "L00003", "L00004", "L00005" };
+
+        List<string> RunInTransaction(MongoQueryMode mode)
+        {
+            using var db = CreateContext(collection, mode);
+            using var tx = db.Database.BeginTransaction();
+            var result = db.Entities
+                .Where(x => x.Value >= 2)
+                .OrderBy(x => x.Value)
+                .ToList()
+                .Select(x => x.Label)
+                .ToList();
+            tx.Commit();
+            return result;
+        }
+
+        var native = RunInTransaction(MongoQueryMode.Native);
+        Assert.Equal(expected, native);
+
+        var driver = RunInTransaction(MongoQueryMode.DriverLinq);
+        Assert.Equal(expected, driver);
+        Assert.Equal(driver, native);
+    }
+
+    [Fact]
+    public void NativeOnly_query_inside_transaction_goes_native_and_returns_correct_rows()
+    {
+        var collection = SeedRange(nameof(NativeOnly_query_inside_transaction_goes_native_and_returns_correct_rows), 6);
+        var expected = new[] { "L00002", "L00003", "L00004", "L00005" };
+
+        using var db = CreateContext(collection, MongoQueryMode.NativeOnly);
+        using var tx = db.Database.BeginTransaction();
+
+        // Under NativeOnly a fallback would throw; success proves the native Aggregate ran against the
+        // ambient session inside the transaction.
+        var result = db.Entities
+            .Where(x => x.Value >= 2)
+            .OrderBy(x => x.Value)
+            .ToList()
+            .Select(x => x.Label)
+            .ToList();
+        tx.Commit();
+
+        Assert.Equal(expected, result);
+    }
+
+    // ── (b) Async cancellation mid-stream stops the native enumerator ─────────────────────────────
+
+    [Fact]
+    public async Task Native_async_enumeration_observes_cancellation_mid_stream()
+    {
+        // Seed enough rows that streaming yields incrementally and there is room to cancel partway.
+        const int rowCount = 5000;
+        var collection = SeedRange(nameof(Native_async_enumeration_observes_cancellation_mid_stream), rowCount);
+
+        await using var db = CreateContext(collection, MongoQueryMode.NativeOnly);
+        using var cts = new CancellationTokenSource();
+
+        var seen = 0;
+
+        async Task Enumerate()
+        {
+            await foreach (var item in db.Entities
+                               .Where(x => x.Value >= 0)
+                               .OrderBy(x => x.Value)
+                               .AsAsyncEnumerable()
+                               .WithCancellation(cts.Token))
+            {
+                seen++;
+                // Cancel partway through the stream. The native enumerator checks the token per MoveNext,
+                // so subsequent iterations must observe the cancellation and stop the stream.
+                if (seen == 10)
+                {
+                    cts.Cancel();
+                }
+            }
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(Enumerate);
+
+        // We cancelled at row 10; the stream must not have run to completion.
+        Assert.True(seen < rowCount, $"Stream ran to completion ({seen} rows) despite cancellation.");
+    }
+
+    [Fact]
+    public async Task Native_ToListAsync_honors_already_cancelled_token()
+    {
+        var collection = SeedRange(nameof(Native_ToListAsync_honors_already_cancelled_token), 100);
+
+        await using var db = CreateContext(collection, MongoQueryMode.NativeOnly);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => db.Entities.Where(x => x.Value >= 0).OrderBy(x => x.Value).ToListAsync(cts.Token));
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeGateIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeGateIncludeTests.cs
@@ -1,0 +1,146 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !EF8 && !EF9
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// Tests covering <c>Include</c> behavior under the EF-323 query-mode gate. Reference Includes are EF9+/EF10
+/// only, so this class is compiled out under EF8.
+/// </summary>
+/// <remarks>
+/// NOTE: Single-level reference Include is NOT yet native — native reference-Include is deferred to the
+/// Includes sub-project. Under <see cref="MongoQueryMode.Native"/> the provider falls back to the driver-LINQ
+/// LeftJoin path, which emits the characteristic <c>_outer</c> / <c>$$ROOT</c> / <c>_inner</c> pipeline shape
+/// rather than a native <c>_lookup_&lt;NavigationName&gt;</c> alias.
+/// </remarks>
+[XUnitCollection("QueryTests")]
+public class QueryModeGateIncludeTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Order
+    {
+        public ObjectId _id { get; set; }
+        public string OrderDescription { get; set; } = "";
+        public ObjectId CustomerId { get; set; }
+        public Customer Customer { get; set; } = null!;
+    }
+
+    private class Customer
+    {
+        public ObjectId _id { get; set; }
+        public string FullName { get; set; } = "";
+        public List<Order> Orders { get; set; } = [];
+    }
+
+    private class OrderCustomerDbContext : DbContext
+    {
+        private readonly string _orders;
+        private readonly string _customers;
+        private readonly List<string> _logs;
+
+        public DbSet<Order> Orders { get; set; } = null!;
+        public DbSet<Customer> Customers { get; set; } = null!;
+
+        public OrderCustomerDbContext(TemporaryDatabaseFixture db, string orders, string customers, List<string> logs)
+            : base(new DbContextOptionsBuilder<OrderCustomerDbContext>()
+                .UseMongoDB(db.Client, db.MongoDatabase.DatabaseNamespace.DatabaseName,
+                    o => o.UseQueryMode(MongoQueryMode.Native))
+                .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .LogTo(logs.Add)
+                .EnableSensitiveDataLogging()
+                .Options)
+        {
+            _orders = orders;
+            _customers = customers;
+            _logs = logs;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.ToCollection(_customers);
+                b.Property(c => c.FullName).HasElementName("name");
+                b.HasMany(c => c.Orders).WithOne(o => o.Customer).HasForeignKey(o => o.CustomerId);
+            });
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.ToCollection(_orders);
+                b.Property(o => o.OrderDescription).HasElementName("desc");
+                b.Property(o => o.CustomerId).HasElementName("cust_id");
+            });
+        }
+
+        private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime) => Interlocked.Increment(ref _count);
+        }
+    }
+
+    [Fact]
+    public void Reference_include_falls_back_to_driver_linq_under_Native_mode()
+    {
+        // Single-level reference Include is NOT yet native — native reference-Include is deferred to the
+        // Includes sub-project. Under MongoQueryMode.Native the provider falls back to the driver-LINQ
+        // LeftJoin path. This test verifies:
+        //   (a) The materialized result graph is correct (Customer navigation is populated).
+        //   (b) The emitted pipeline reflects the driver-LINQ shape (contains the $$ROOT / _outer / _inner
+        //       markers that characterise the LeftJoin path) and does NOT contain a native _lookup_ alias.
+        var customersName = TemporaryDatabaseFixtureBase.CreateCollectionName("GateCustomers") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("GateOrders") + Guid.NewGuid().ToString("N")[..8];
+
+        var customerId = ObjectId.GenerateNewId();
+        database.MongoDatabase.GetCollection<BsonDocument>(customersName).InsertOne(
+            new BsonDocument { { "_id", customerId }, { "name", "Alice" } });
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order 1" }, { "cust_id", customerId } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order 2" }, { "cust_id", customerId } },
+        ]);
+
+        var logs = new List<string>();
+        using var db = new OrderCustomerDbContext(database, ordersName, customersName, logs);
+
+        var orders = db.Orders.Include(o => o.Customer).OrderBy(o => o.OrderDescription).ToList();
+
+        // (a) Correct materialized graph: both orders have their Customer navigation populated.
+        Assert.Equal(2, orders.Count);
+        Assert.All(orders, o => Assert.NotNull(o.Customer));
+        Assert.All(orders, o => Assert.Equal("Alice", o.Customer.FullName));
+
+        // (b) Driver-LINQ LeftJoin shape: $$ROOT is projected as _outer, related documents collected as _inner.
+        //     This is distinct from the future native path which would use a _lookup_<NavigationName> alias.
+        var mql = Assert.Single(logs, l => l.Contains("Executed MQL query"));
+        Assert.Contains("$$ROOT", mql);      // driver projects principal rows as $$ROOT before joining
+        Assert.Contains("_outer", mql);      // LeftJoin wrapper field for principal document
+        Assert.Contains("_inner", mql);      // LeftJoin wrapper field for related document
+        Assert.DoesNotContain("_lookup_", mql);  // native path would use _lookup_<NavigationName> alias
+    }
+}
+#endif

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeGateTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeGateTests.cs
@@ -1,0 +1,284 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// End-to-end proof of the EF-323 compile-time native-vs-driver gate (Task 14). These are the first tests
+/// that actually execute native aggregation pipelines (not just assert the rendered MQL of the driver-LINQ
+/// path). Each test asserts results AND/OR the captured MQL shape via a <c>LogTo</c> sink with sensitive-data
+/// logging enabled (so bound parameter values appear in the logged pipeline).
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class QueryModeGateTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private class Customer
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+        public int Score { get; set; }
+    }
+
+    // ── Test fixtures ───────────────────────────────────────────────────────────────────────────
+
+    private (IMongoCollection<Customer> collection, List<string> logs) SeedCustomers(string name)
+    {
+        var collectionName = TemporaryDatabaseFixtureBase.CreateCollectionName(name) + Guid.NewGuid().ToString("N")[..8];
+        var bson = database.MongoDatabase.GetCollection<BsonDocument>(collectionName);
+        bson.InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Alice" }, { "Score", 10 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Bob" }, { "Score", 20 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Carol" }, { "Score", 30 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Name", "Dave" }, { "Score", 40 } },
+        ]);
+        return (database.MongoDatabase.GetCollection<Customer>(collectionName), []);
+    }
+
+    private SingleEntityDbContext<Customer> CreateContext(
+        IMongoCollection<Customer> collection, List<string> logs, MongoQueryMode mode)
+        => SingleEntityDbContext.Create(
+            collection,
+            optionsBuilderAction: b =>
+            {
+                b.LogTo(logs.Add)
+                    .EnableSensitiveDataLogging()
+                    .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+                new MongoDbContextOptionsBuilder(b).UseQueryMode(mode);
+            });
+
+    private static string Mql(List<string> logs)
+        => Assert.Single(logs, l => l.Contains("Executed MQL query"));
+
+    // ── 1. Native mode (default): filter renders a raw aggregation $match ─────────────────────────
+
+    [Fact]
+    public void Native_mode_filter_uses_native_match_pipeline()
+    {
+        var (collection, logs) = SeedCustomers(nameof(Native_mode_filter_uses_native_match_pipeline));
+        using var db = CreateContext(collection, logs, MongoQueryMode.Native);
+
+        var value = 15;
+        var results = db.Entities.Where(c => c.Score > value).OrderBy(c => c.Score).ToList();
+
+        Assert.Equal(["Bob", "Carol", "Dave"], results.Select(c => c.Name).ToArray());
+
+        var mql = Mql(logs);
+        // Native $match emitted by the renderer; NOT the driver-LINQ pipeline shape.
+        Assert.Contains("$match", mql);
+        Assert.Contains("\"Score\"", mql);
+        Assert.Contains("$gt", mql);
+    }
+
+    // ── 2. Parameterized across executions (compiled-query cache correctness) ─────────────────────
+
+    [Fact]
+    public void Native_parameterized_query_returns_correct_rows_for_each_value()
+    {
+        var (collection, logs) = SeedCustomers(nameof(Native_parameterized_query_returns_correct_rows_for_each_value));
+
+        // First execution: threshold 15 → Bob, Carol, Dave.
+        using (var db = CreateContext(collection, logs, MongoQueryMode.Native))
+        {
+            var threshold = 15;
+            var names = db.Entities.Where(c => c.Score > threshold).OrderBy(c => c.Score)
+                .Select(c => c.Name).ToList();
+            Assert.Equal(["Bob", "Carol", "Dave"], names.ToArray());
+        }
+
+        // Second execution of the same query shape with a different parameter value: threshold 25 → Carol, Dave.
+        using (var db = CreateContext(collection, logs, MongoQueryMode.Native))
+        {
+            var threshold = 25;
+            var names = db.Entities.Where(c => c.Score > threshold).OrderBy(c => c.Score)
+                .Select(c => c.Name).ToList();
+            Assert.Equal(["Carol", "Dave"], names.ToArray());
+        }
+    }
+
+    // ── 3. Sort + paging → native $sort / $skip / $limit ──────────────────────────────────────────
+    // Uses NativeOnly to distinguish native execution from driver-LINQ fallback: both paths emit
+    // $sort/$skip/$limit, so the MQL shape alone is not a reliable discriminator. Under NativeOnly,
+    // a fallback would throw; success proves the query executed natively.
+
+    [Fact]
+    public void Native_sort_skip_take_uses_native_pipeline()
+    {
+        var (collection, logs) = SeedCustomers(nameof(Native_sort_skip_take_uses_native_pipeline));
+        using var db = CreateContext(collection, logs, MongoQueryMode.NativeOnly);
+
+        // Under NativeOnly, this would throw before the fix; after the fix it succeeds.
+        var page = db.Entities.OrderBy(c => c.Score).Skip(1).Take(2).ToList();
+
+        Assert.Equal(["Bob", "Carol"], page.Select(c => c.Name).ToArray());
+    }
+
+    // ── 6. DriverLinq mode never goes native (even a representable Where) ─────────────────────────
+
+    [Fact]
+    public void DriverLinq_mode_never_uses_native_pipeline()
+    {
+        var (collection, logs) = SeedCustomers(nameof(DriverLinq_mode_never_uses_native_pipeline));
+        using var db = CreateContext(collection, logs, MongoQueryMode.DriverLinq);
+
+        var results = db.Entities.Where(c => c.Score > 15).OrderBy(c => c.Score).ToList();
+
+        // Results must still be correct via the driver-LINQ path.
+        Assert.Equal(["Bob", "Carol", "Dave"], results.Select(c => c.Name).ToArray());
+
+        // The driver-LINQ provider renders element names through the EF serializer; both paths emit $match,
+        // so the discriminating signal is behavioral: DriverLinq compiled a driver-LINQ shaper, asserted by
+        // the suite-wide zero-regression run. Here we simply confirm correctness and that MQL was logged.
+        var mql = Mql(logs);
+        Assert.Contains("aggregate", mql);
+    }
+
+    // ── 7. Native fallback: a non-representable query returns correct results via the driver path ──
+
+    [Fact]
+    public void Native_mode_falls_back_for_unrepresentable_query()
+    {
+        var (collection, logs) = SeedCustomers(nameof(Native_mode_falls_back_for_unrepresentable_query));
+        using var db = CreateContext(collection, logs, MongoQueryMode.Native);
+
+        // A scalar projection is not natively representable (the push-down projection path); it must fall
+        // back to the driver-LINQ path and still return correct results.
+        var names = db.Entities.Where(c => c.Score > 15).OrderBy(c => c.Score)
+            .Select(c => c.Name).ToList();
+
+        Assert.Equal(["Bob", "Carol", "Dave"], names.ToArray());
+    }
+
+    // ── 5. NativeOnly throws at compile time on a non-representable query ──────────────────────────
+
+    [Fact]
+    public void NativeOnly_mode_throws_on_unrepresentable_query()
+    {
+        var (collection, logs) = SeedCustomers(nameof(NativeOnly_mode_throws_on_unrepresentable_query));
+        using var db = CreateContext(collection, logs, MongoQueryMode.NativeOnly);
+
+        // A scalar projection is not natively representable; NativeOnly forbids the driver fallback, so the
+        // query must throw at compile time.
+        var query = db.Entities.Where(c => c.Score > 15).Select(c => new { c.Name, c.Score });
+
+        Assert.Throws<NativeTranslationNotSupportedException>(() => query.ToList());
+    }
+
+    [Fact]
+    public void NativeOnly_mode_allows_representable_query()
+    {
+        var (collection, logs) = SeedCustomers(nameof(NativeOnly_mode_allows_representable_query));
+        using var db = CreateContext(collection, logs, MongoQueryMode.NativeOnly);
+
+        var results = db.Entities.Where(c => c.Score > 15).OrderBy(c => c.Score).ToList();
+
+        Assert.Equal(["Bob", "Carol", "Dave"], results.Select(c => c.Name).ToArray());
+        Assert.Contains("$match", Mql(logs));
+    }
+
+    // ── Canonical-order guard: paging-then-filter / paging-then-sort must fall back ───────────────
+    // The native lowerer emits stages in canonical order ($match → $sort → $skip → $limit). If an
+    // operator that lowers to $match or $sort is applied AFTER paging (Skip/Take) has already been
+    // recorded, emitting it natively would reorder it ahead of the paging and silently return the
+    // wrong rows. These queries must therefore fall back to the driver-LINQ path under Native (and
+    // throw under NativeOnly).
+
+    [Fact]
+    public void Native_where_after_skip_returns_correct_rows_via_fallback()
+    {
+        var (collection, logs) = SeedCustomers(nameof(Native_where_after_skip_returns_correct_rows_via_fallback));
+        using var db = CreateContext(collection, logs, MongoQueryMode.Native);
+
+        // Sorted by Score: Alice(10), Bob(20), Carol(30), Dave(40). Skip(1) drops Alice, leaving
+        // Bob, Carol, Dave; the Where(Score > 25) then keeps Carol and Dave. Emitting $match before
+        // $skip natively would instead keep {Carol, Dave} then skip the first → ["Dave"] (wrong).
+        var results = db.Entities.OrderBy(c => c.Score).Skip(1).Where(c => c.Score > 25).ToList();
+
+        Assert.Equal(["Carol", "Dave"], results.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void NativeOnly_where_after_skip_throws()
+    {
+        var (collection, logs) = SeedCustomers(nameof(NativeOnly_where_after_skip_throws));
+        using var db = CreateContext(collection, logs, MongoQueryMode.NativeOnly);
+
+        var query = db.Entities.OrderBy(c => c.Score).Skip(1).Where(c => c.Score > 25);
+
+        Assert.Throws<NativeTranslationNotSupportedException>(() => query.ToList());
+    }
+
+    [Fact]
+    public void Native_order_after_skip_returns_correct_rows_via_fallback()
+    {
+        var (collection, logs) = SeedCustomers(nameof(Native_order_after_skip_returns_correct_rows_via_fallback));
+        using var db = CreateContext(collection, logs, MongoQueryMode.Native);
+
+        // Skip(1) (in document/insertion order) drops Alice, leaving Bob, Carol, Dave; then order
+        // those descending by Score → Dave, Carol, Bob. Emitting $sort before $skip natively would
+        // sort the full set first and skip Dave → ["Carol", "Bob"] (wrong).
+        var results = db.Entities.Skip(1).OrderByDescending(c => c.Score).ToList();
+
+        Assert.Equal(["Dave", "Carol", "Bob"], results.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void NativeOnly_order_after_skip_throws()
+    {
+        var (collection, logs) = SeedCustomers(nameof(NativeOnly_order_after_skip_throws));
+        using var db = CreateContext(collection, logs, MongoQueryMode.NativeOnly);
+
+        var query = db.Entities.Skip(1).OrderByDescending(c => c.Score);
+
+        Assert.Throws<NativeTranslationNotSupportedException>(() => query.ToList());
+    }
+
+    [Fact]
+    public void Native_order_after_take_returns_correct_rows_via_fallback()
+    {
+        var (collection, logs) = SeedCustomers(nameof(Native_order_after_take_returns_correct_rows_via_fallback));
+        using var db = CreateContext(collection, logs, MongoQueryMode.Native);
+
+        // Take(2) (in document/insertion order) keeps Alice, Bob; then order those descending by
+        // Score → Bob, Alice. Emitting $sort before $limit natively would sort all four descending
+        // and take the first two → ["Dave", "Carol"] (wrong).
+        var results = db.Entities.Take(2).OrderByDescending(c => c.Score).ToList();
+
+        Assert.Equal(["Bob", "Alice"], results.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void NativeOnly_order_after_take_throws()
+    {
+        var (collection, logs) = SeedCustomers(nameof(NativeOnly_order_after_take_throws));
+        using var db = CreateContext(collection, logs, MongoQueryMode.NativeOnly);
+
+        var query = db.Entities.Take(2).OrderByDescending(c => c.Score);
+
+        Assert.Throws<NativeTranslationNotSupportedException>(() => query.ToList());
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeOptionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/QueryModeOptionTests.cs
@@ -1,0 +1,59 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+public class QueryModeOptionTests
+{
+    [Fact]
+    public void QueryMode_defaults_to_Native()
+    {
+        var options = new DbContextOptionsBuilder<DbContext>();
+        new MongoDbContextOptionsBuilder(options); // no UseQueryMode call
+        var ext = options.Options.FindExtension<MongoOptionsExtension>();
+        Assert.Null(ext); // no extension added by just constructing the builder
+    }
+
+    [Fact]
+    public void QueryMode_on_fresh_extension_defaults_to_Native()
+    {
+        var ext = new MongoOptionsExtension();
+        Assert.Equal(MongoQueryMode.Native, ext.QueryMode);
+    }
+
+    [Fact]
+    public void UseQueryMode_round_trips_through_the_extension()
+    {
+        var options = new DbContextOptionsBuilder<DbContext>();
+        var optionsExtension = new MongoOptionsExtension().WithConnectionString("mongodb://localhost");
+        ((IDbContextOptionsBuilderInfrastructure)options).AddOrUpdateExtension(optionsExtension);
+        new MongoDbContextOptionsBuilder(options).UseQueryMode(MongoQueryMode.DriverLinq);
+        Assert.Equal(MongoQueryMode.DriverLinq, options.Options.FindExtension<MongoOptionsExtension>()!.QueryMode);
+    }
+
+    [Fact]
+    public void UseQueryMode_NativeOnly_round_trips_through_the_extension()
+    {
+        var options = new DbContextOptionsBuilder<DbContext>();
+        var optionsExtension = new MongoOptionsExtension().WithConnectionString("mongodb://localhost");
+        ((IDbContextOptionsBuilderInfrastructure)options).AddOrUpdateExtension(optionsExtension);
+        new MongoDbContextOptionsBuilder(options).UseQueryMode(MongoQueryMode.NativeOnly);
+        Assert.Equal(MongoQueryMode.NativeOnly, options.Options.FindExtension<MongoOptionsExtension>()!.QueryMode);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -3975,14 +3975,12 @@ Orders.{ "$match" : { "_id" : { "$lt" : 10300 } } }, { "$sort" : { "_id" : 1 } }
     public override async Task Skip_0_Take_0_works_when_parameter(bool async)
     {
         // Fails: Take zero EF-254
-        Assert.Contains(
-            "Value is not greater than 0: 0",
-            (await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => base.Skip_0_Take_0_works_when_parameter(async))).Message);
+        // (EF-323: native paging now validates bounds in MongoPipelineFactory.Build and throws
+        // ArgumentOutOfRangeException client-side, before the invalid $limit: 0 is sent to MongoDB —
+        // same known gap as before, just thrown by us rather than the driver, so no MQL is logged.)
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => base.Skip_0_Take_0_works_when_parameter(async));
 
-        AssertMql(
-            """
-            Customers.
-            """);
+        AssertMql();
     }
 
     public override async Task Skip_0_Take_0_works_when_constant(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Utilities/MongoTestStore.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Utilities/MongoTestStore.cs
@@ -18,6 +18,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Utilities;
+using MongoDB.EntityFrameworkCore.Infrastructure;
 using MongoDB.EntityFrameworkCore.Storage;
 
 namespace MongoDB.EntityFrameworkCore.SpecificationTests.Utilities;
@@ -39,7 +40,10 @@ public class MongoTestStore : TestStore
         => throw new NotSupportedException();
 
     public override DbContextOptionsBuilder AddProviderOptions(DbContextOptionsBuilder builder)
-        => builder.UseMongoDB(TestServer.Client, Name);
+        => builder.UseMongoDB(TestServer.Client, Name,
+            Environment.GetEnvironmentVariable("MONGODB_EF_NATIVE_ONLY") == "1"
+                ? o => o.UseQueryMode(MongoQueryMode.NativeOnly)
+                : null);
 
 #if !EF8
     protected override async Task InitializeAsync(Func<DbContext> createContext, Func<DbContext, Task>? seed,

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoExpressionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoExpressionTests.cs
@@ -1,0 +1,44 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Linq.Expressions;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+public class MongoExpressionTests
+{
+    [Fact]
+    public void Binary_node_exposes_operator_and_operands()
+    {
+        var left = new MongoConstantExpression(1, forSerialization: null);
+        var right = new MongoConstantExpression(2, forSerialization: null);
+        var bin = new MongoBinaryExpression(MongoBinaryOperator.LessThan, left, right);
+
+        Assert.Equal(MongoBinaryOperator.LessThan, bin.Operator);
+        Assert.Same(left, bin.Left);
+        Assert.Same(right, bin.Right);
+        Assert.Equal(ExpressionType.Extension, bin.NodeType);
+    }
+
+    [Fact]
+    public void Ordering_carries_key_and_direction()
+    {
+        var key = new MongoConstantExpression(0, null);
+        var ordering = new MongoOrdering(key, Ascending: false);
+        Assert.Same(key, ordering.KeySelector);
+        Assert.False(ordering.Ascending);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoExpressionTranslatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoExpressionTranslatorTests.cs
@@ -1,0 +1,250 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="MongoExpressionTranslator"/>, which translates EF predicate/key-selector
+/// lambda bodies into dialect-agnostic <see cref="MongoExpression"/> trees.
+/// </summary>
+public class MongoExpressionTranslatorTests
+{
+    // --- Entity model used across tests ---
+
+    private class Customer
+    {
+        public ObjectId Id { get; set; }
+        public int Age { get; set; }
+        public string Name { get; set; } = "";
+        public bool Active { get; set; }
+    }
+
+    /// <summary>
+    /// Returns the entity type for <typeparamref name="T"/> from a minimal in-memory model.
+    /// </summary>
+    private static IEntityType GetEntityType<T>() where T : class
+    {
+        using var db = SingleEntityDbContext.Create<T>();
+        // We need the model to stay alive for the test — grab the entity type from the model directly.
+        return db.Model.FindEntityType(typeof(T))!;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="MongoExpressionTranslator"/> for the given entity type.
+    /// </summary>
+    private static MongoExpressionTranslator NewTranslator(IEntityType entityType)
+        => new(entityType);
+
+    /// <summary>
+    /// Extracts the body of a predicate lambda as a raw <see cref="Expression"/>.
+    /// </summary>
+    private static Expression PredicateBody<T>(Expression<Func<T, bool>> predicate)
+        => predicate.Body;
+
+    // ------------------------------------------------------------------
+    // Test 1: simple comparison → MongoBinaryExpression(GreaterThan, ...)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Translates_simple_comparison_to_field_op()
+    {
+        var entityType = GetEntityType<Customer>();
+        var body = PredicateBody<Customer>(c => c.Age > 21);
+        var translator = NewTranslator(entityType);
+
+        var translated = translator.TryTranslate(body, out var result);
+
+        Assert.True(translated);
+        var bin = Assert.IsType<MongoBinaryExpression>(result);
+        Assert.Equal(MongoBinaryOperator.GreaterThan, bin.Operator);
+        var field = Assert.IsType<MongoFieldExpression>(bin.Left);
+        Assert.Equal("Age", field.ElementName);
+        var constant = Assert.IsType<MongoConstantExpression>(bin.Right);
+        Assert.Equal(21, constant.Value);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: conjunction → top-level MongoBinaryExpression(AndAlso, ...)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Conjunction_maps_to_AndAlso()
+    {
+        var entityType = GetEntityType<Customer>();
+        var body = PredicateBody<Customer>(c => c.Age > 21 && c.Age < 65);
+        var translator = NewTranslator(entityType);
+
+        var translated = translator.TryTranslate(body, out var result);
+
+        Assert.True(translated);
+        var bin = Assert.IsType<MongoBinaryExpression>(result);
+        Assert.Equal(MongoBinaryOperator.AndAlso, bin.Operator);
+        Assert.IsType<MongoBinaryExpression>(bin.Left);
+        Assert.IsType<MongoBinaryExpression>(bin.Right);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: method call → returns false, result null
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Unsupported_method_call_reports_not_translatable()
+    {
+        var entityType = GetEntityType<Customer>();
+        var body = PredicateBody<Customer>(c => c.Name.StartsWith("A"));
+        var translator = NewTranslator(entityType);
+
+        var translated = translator.TryTranslate(body, out var result);
+
+        Assert.False(translated);
+        Assert.Null(result);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: query parameter → MongoParameterExpression (B2 invariant)
+    // Constructs a parameterized body by hand, mimicking what EF emits for
+    // a captured local in `var minAge = 21; ctx.Set<Customer>().Where(c => c.Age > minAge)`.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Query_parameter_becomes_MongoParameterExpression_not_constant()
+    {
+        var entityType = GetEntityType<Customer>();
+
+        // Build: c.Age > <query-parameter>  — shape differs by EF version.
+        var cParam = Expression.Parameter(typeof(Customer), "c");
+        var ageMember = Expression.MakeMemberAccess(cParam, typeof(Customer).GetProperty(nameof(Customer.Age))!);
+
+#if EF8 || EF9
+        // EF8/EF9: query parameters are plain ParameterExpressions whose names start with the EF prefix.
+        const string paramName = QueryCompilationContext.QueryParameterPrefix + "minAge_0";
+        Expression efParam = Expression.Parameter(typeof(int), paramName);
+#else
+        // EF10: query parameters are QueryParameterExpression nodes.
+        const string paramName = "__minAge_0";
+        Expression efParam = new Microsoft.EntityFrameworkCore.Query.QueryParameterExpression(paramName, typeof(int));
+#endif
+        var body = Expression.GreaterThan(ageMember, efParam);
+
+        var translator = NewTranslator(entityType);
+        var translated = translator.TryTranslate(body, out var result);
+
+        // The body should translate successfully …
+        Assert.True(translated);
+        var bin = Assert.IsType<MongoBinaryExpression>(result);
+        Assert.Equal(MongoBinaryOperator.GreaterThan, bin.Operator);
+        Assert.IsType<MongoFieldExpression>(bin.Left);
+        // … and the right side must be a MongoParameterExpression, not a MongoConstantExpression.
+        var mongoParam = Assert.IsType<MongoParameterExpression>(bin.Right);
+        Assert.Equal(paramName, mongoParam.Name);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 5: bare boolean field → MongoFieldExpression (bool)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Bare_boolean_field_translates_to_field_expression()
+    {
+        var entityType = GetEntityType<Customer>();
+        var body = PredicateBody<Customer>(c => c.Active);
+        var translator = NewTranslator(entityType);
+
+        var translated = translator.TryTranslate(body, out var result);
+
+        Assert.True(translated);
+        var field = Assert.IsType<MongoFieldExpression>(result);
+        Assert.Equal("Active", field.ElementName);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 6: negated boolean field → MongoUnaryExpression(Not, ...)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Negated_boolean_field_translates_to_Not_unary()
+    {
+        var entityType = GetEntityType<Customer>();
+        var body = PredicateBody<Customer>(c => !c.Active);
+        var translator = NewTranslator(entityType);
+
+        var translated = translator.TryTranslate(body, out var result);
+
+        Assert.True(translated);
+        var unary = Assert.IsType<MongoUnaryExpression>(result);
+        Assert.Equal(MongoUnaryOperator.Not, unary.Operator);
+        var field = Assert.IsType<MongoFieldExpression>(unary.Operand);
+        Assert.Equal("Active", field.ElementName);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 7: OrElse → MongoBinaryExpression(OrElse, ...)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void OrElse_maps_to_OrElse()
+    {
+        var entityType = GetEntityType<Customer>();
+        var body = PredicateBody<Customer>(c => c.Age < 18 || c.Age > 65);
+        var translator = NewTranslator(entityType);
+
+        var translated = translator.TryTranslate(body, out var result);
+
+        Assert.True(translated);
+        var bin = Assert.IsType<MongoBinaryExpression>(result);
+        Assert.Equal(MongoBinaryOperator.OrElse, bin.Operator);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 8: composite-PK property → returns false, result null
+    // A property that is part of a composite primary key is stored under
+    // "_id.<element>", which the native translator cannot address. It must
+    // fall back to driver-LINQ rather than emit a $match against the wrong
+    // top-level field.
+    // ------------------------------------------------------------------
+
+    private class OrderLine
+    {
+        public int OrderId { get; set; }
+        public int ProductId { get; set; }
+        public int Quantity { get; set; }
+    }
+
+    [Fact]
+    public void Composite_PK_property_access_reports_not_translatable()
+    {
+        // Build a model where (OrderId, ProductId) form the composite primary key.
+        using var db = SingleEntityDbContext.Create<OrderLine>(mb =>
+            mb.Entity<OrderLine>().HasKey(e => new { e.OrderId, e.ProductId }));
+        var entityType = db.Model.FindEntityType(typeof(OrderLine))!;
+
+        // A predicate over one of the composite-PK components should be rejected.
+        var body = PredicateBody<OrderLine>(ol => ol.OrderId == 10248);
+        var translator = NewTranslator(entityType);
+
+        var translated = translator.TryTranslate(body, out var result);
+
+        Assert.False(translated);
+        Assert.Null(result);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoPipelineFactoryTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoPipelineFactoryTests.cs
@@ -1,0 +1,271 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="MongoPipelineFactory"/> — compile-time template construction
+/// and per-execution parameter binding.
+/// </summary>
+public class MongoPipelineFactoryTests
+{
+    // --- Entity model used across tests ---
+
+    private class Customer
+    {
+        public MongoDB.Bson.ObjectId Id { get; set; }
+        public int Age { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private static IProperty GetProperty<T>(string propertyName) where T : class
+    {
+        using var db = SingleEntityDbContext.Create<T>();
+        return db.Model.FindEntityType(typeof(T))!.FindProperty(propertyName)!;
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1 (headline): same factory, different parameter values, template NOT mutated
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Same_template_binds_different_parameter_values_across_executions()
+    {
+        // Build a factory whose $match is { Age: { $gt: <param p0> } } with an Int32 serializer.
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.GreaterThan,
+            field,
+            new MongoParameterExpression("p0", ageProperty));
+
+        var stages = new List<MongoPipelineStage> { new MongoMatchStage(pred) };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        var first = factory.Build(new Dictionary<string, object?> { ["p0"] = 21 });
+        var second = factory.Build(new Dictionary<string, object?> { ["p0"] = 40 });
+
+        Assert.Equal(BsonDocument.Parse("{ $match: { Age: { $gt: 21 } } }"), first[0]);
+        Assert.Equal(BsonDocument.Parse("{ $match: { Age: { $gt: 40 } } }"), second[0]);
+
+        // Template is not mutated between builds: building p0=21 again must equal first result.
+        var third = factory.Build(new Dictionary<string, object?> { ["p0"] = 21 });
+        Assert.Equal(first[0], third[0]);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: constant value baked into template — Build with empty dict works
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Constant_value_is_baked_into_template()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+
+        var stages = new List<MongoPipelineStage>
+        {
+            new MongoLimitStage(new MongoConstantExpression(10, ageProperty))
+        };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        var result = factory.Build(new Dictionary<string, object?>());
+
+        Assert.Single(result);
+        Assert.Equal(BsonDocument.Parse("{ $limit: 10 }"), result[0]);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: $sort stage — ascending + descending orderings
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Sort_stage_renders_ascending_and_descending_orderings()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var nameProperty = GetProperty<Customer>("Name");
+
+        var orderings = new List<MongoOrdering>
+        {
+            new MongoOrdering(new MongoFieldExpression(ageProperty, "Age"), Ascending: true),
+            new MongoOrdering(new MongoFieldExpression(nameProperty, "Name"), Ascending: false)
+        };
+
+        var stages = new List<MongoPipelineStage> { new MongoSortStage(orderings) };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        var result = factory.Build(new Dictionary<string, object?>());
+
+        Assert.Single(result);
+        Assert.Equal(BsonDocument.Parse("{ $sort: { Age: 1, Name: -1 } }"), result[0]);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: multi-stage canonical pipeline: match + sort + skip + limit
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Multi_stage_canonical_pipeline_produces_stages_in_order()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var nameProperty = GetProperty<Customer>("Name");
+
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.GreaterThan,
+            new MongoFieldExpression(ageProperty, "Age"),
+            new MongoParameterExpression("minAge", ageProperty));
+
+        var orderings = new List<MongoOrdering>
+        {
+            new MongoOrdering(new MongoFieldExpression(nameProperty, "Name"), Ascending: true)
+        };
+
+        var stages = new List<MongoPipelineStage>
+        {
+            new MongoMatchStage(pred),
+            new MongoSortStage(orderings),
+            new MongoSkipStage(new MongoConstantExpression(5, ageProperty)),
+            new MongoLimitStage(new MongoConstantExpression(10, ageProperty))
+        };
+
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        var result = factory.Build(new Dictionary<string, object?> { ["minAge"] = 18 });
+
+        Assert.Equal(4, result.Length);
+        Assert.Equal(BsonDocument.Parse("{ $match: { Age: { $gt: 18 } } }"), result[0]);
+        Assert.Equal(BsonDocument.Parse("{ $sort: { Name: 1 } }"), result[1]);
+        Assert.Equal(BsonDocument.Parse("{ $skip: 5 }"), result[2]);
+        Assert.Equal(BsonDocument.Parse("{ $limit: 10 }"), result[3]);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 5: $skip with a parameterized count (forSerialization: null) — BsonValue.Create path
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Null_serializer_placeholder_substitutes_BsonValue_Create()
+    {
+        // $skip with a PARAMETERIZED count (forSerialization: null)
+        var skipParam = new MongoParameterExpression("skip_count", forSerialization: null);
+        var stages = new List<MongoPipelineStage> { new MongoSkipStage(skipParam) };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        var result = factory.Build(new Dictionary<string, object?> { ["skip_count"] = 5 });
+
+        Assert.Single(result);
+        Assert.Equal(BsonDocument.Parse("{ $skip: 5 }"), result[0]);
+    }
+
+    // ------------------------------------------------------------------
+    // Paging bounds validation tests
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Build_throws_ArgumentOutOfRangeException_for_limit_zero_constant()
+    {
+        // A baked constant $limit: 0 must throw before reaching MongoDB.
+        var ageProperty = GetProperty<Customer>("Age");
+        var stages = new List<MongoPipelineStage>
+        {
+            new MongoLimitStage(new MongoConstantExpression(0, ageProperty))
+        };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            factory.Build(new Dictionary<string, object?>()));
+    }
+
+    [Fact]
+    public void Build_throws_ArgumentOutOfRangeException_for_limit_negative_constant()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var stages = new List<MongoPipelineStage>
+        {
+            new MongoLimitStage(new MongoConstantExpression(-1, ageProperty))
+        };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            factory.Build(new Dictionary<string, object?>()));
+    }
+
+    [Fact]
+    public void Build_throws_ArgumentOutOfRangeException_for_limit_zero_parameter()
+    {
+        // A parameterized Take that binds to 0 at execution time must throw.
+        var limitParam = new MongoParameterExpression("take_count", forSerialization: null);
+        var stages = new List<MongoPipelineStage> { new MongoLimitStage(limitParam) };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            factory.Build(new Dictionary<string, object?> { ["take_count"] = 0 }));
+    }
+
+    [Fact]
+    public void Build_throws_ArgumentOutOfRangeException_for_skip_negative_parameter()
+    {
+        var skipParam = new MongoParameterExpression("skip_count", forSerialization: null);
+        var stages = new List<MongoPipelineStage> { new MongoSkipStage(skipParam) };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            factory.Build(new Dictionary<string, object?> { ["skip_count"] = -1 }));
+    }
+
+    [Fact]
+    public void Build_does_not_throw_for_valid_skip_and_limit()
+    {
+        // Skip(1), Take(2) — both valid — must build without throwing.
+        var skipParam = new MongoParameterExpression("skip_count", forSerialization: null);
+        var limitParam = new MongoParameterExpression("take_count", forSerialization: null);
+        var stages = new List<MongoPipelineStage>
+        {
+            new MongoSkipStage(skipParam),
+            new MongoLimitStage(limitParam)
+        };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        var result = factory.Build(new Dictionary<string, object?>
+        {
+            ["skip_count"] = 1,
+            ["take_count"] = 2
+        });
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(BsonDocument.Parse("{ $skip: 1 }"), result[0]);
+        Assert.Equal(BsonDocument.Parse("{ $limit: 2 }"), result[1]);
+    }
+
+    [Fact]
+    public void Build_does_not_throw_for_skip_zero()
+    {
+        // Skip(0) is valid — $skip accepts 0.
+        var skipParam = new MongoParameterExpression("skip_count", forSerialization: null);
+        var stages = new List<MongoPipelineStage> { new MongoSkipStage(skipParam) };
+        var factory = MongoPipelineFactory.Create(stages, new MongoQueryLanguageRenderer());
+
+        // Should NOT throw
+        var result = factory.Build(new Dictionary<string, object?> { ["skip_count"] = 0 });
+        Assert.Equal(BsonDocument.Parse("{ $skip: 0 }"), result[0]);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoPipelineStageTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoPipelineStageTests.cs
@@ -1,0 +1,55 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+public class MongoPipelineStageTests
+{
+    [Fact]
+    public void Match_stage_carries_its_predicate()
+    {
+        var predicate = new MongoConstantExpression(true, null);
+        var stage = new MongoMatchStage(predicate);
+        Assert.Same(predicate, stage.Predicate);
+    }
+
+    [Fact]
+    public void Sort_stage_carries_its_orderings()
+    {
+        var keySelector = new MongoConstantExpression(0, null);
+        var orderings = new[] { new MongoOrdering(keySelector, Ascending: true) };
+        var stage = new MongoSortStage(orderings);
+        Assert.Same(orderings, stage.Orderings);
+    }
+
+    [Fact]
+    public void Skip_stage_carries_its_offset()
+    {
+        var offset = new MongoConstantExpression(10, null);
+        var stage = new MongoSkipStage(offset);
+        Assert.Same(offset, stage.Offset);
+    }
+
+    [Fact]
+    public void Limit_stage_carries_its_limit()
+    {
+        var limit = new MongoConstantExpression(5, null);
+        var stage = new MongoLimitStage(limit);
+        Assert.Same(limit, stage.Limit);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoQueryLanguageRendererTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoQueryLanguageRendererTests.cs
@@ -1,0 +1,319 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="MongoQueryLanguageRenderer"/>, which renders dialect-agnostic
+/// <see cref="MongoExpression"/> predicates into MongoDB <c>$match</c>-dialect BSON filter bodies.
+/// </summary>
+public class MongoQueryLanguageRendererTests
+{
+    // --- Entity model used across tests ---
+
+    private class Customer
+    {
+        public MongoDB.Bson.ObjectId Id { get; set; }
+        public int Age { get; set; }
+        public bool Active { get; set; }
+    }
+
+    private static IProperty GetProperty<T>(string propertyName) where T : class
+    {
+        using var db = SingleEntityDbContext.Create<T>();
+        return db.Model.FindEntityType(typeof(T))!.FindProperty(propertyName)!;
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1: simple GreaterThan comparison → { Age: { $gt: 21 } }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_greater_than_in_query_dialect()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.GreaterThan,
+            field,
+            new MongoConstantExpression(21, ageProperty));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Age: { $gt: 21 } }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: AndAlso of two ranges on the same field merges operator docs
+    //         Age > 21 && Age < 65 → { Age: { $gt: 21, $lt: 65 } }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Merges_two_ranges_on_one_field()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.AndAlso,
+            new MongoBinaryExpression(
+                MongoBinaryOperator.GreaterThan,
+                field,
+                new MongoConstantExpression(21, ageProperty)),
+            new MongoBinaryExpression(
+                MongoBinaryOperator.LessThan,
+                field,
+                new MongoConstantExpression(65, ageProperty)));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Age: { $gt: 21, $lt: 65 } }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: Equal comparison → bare { Age: value } (no $eq wrapper)
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_equal_as_bare_value()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.Equal,
+            field,
+            new MongoConstantExpression(30, ageProperty));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Age: 30 }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: NotEqual → { Age: { $ne: value } }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_not_equal_with_ne_operator()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.NotEqual,
+            field,
+            new MongoConstantExpression(0, ageProperty));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Age: { $ne: 0 } }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 5: LessThanOrEqual → { Age: { $lte: value } }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_less_than_or_equal()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.LessThanOrEqual,
+            field,
+            new MongoConstantExpression(100, ageProperty));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Age: { $lte: 100 } }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 6: GreaterThanOrEqual → { Age: { $gte: value } }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_greater_than_or_equal()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.GreaterThanOrEqual,
+            field,
+            new MongoConstantExpression(18, ageProperty));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Age: { $gte: 18 } }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 7: OrElse → { $or: [ { Age: { $lt: 18 } }, { Age: { $gt: 65 } } ] }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_or_else_as_or_array()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.OrElse,
+            new MongoBinaryExpression(
+                MongoBinaryOperator.LessThan,
+                field,
+                new MongoConstantExpression(18, ageProperty)),
+            new MongoBinaryExpression(
+                MongoBinaryOperator.GreaterThan,
+                field,
+                new MongoConstantExpression(65, ageProperty)));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(
+            BsonDocument.Parse("{ $or: [ { Age: { $lt: 18 } }, { Age: { $gt: 65 } } ] }"),
+            rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 8: bare bool field → { Active: true }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_bare_bool_field_as_true()
+    {
+        var activeProperty = GetProperty<Customer>("Active");
+        var field = new MongoFieldExpression(activeProperty, "Active");
+
+        var rendered = new MongoQueryLanguageRenderer().Render(field, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Active: true }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 9: Not(bool field) → { Active: { $ne: true } }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_not_bool_field_as_ne_true()
+    {
+        var activeProperty = GetProperty<Customer>("Active");
+        var field = new MongoFieldExpression(activeProperty, "Active");
+        var pred = new MongoUnaryExpression(MongoUnaryOperator.Not, field);
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Active: { $ne: true } }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 10: B2 parameter placeholder — renders sentinel, records in PlaceholderTable
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_parameter_as_sentinel_and_records_in_placeholder_table()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var field = new MongoFieldExpression(ageProperty, "Age");
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.GreaterThan,
+            field,
+            new MongoParameterExpression("p0", ageProperty));
+
+        var placeholders = new PlaceholderTable();
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, placeholders);
+
+        // The placeholder table must record one entry named "p0" with a non-null serializer.
+        Assert.Single(placeholders.Entries);
+        Assert.Equal("p0", placeholders.Entries[0].Name);
+        Assert.NotNull(placeholders.Entries[0].Serializer);
+
+        // The rendered body must be { Age: { $gt: <sentinel> } } where the sentinel is
+        // a placeholder marker document that TryGetPlaceholderIndex recognises as index 0.
+        var rendered_doc = Assert.IsType<BsonDocument>(rendered);
+        var ageCond = Assert.IsType<BsonDocument>(rendered_doc["Age"]);
+        var sentinelValue = ageCond["$gt"];
+        Assert.True(PlaceholderTable.TryGetPlaceholderIndex(sentinelValue, out var index));
+        Assert.Equal(0, index);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 11: AndAlso with two different fields — no merge, remain flat { f1: ..., f2: ... }
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void And_with_two_different_fields_stays_flat()
+    {
+        var ageProperty = GetProperty<Customer>("Age");
+        var activeProperty = GetProperty<Customer>("Active");
+
+        var pred = new MongoBinaryExpression(
+            MongoBinaryOperator.AndAlso,
+            new MongoBinaryExpression(
+                MongoBinaryOperator.GreaterThan,
+                new MongoFieldExpression(ageProperty, "Age"),
+                new MongoConstantExpression(21, ageProperty)),
+            new MongoFieldExpression(activeProperty, "Active"));
+
+        var rendered = new MongoQueryLanguageRenderer().Render(pred, new PlaceholderTable());
+
+        Assert.Equal(BsonDocument.Parse("{ Age: { $gt: 21 }, Active: true }"), rendered);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 12: MongoConstantExpression with null ForSerialization (Skip/Take count)
+    //          → BsonValue.Create(value), no throw
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_constant_with_null_ForSerialization_as_BsonValue()
+    {
+        // MongoConstantExpression(5, forSerialization: null) — Skip/Take count
+        var constant = new MongoConstantExpression(5, forSerialization: null);
+        var placeholders = new PlaceholderTable();
+        var renderer = new MongoQueryLanguageRenderer();
+
+        var result = renderer.RenderValue(constant, placeholders);
+
+        Assert.Equal(new BsonInt32(5), result);
+    }
+
+    // ------------------------------------------------------------------
+    // Test 13: MongoParameterExpression with null ForSerialization (Skip/Take count)
+    //          → placeholder with null serializer, no throw
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void Renders_parameter_with_null_ForSerialization_as_null_serializer_placeholder()
+    {
+        // MongoParameterExpression("p", forSerialization: null) — Skip/Take count
+        var parameter = new MongoParameterExpression("p", forSerialization: null);
+        var placeholders = new PlaceholderTable();
+        var renderer = new MongoQueryLanguageRenderer();
+
+        var result = renderer.RenderValue(parameter, placeholders);
+
+        // Must record a placeholder entry with null serializer.
+        Assert.Single(placeholders.Entries);
+        Assert.Equal("p", placeholders.Entries[0].Name);
+        Assert.Null(placeholders.Entries[0].Serializer);
+
+        // The returned value must be a valid sentinel.
+        Assert.True(PlaceholderTable.TryGetPlaceholderIndex(result, out var index));
+        Assert.Equal(0, index);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoSelectExpressionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoSelectExpressionTests.cs
@@ -1,0 +1,60 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.UnitTests.TestUtilities;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Tests for the native-translation logical-slot additions on <see cref="MongoQueryExpression"/>.
+/// These slots are the "MongoSelectExpression" described in the EF-323 design; they are implemented
+/// in-place on <see cref="MongoQueryExpression"/> to avoid churning the QMTEV / shaper / factory
+/// plumbing (controller decision).
+/// </summary>
+public class MongoSelectExpressionTests
+{
+    private class StubEntity
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private static MongoQueryExpression TestSelect()
+    {
+        using var db = SingleEntityDbContext.Create<StubEntity>();
+        var entityType = db.Model.GetEntityTypes().First();
+        return new MongoQueryExpression(entityType);
+    }
+
+    [Fact]
+    public void AddPredicateConjunct_ANDs_into_a_single_predicate()
+    {
+        var select = TestSelect();
+        var a = new MongoConstantExpression(true, null);
+        var b = new MongoConstantExpression(true, null);
+
+        select.AddPredicateConjunct(a);
+        select.AddPredicateConjunct(b);
+
+        var binary = Assert.IsType<MongoBinaryExpression>(select.Predicate);
+        Assert.Equal(MongoBinaryOperator.AndAlso, binary.Operator);
+    }
+
+    [Fact]
+    public void New_select_is_native_representable_by_default()
+        => Assert.True(TestSelect().IsNativeRepresentable);
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoSelectLowererTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/MongoSelectLowererTests.cs
@@ -1,0 +1,166 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation.Stages;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Tests for <see cref="MongoSelectLowerer"/>, which turns the native-translation slots
+/// on <see cref="MongoQueryExpression"/> into a typed <see cref="MongoPipelineStage"/> list
+/// in canonical pipeline order ($match → $sort → $skip → $limit → $lookup/$unwind).
+/// </summary>
+public class MongoSelectLowererTests
+{
+    private class StubEntity
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private static MongoQueryExpression TestSelect()
+    {
+        using var db = SingleEntityDbContext.Create<StubEntity>();
+        var entityType = db.Model.GetEntityTypes().First();
+        return new MongoQueryExpression(entityType);
+    }
+
+    // ── Test 1: Empty slots → no stages ─────────────────────────────────────────
+
+    [Fact]
+    public void Empty_slots_lower_to_no_stages()
+    {
+        var select = TestSelect();
+        var stages = new MongoSelectLowerer().Lower(select);
+        Assert.Empty(stages);
+    }
+
+    // ── Test 2: All slots populated → canonical order ────────────────────────────
+
+    [Fact]
+    public void Predicate_ordering_offset_limit_lower_in_canonical_order()
+    {
+        var select = TestSelect();
+        select.AddPredicateConjunct(new MongoConstantExpression(true, null));
+        select.AppendOrdering(new MongoOrdering(new MongoConstantExpression(0, null), true));
+        select.Offset = new MongoConstantExpression(5, null);
+        select.Limit = new MongoConstantExpression(10, null);
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        Assert.Equal(4, stages.Count);
+        Assert.IsType<MongoMatchStage>(stages[0]);
+        Assert.IsType<MongoSortStage>(stages[1]);
+        Assert.IsType<MongoSkipStage>(stages[2]);
+        Assert.IsType<MongoLimitStage>(stages[3]);
+    }
+
+    // ── Test 3: Only a predicate → exactly one MongoMatchStage ──────────────────
+
+    [Fact]
+    public void Only_predicate_lowers_to_single_match_stage()
+    {
+        var select = TestSelect();
+        select.AddPredicateConjunct(new MongoConstantExpression(true, null));
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        Assert.Single(stages);
+        Assert.IsType<MongoMatchStage>(stages[0]);
+    }
+
+    // ── Test 4: Match stage carries the predicate expression ────────────────────
+
+    [Fact]
+    public void Match_stage_carries_the_predicate_expression()
+    {
+        var select = TestSelect();
+        var predicate = new MongoConstantExpression(42, null);
+        select.AddPredicateConjunct(predicate);
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        var matchStage = Assert.IsType<MongoMatchStage>(stages[0]);
+        Assert.Same(predicate, matchStage.Predicate);
+    }
+
+    // ── Test 5: Only orderings → exactly one MongoSortStage ─────────────────────
+
+    [Fact]
+    public void Only_orderings_lower_to_single_sort_stage()
+    {
+        var select = TestSelect();
+        select.AppendOrdering(new MongoOrdering(new MongoConstantExpression(0, null), true));
+        select.AppendOrdering(new MongoOrdering(new MongoConstantExpression(1, null), false));
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        Assert.Single(stages);
+        var sortStage = Assert.IsType<MongoSortStage>(stages[0]);
+        Assert.Equal(2, sortStage.Orderings.Count);
+    }
+
+    // ── Test 6: Only Offset → exactly one MongoSkipStage ────────────────────────
+
+    [Fact]
+    public void Only_offset_lowers_to_single_skip_stage()
+    {
+        var select = TestSelect();
+        var offset = new MongoConstantExpression(10, null);
+        select.Offset = offset;
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        Assert.Single(stages);
+        var skipStage = Assert.IsType<MongoSkipStage>(stages[0]);
+        Assert.Same(offset, skipStage.Offset);
+    }
+
+    // ── Test 7: Only Limit → exactly one MongoLimitStage ────────────────────────
+
+    [Fact]
+    public void Only_limit_lowers_to_single_limit_stage()
+    {
+        var select = TestSelect();
+        var limit = new MongoConstantExpression(5, null);
+        select.Limit = limit;
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        Assert.Single(stages);
+        var limitStage = Assert.IsType<MongoLimitStage>(stages[0]);
+        Assert.Same(limit, limitStage.Limit);
+    }
+
+    // ── Test 8: Sort stage carries orderings from the slot ───────────────────────
+
+    [Fact]
+    public void Sort_stage_carries_orderings_from_the_slot()
+    {
+        var select = TestSelect();
+        var keyExpr = new MongoConstantExpression(0, null);
+        select.AppendOrdering(new MongoOrdering(keyExpr, Ascending: true));
+
+        var stages = new MongoSelectLowerer().Lower(select);
+
+        var sortStage = Assert.IsType<MongoSortStage>(stages[0]);
+        var ordering = Assert.Single(sortStage.Orderings);
+        Assert.Same(keyExpr, ordering.KeySelector);
+        Assert.True(ordering.Ascending);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/SlotPopulationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/SlotPopulationTests.cs
@@ -1,0 +1,173 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+using MongoDB.EntityFrameworkCore.Query.Visitors;
+using MongoDB.EntityFrameworkCore.UnitTests.TestUtilities;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Tests that <see cref="MongoQueryableMethodTranslatingExpressionVisitor"/> populates the native-query
+/// slots on <see cref="MongoQueryExpression"/> (EF-323 Task 6: QMTEV slot population).
+/// </summary>
+public class SlotPopulationTests
+{
+    // ── Entity model used across all tests ───────────────────────────────────────
+
+    private class Customer
+    {
+        public ObjectId Id { get; set; }
+        public int Age { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    // ── Test harness ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Drives a LINQ query expression through the real QMTEV pipeline and returns the resulting
+    /// <see cref="MongoQueryExpression"/> so tests can inspect its native slots.
+    ///
+    /// Strategy: obtain a real <see cref="IQueryable{T}"/> from the DbSet so the expression tree is
+    /// rooted in a proper <see cref="EntityQueryRootExpression"/>, apply operators to get a method-call
+    /// chain, then feed that chain through the QMTEV directly — bypassing the preprocessing step
+    /// (which is not needed for these simple flat-entity tests).
+    /// </summary>
+    /// <typeparam name="T">The entity type.</typeparam>
+    /// <param name="buildQuery">
+    /// A function that applies LINQ operators to the DbSet's <see cref="IQueryable{T}"/> — e.g.
+    /// <c>q => q.Where(c => c.Age > 21)</c>. The result's <c>.Expression</c> is fed into the visitor.
+    /// </param>
+    private static MongoQueryExpression TranslateToMongoQuery<T>(
+        Func<IQueryable<T>, IQueryable> buildQuery) where T : class
+    {
+        using var db = SingleEntityDbContext.Create<T>();
+
+        // Obtain the factory and compilation context from EF's DI container.
+        var visitorFactory = db.GetService<IQueryableMethodTranslatingExpressionVisitorFactory>();
+        var ccFactory = db.GetService<IQueryCompilationContextFactory>();
+        var compilationContext = ccFactory.Create(async: false);
+
+        // Create the QMTEV.
+        var visitor = visitorFactory.Create(compilationContext);
+
+        // Build the expression tree: the DbSet<T> implements IQueryable<T>, so its .Expression
+        // is a ConstantExpression(DbSet<T>). We need an EntityQueryRootExpression at the bottom.
+        // Use the entity type from the compiled model to build the root directly.
+        var entityType = db.Model.FindEntityType(typeof(T))!;
+        var rootExpression = new EntityQueryRootExpression(entityType);
+
+        // Wrap it in a minimal stub IQueryable so we can apply LINQ operators.
+        // The stub's .Expression property returns the EntityQueryRootExpression.
+        // This mimics the preprocessed form the QMTEV normally receives.
+        var rootQueryable = new RootExpressionQueryable<T>(rootExpression);
+        var query = buildQuery(rootQueryable);
+
+        // Visit the top-level expression tree.
+        var result = visitor.Visit(query.Expression);
+
+        Assert.NotNull(result);
+        var shaped = Assert.IsAssignableFrom<ShapedQueryExpression>(result);
+        return Assert.IsType<MongoQueryExpression>(shaped.QueryExpression);
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IQueryable{T}"/> and <see cref="IOrderedQueryable{T}"/> stub that wraps
+    /// a root expression node. When LINQ operators such as <c>Where</c>, <c>OrderBy</c>, <c>Take</c>,
+    /// <c>Select</c> are applied to this queryable via <see cref="Queryable"/>-extension methods, the
+    /// C# compiler constructs <see cref="MethodCallExpression"/> trees rooted in <see cref="Expression"/>.
+    /// Those trees can then be fed directly to the QMTEV.
+    /// Implements both <see cref="IOrderedQueryable{T}"/> and <see cref="IQueryable{T}"/> so that both
+    /// <c>OrderBy</c> (which requires <c>IOrderedQueryable</c> for <c>ThenBy</c>) and plain operators work.
+    /// </summary>
+    private sealed class RootExpressionQueryable<T> : IOrderedQueryable<T>
+    {
+        private readonly Expression _expression;
+
+        public RootExpressionQueryable(Expression expression)
+        {
+            _expression = expression;
+        }
+
+        public Type ElementType => typeof(T);
+        public Expression Expression => _expression;
+        public IQueryProvider Provider => new ThrowingProvider();
+        public IEnumerator<T> GetEnumerator() => throw new NotSupportedException("Test stub only.");
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => throw new NotSupportedException("Test stub only.");
+
+        /// <summary>
+        /// A provider that throws on any attempt to execute — this stub is only used to build expression trees.
+        /// </summary>
+        private sealed class ThrowingProvider : IQueryProvider
+        {
+            public IQueryable CreateQuery(Expression expression) => new RootExpressionQueryable<T>(expression);
+            public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+                => new RootExpressionQueryable<TElement>(expression);
+            public object? Execute(Expression expression) => throw new NotSupportedException();
+            public TResult Execute<TResult>(Expression expression) => throw new NotSupportedException();
+        }
+    }
+
+    // ── Test 1: Where → Predicate slot populated ─────────────────────────────────
+
+    [Fact]
+    public void Where_populates_the_predicate_slot()
+    {
+        var mongoQ = TranslateToMongoQuery<Customer>(q => q.Where(c => c.Age > 21));
+
+        Assert.NotNull(mongoQ.Predicate);
+        Assert.True(mongoQ.IsNativeRepresentable);
+        Assert.NotNull(mongoQ.CapturedExpression);
+    }
+
+    // ── Test 2: OrderBy + ThenByDescending → Orderings slot populated ─────────────
+
+    [Fact]
+    public void OrderBy_then_ThenBy_preserves_order()
+    {
+        var mongoQ = TranslateToMongoQuery<Customer>(
+            q => q.OrderBy(c => c.Age).ThenByDescending(c => c.Name));
+
+        Assert.Equal(2, mongoQ.Orderings.Count);
+        Assert.True(mongoQ.Orderings[0].Ascending);
+        Assert.False(mongoQ.Orderings[1].Ascending);
+    }
+
+    // ── Test 3: Where after Take → non-canonical → IsNativeRepresentable = false ──
+
+    [Fact]
+    public void Where_after_Take_is_not_native_representable()
+    {
+        var mongoQ = TranslateToMongoQuery<Customer>(q => q.Take(10).Where(c => c.Age > 21));
+
+        Assert.False(mongoQ.IsNativeRepresentable);
+        Assert.NotNull(mongoQ.CapturedExpression);
+    }
+
+    // ── Test 4: Projecting Select → IsNativeRepresentable = false ────────────────
+
+    [Fact]
+    public void Projecting_Select_is_not_native_representable()
+    {
+        var mongoQ = TranslateToMongoQuery<Customer>(q => q.Select(c => c.Name));
+
+        Assert.False(mongoQ.IsNativeRepresentable);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/StreamingEligibilityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/StreamingEligibilityTests.cs
@@ -1,0 +1,210 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Query.NativeTranslation;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Unit tests for <see cref="StreamingEligibility.IsEligible"/>, a pure function that decides
+/// whether an entity type can be materialized via the forward-only streaming reader.
+/// </summary>
+public class StreamingEligibilityTests
+{
+    // --- Simple flat entity with int PK ---
+
+    private class FlatEntityIntId
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public int Age { get; set; }
+    }
+
+    [Fact]
+    public void FlatEntity_WithIntId_IsEligible()
+    {
+        var entityType = GetEntityType<FlatEntityIntId>();
+        Assert.True(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- Simple flat entity with ObjectId PK ---
+
+    private class FlatEntityObjectId
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+        public double Score { get; set; }
+    }
+
+    [Fact]
+    public void FlatEntity_WithObjectIdId_IsEligible()
+    {
+        var entityType = GetEntityType<FlatEntityObjectId>();
+        Assert.True(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- Composite primary key (non-owned) makes entity ineligible ---
+
+    private class CompositeKeyEntity
+    {
+        public int KeyA { get; set; }
+        public int KeyB { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    [Fact]
+    public void Entity_WithCompositePrimaryKey_IsNotEligible()
+    {
+        var entityType = GetEntityType<CompositeKeyEntity>(mb =>
+        {
+            mb.Entity<CompositeKeyEntity>().HasKey(e => new { e.KeyA, e.KeyB });
+        });
+        Assert.False(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- Owned collection navigation makes entity ineligible ---
+
+    private class OwnedCollectionItem
+    {
+        public string Value { get; set; } = "";
+    }
+
+    private class EntityWithOwnedCollection
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public IList<OwnedCollectionItem> Items { get; set; } = [];
+    }
+
+    [Fact]
+    public void Entity_WithOwnedFlatCollectionNavigation_IsEligible()
+    {
+        // A flat owned collection (element type has no sub-collections) is allowed by the spike's
+        // streaming rules. The rewriter emits an array loop for it. Only "collection-of-collection"
+        // nesting (element type itself owns a collection) is rejected.
+        var entityType = GetEntityType<EntityWithOwnedCollection>(mb =>
+        {
+            mb.Entity<EntityWithOwnedCollection>().OwnsMany(e => e.Items);
+        });
+        Assert.True(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- Owned reference navigation to an eligible owned type: entity is eligible ---
+
+    private class OwnedAddress
+    {
+        public string Street { get; set; } = "";
+        public string City { get; set; } = "";
+    }
+
+    private class EntityWithOwnedReference
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public OwnedAddress? Address { get; set; }
+    }
+
+    [Fact]
+    public void Entity_WithSingleOwnedReferenceNavigation_IsEligible()
+    {
+        var entityType = GetEntityType<EntityWithOwnedReference>(mb =>
+        {
+            mb.Entity<EntityWithOwnedReference>().OwnsOne(e => e.Address);
+        });
+        Assert.True(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- TPH hierarchy (has base type) makes entity ineligible ---
+
+    private abstract class AnimalBase
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private class Dog : AnimalBase
+    {
+        public string Breed { get; set; } = "";
+    }
+
+    [Fact]
+    public void Entity_InTPHHierarchy_WithBaseType_IsNotEligible()
+    {
+        var entityType = GetEntityType<Dog>(mb =>
+        {
+            mb.Entity<AnimalBase>().HasDiscriminator<string>("AnimalType");
+            mb.Entity<Dog>();
+        });
+        Assert.False(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- No primary key makes entity ineligible ---
+
+    private class NoPrimaryKey
+    {
+        public string Name { get; set; } = "";
+    }
+
+    [Fact]
+    public void Entity_WithNoPrimaryKey_IsNotEligible()
+    {
+        var entityType = GetEntityType<NoPrimaryKey>(mb =>
+        {
+            mb.Entity<NoPrimaryKey>().HasNoKey();
+        });
+        Assert.False(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- Owned collection whose element type also owns a collection: root is ineligible (collection-of-collection) ---
+
+    private class InnerWithCollection
+    {
+        public string Value { get; set; } = "";
+        public IList<OwnedCollectionItem> Nested { get; set; } = [];
+    }
+
+    private class EntityWithNestedOwnedCollection
+    {
+        public int Id { get; set; }
+        public IList<InnerWithCollection> Inner { get; set; } = [];
+    }
+
+    [Fact]
+    public void Entity_WithOwnedCollectionNavigation_WhoseElementHasOwnedCollection_IsNotEligible()
+    {
+        // A collection element type that itself owns a collection ("collection-of-collection") makes the
+        // root entity ineligible. The spike rejects this case explicitly (see the navigation.IsCollection &&
+        // target.GetNavigations().Any(n => n.IsCollection) check in StreamingEligibility).
+        var entityType = GetEntityType<EntityWithNestedOwnedCollection>(mb =>
+        {
+            mb.Entity<EntityWithNestedOwnedCollection>().OwnsMany(e => e.Inner, inner =>
+            {
+                inner.OwnsMany(i => i.Nested);
+            });
+        });
+        Assert.False(StreamingEligibility.IsEligible(entityType));
+    }
+
+    // --- Helper ---
+
+    private static IEntityType GetEntityType<T>(Action<ModelBuilder>? configure = null) where T : class
+    {
+        using var db = SingleEntityDbContext.Create<T>(configure);
+        return db.Model.FindEntityType(typeof(T))!;
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/StreamingReferenceLookupsTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/NativeTranslation/StreamingReferenceLookupsTests.cs
@@ -1,0 +1,176 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Extensions;
+using MongoDB.EntityFrameworkCore.Query.Expressions;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.NativeTranslation;
+
+/// <summary>
+/// Tests for <see cref="MongoQueryExpression.GetStreamingReferenceLookups"/>, which
+/// reconstructs the list of <see cref="LookupExpression"/>s the native streaming path must
+/// emit as $lookup + $unwind stages for single-level reference Includes.
+/// </summary>
+public class StreamingReferenceLookupsTests
+{
+    // ── Entity model ─────────────────────────────────────────────────────────────
+
+    private class Customer
+    {
+        public ObjectId Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private class Order
+    {
+        public ObjectId Id { get; set; }
+        public ObjectId CustomerId { get; set; }
+        public Customer? Customer { get; set; }
+    }
+
+    // ── Two-entity DbContext ──────────────────────────────────────────────────────
+
+    private class TwoEntityDbContext : DbContext
+    {
+        public DbSet<Order> Orders => Set<Order>();
+        public DbSet<Customer> Customers => Set<Customer>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<Order>()
+                .HasOne(o => o.Customer)
+                .WithMany()
+                .HasForeignKey(o => o.CustomerId);
+        }
+
+        private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime) => Interlocked.Increment(ref _count);
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    private static (IEntityType orderEntityType, IEntityType customerEntityType) GetEntityTypes()
+    {
+        using var db = new TwoEntityDbContext();
+        return (db.Model.FindEntityType(typeof(Order))!, db.Model.FindEntityType(typeof(Customer))!);
+    }
+
+    // ── Test 1: Flat query — no inner collections → GetStreamingReferenceLookups is empty ──
+
+    [Fact]
+    public void No_inner_collections_returns_empty_lookups()
+    {
+        var (orderEntityType, _) = GetEntityTypes();
+        var query = new MongoQueryExpression(orderEntityType);
+
+        // No AddInnerCollection called → UsesDriverJoinFields is false, no pending lookups
+        var result = query.GetStreamingReferenceLookups();
+
+        Assert.Empty(result);
+    }
+
+    // ── Test 2: Single reference Include in driver-join state → synthesizes one LookupExpression ──
+
+    [Fact]
+    public void Single_reference_include_in_driver_join_state_returns_one_lookup()
+    {
+        var (orderEntityType, customerEntityType) = GetEntityTypes();
+        var query = new MongoQueryExpression(orderEntityType);
+
+        // Simulate the driver-native LeftJoin: one inner collection, no forced-unwind pending lookup.
+        // UsesDriverJoinFields will be true after this.
+        query.AddInnerCollection(customerEntityType);
+
+        Assert.True(query.UsesDriverJoinFields);
+        Assert.Empty(query.GetPendingLookups());
+
+        var result = query.GetStreamingReferenceLookups();
+
+        Assert.Single(result);
+
+        var lookup = result[0];
+        // The navigation on Order → Customer is a single reference (not a collection).
+        Assert.False(lookup.Navigation.IsCollection);
+        Assert.Equal("Customer", lookup.Navigation.Name);
+        // As = "_lookup_Customer"
+        Assert.Equal("_lookup_Customer", lookup.As);
+        // From = the Customer collection name
+        var expectedFrom = customerEntityType.GetCollectionName();
+        Assert.Equal(expectedFrom, lookup.From);
+        // LocalField = FK property element name on Order (CustomerId → customerId by convention)
+        Assert.False(string.IsNullOrEmpty(lookup.LocalField));
+        // ForeignField = PK property element name on Customer (_id)
+        Assert.False(string.IsNullOrEmpty(lookup.ForeignField));
+    }
+
+    // ── Test 3: Query with pending lookups (forced-unwind) → returns pending lookups directly ──
+
+    [Fact]
+    public void Pending_lookups_registered_returns_them_directly()
+    {
+        var (orderEntityType, customerEntityType) = GetEntityTypes();
+        var query = new MongoQueryExpression(orderEntityType);
+
+        // Register a lookup via AddLookup (forced-unwind mode).
+        var nav = orderEntityType.GetNavigations()
+            .Single(n => n.TargetEntityType == customerEntityType && !n.IsCollection);
+        var explicitLookup = new LookupExpression(nav, forceUnwind: true);
+        query.AddLookup(explicitLookup);
+
+        // With a ForceUnwind lookup registered, UsesDriverJoinFields should be false.
+        Assert.False(query.UsesDriverJoinFields);
+
+        var result = query.GetStreamingReferenceLookups();
+
+        Assert.Single(result);
+        Assert.Same(explicitLookup, result[0]);
+    }
+
+    // ── Test 4: Lookups slot on MongoQueryExpression delegates to GetStreamingReferenceLookups ──
+
+    [Fact]
+    public void Lookups_property_delegates_to_GetStreamingReferenceLookups()
+    {
+        var (orderEntityType, customerEntityType) = GetEntityTypes();
+        var query = new MongoQueryExpression(orderEntityType);
+
+        query.AddInnerCollection(customerEntityType);
+
+        // The Lookups slot and GetStreamingReferenceLookups() must return the same result.
+        var fromSlot = query.Lookups;
+        var fromMethod = query.GetStreamingReferenceLookups();
+
+        Assert.Equal(fromMethod.Count, fromSlot.Count);
+        if (fromMethod.Count > 0)
+        {
+            Assert.Equal(fromMethod[0].Navigation, fromSlot[0].Navigation);
+        }
+    }
+}


### PR DESCRIPTION
Sub-project 1 of the ground-up native LINQ query rebuild (EF-322): the provider now translates queries to MongoDB aggregation pipelines itself for the supported slice, instead of always delegating to the C# driver's LINQ provider.

- Translates single-collection **filter / sort / paging** over whole-entity results to native MongoDB aggregation pipelines (`$match`/`$sort`/`$skip`/`$limit`, executed via `Aggregate`); everything outside that slice transparently falls back to the driver's LINQ provider.
- New compile-time gate `MongoQueryMode` — `Native` (default), `DriverLinq` (pre-rebuild behaviour), `NativeOnly` (diagnostic: native-or-throw) — selected via `UseQueryMode(...)`.
- ~50–58% lower allocation and ~18–51% faster on the native slice (quiet M4 Max, N=10k), matching the reference spike's native numbers.
- Purely additive public API (`MongoQueryMode`, `UseQueryMode`); query results are identical to before; no breaking changes.
- Zero regressions — full Unit / Functional / Specification suites green on EF8, EF9 and EF10.
- Unsupported shapes are detected and fall back, never mis-translated — proven by native-vs-driver-LINQ parity tests across the mis-routing surface.
- Reference `Include`, predicate breadth, `$project` pushdown, scalar cardinality and the operator long tail are deferred to later sub-projects (they fall back today).

**Pipeline (built the EF / relational way).** The QMTEV populates structured slots on `MongoQueryExpression` (predicate / orderings / offset / limit) instead of returning `null`; `MongoSelectLowerer` lowers them to a typed `MongoPipelineStage[]` IR; `MongoQueryLanguageRenderer` renders the `$match` body (with the driver-parity AND/OR field-merge) and `MongoPipelineFactory` walks the stages into a `BsonDocument[]` template.

**"B2" translation timing.** Lowering + rendering happen **once at compile time** into a cached pipeline *template* whose `MongoParameterExpression` placeholders are bound per execution — so per-query work is a clone-and-substitute, not a re-walk of the LINQ chain. A consequence: the native-vs-driver and streaming-vs-DOM decisions are made deterministically at **compile time**, so exactly one shaper is compiled per query (no runtime dual-shaper dispatch).

**Conservative gate.** The driver-LINQ path is retained unchanged as the gated fallback, and the QMTEV always also captures the raw method chain so the fallback stays intact. Any operator the native path does not lower into a slot is marked non-representable and falls back — correctness-safe by construction (a missed optimisation, never a wrong result). Under `NativeOnly` such a query throws instead (a coverage/diagnostic instrument).

**Materialization.** Whole-entity results for streaming-eligible entities materialize via a forward-only reader over `RawBsonDocument` (no intermediate DOM); other shapes use the existing `BsonDocument` shaper. The streaming materializer is reproduced from the reference spike (which is reference-only; nothing else was ported).

**Scope / deferral.** Native single-level reference `Include` was in the original SP1 target but is **deferred to the Collection Includes sub-project**: EF nav-expands it into a `LeftJoin` the gate treats as non-native, so it falls back to driver-LINQ (correct results; throws under `NativeOnly`). The `$lookup`/`$unwind` lowering + streaming-Include machinery is built but dormant, ready for that sub-project to activate.

**Notable as-built decisions.** The slot model was added *in place* on `MongoQueryExpression` (rather than introducing a separate `MongoSelectExpression`) to avoid churning the QMTEV/shaper/factory plumbing during a zero-regression foundation; the native carriers on `MongoExecutableQuery` (`NativePipeline`/`Session`/`Streaming`) are `internal`; and `MongoQueryMode` participates in `GetServiceProviderHashCode`/`ShouldUseSameServiceProvider` so contexts differing only by mode don't share a service provider or compiled-query cache.

**Correctness.** Validated against driver-LINQ as the oracle. Four divergences found during review were fixed, each with a committed regression test: (1) paging was silently *not* going native; (2) `Where`/`OrderBy` after `Skip`/`Take` reordered stages and returned wrong rows; (3) non-positive `Take` now throws `ArgumentOutOfRangeException` (matching EF/driver) rather than emitting an invalid `{$limit:0}`; (4) two streaming-materializer nullability cases — a *missing* required scalar now throws `InvalidOperationException` (matching the driver entity binding) and an explicit BSON `null` on a non-nullable property now materializes `default(T)` (matching the driver) instead of throwing.

<details>
<summary>Full detail — components, files, scope, testing, performance</summary>

- **`Expressions/MongoExpression`** hierarchy (`MongoField`/`Constant`/`Parameter`/`Binary`/`Unary` + `MongoOrdering`) — a dialect-agnostic `SqlExpression`-analog node set (custom `System.Linq.Expressions.Expression` subclasses; the visitor machinery is present for future passes but not yet exercised at parity).
- **`Expressions/MongoQueryExpression.NativeSlots.cs`** — structured slots (`Predicate`/`Orderings`/`Offset`/`Limit`/`IsNativeRepresentable`/`Lookups`) added to the existing query root; retains `CapturedExpression` + `ProjectionMapping` for the fallback.
- **`Visitors/MongoQueryableMethodTranslatingExpressionVisitor`** — `PopulateNativeSlots` fills the slots for `Where`/`OrderBy(Descending)`/`ThenBy(Descending)`/`Skip`/`Take`; everything else (a non-slot operator, an un-translatable predicate, a non-canonical order, a projecting `Select`, `OfType`, composite-PK key access, …) sets `IsNativeRepresentable = false`. Always still captures the raw chain.
- **`NativeTranslation/MongoExpressionTranslator`** — EF predicate / sort-key body → `MongoExpression` (carries the spike's element-name resolution + value coercion; query parameters become placeholders, not baked constants); acceptance set matches the spike's (nullable-equality, numeric member casts, method calls, composite-PK, etc. fall back).
- **`NativeTranslation/MongoSelectLowerer`** + **`Stages/`** — slots → typed `MongoPipelineStage[]` in canonical order `$match → $sort → $skip → $limit → $lookup/$unwind`; BSON-free; owns the single-level-reference lookup eligibility (`LookupExpression.IsStreamableReference`).
- **`NativeTranslation/MongoQueryLanguageRenderer`** + **`PlaceholderTable`** — `MongoExpression` → `$match`-dialect BSON; records parameter placeholders. `MongoExprRenderer`/dialect selection is **deferred to SP2** (no `$expr` renderer at the foundation).
- **`NativeTranslation/BsonValueSerializer`** — shared coerce + serialize-through-`IBsonSerializer` helper used by both the renderer (constants) and the factory (parameters); property-less primitives (Skip/Take counts) serialize via `BsonValue.Create`.
- **`NativeTranslation/MongoPipelineFactory`** — `Create(stages, renderer)` walks the IR into a `BsonDocument[]` template + placeholder table; `Build(parameterValues)` deep-clones and substitutes per execution, validating `$limit > 0` / `$skip ≥ 0`.
- **`NativeTranslation/{MongoStreamingEntityMaterializerRewriter, BsonRowReader, StreamingEligibility}`** — forward-only `RawBsonDocument` → POCO materialization (reproduced from the spike; missing/null-required handling fixed to match driver-LINQ).
- **`NativeTranslation/NativeQueryParameter`** — single EF8/EF9-vs-EF10 query-parameter detection helper (used by the translator + the QMTEV).

- **`Visitors/MongoShapedQueryCompilingExpressionVisitor`** — the compile-time gate: under `Native`, if `IsNativeRepresentable` and lower/render succeed it builds the `MongoPipelineFactory` and compiles the streaming or DOM shaper; otherwise (or under `DriverLinq`) it compiles the driver-LINQ fallback; under `NativeOnly` a non-representable query throws.
- **`MongoExecutableQuery`** gains `internal` `NativePipeline`/`Session`/`Streaming`; **`Storage/MongoClientWrapper.Execute`** runs `collection.Aggregate(pipeline)` (raw or DOM, session-aware) when a native pipeline is present, else the driver-LINQ path; MQL is logged through the existing redaction-gated `ExecutedMqlQuery` overload.
- **`Infrastructure/MongoQueryMode`** + **`MongoDbContextOptionsBuilder.UseQueryMode`** + `MongoOptionsExtension.QueryMode`/`WithQueryMode` + `MongoQueryCompilationContext.QueryMode` — the user-facing option, folded into the options hash/equality/debug-info.

- **In (native):** `Where` (the basic predicate set `== != < <= > >= && ||`, bare/negated bool), `OrderBy`/`ThenBy`(`Descending`), canonical `Skip`/`Take`, whole-entity results.
- **Falls back to driver-LINQ (deferred to later sub-projects):** reference `Include`; predicate breadth (string methods, `Contains`/`IN`, computed, date, member casts, nullable-equality); `$project` pushdown; scalar cardinality (`Count`/`First`/`Any`/aggregates); `GroupBy`/`SelectMany`/set-ops/`Distinct`/`OfType`/`VectorSearch`; non-canonical paging; composite-PK key predicates/sort.

- New unit tests for every translation component (`tests/.../UnitTests/Query/NativeTranslation/`).
- New functional tests: `QueryModeGateTests`, `QueryModeGateIncludeTests`, `QueryModeOptionTests`, `NativePipelineExecutionTests`, `NativeGateRoutingTests` (value-converter / owned-nav / TPH native-vs-driver parity), `NativeCombinationQueryTests` (multi-key ordered + parameterized paging under `NativeOnly`), `NativeTransactionAndCancellationTests` (native-in-transaction + async cancellation mid-stream), `NativeMaterializerNullabilityTests` (missing/null required parity).
- `MongoTestStore` gains a **test-only** `MONGODB_EF_NATIVE_ONLY=1` env gate that flips the spec suite to `NativeOnly` — a native-coverage instrument (default-off; zero effect on normal runs).
- Verified on EF8, EF9 and EF10 (full Unit/Functional/Specification suites, 0 failures).

| Shape | Time | Allocation |
|---|---|---|
| Where→ToList | 8.27 vs 15.15 ms (−45%) | 9.6 vs 22.7 MB (−58%) | | Whole-entity no-track | 15.81 vs 32.37 ms (−51%) | 19.1 vs 45.3 MB (−58%) | | Whole-entity tracked | 25.22 vs 42.68 ms (−41%) | 25.2 vs 51.4 MB (−51%) | | OrderByTake | 2.61 vs 3.20 ms (−18%) | 0.24 vs 0.51 MB (−53%) | | Reference Include | ~parity (falls back — deferred) | ~same |

Native matches the reference spike's recorded native numbers on the supported slice (the SP1 "native ≥ spike" bar). A third `EF-Native` config was added to the benchmark harness; `results/perf-baseline.md` records the authoritative numbers.

`Query/AGENTS.md` rewritten for the dual-path architecture; SP1 design/overview docs record the scope and the as-built deferrals. (The SP1 design/overview/plan docs also appear in the docs PR; dedupe during rebase.)

</details>