### PR TITLE
EF-317: Adopt driver 3.10 native LeftJoin for Include

### DIFF
--- a/Versions.props
+++ b/Versions.props
@@ -4,7 +4,7 @@
     <EF9Version>9.0.16</EF9Version>
     <EF10Version>10.0.8</EF10Version>
     <!-- DRIVER_VERSION env variable could be set by the CI to test EF Provider compatibility with different (newer) versions of the MongoDB.Driver -->
-    <CSharpDriverVersion Condition="'$(DRIVER_VERSION)' == ''">3.9.0</CSharpDriverVersion>
+    <CSharpDriverVersion Condition="'$(DRIVER_VERSION)' == ''">3.10.0</CSharpDriverVersion>
     <CSharpDriverVersion Condition="'$(DRIVER_VERSION)' != ''">$(DRIVER_VERSION)</CSharpDriverVersion>
   </PropertyGroup>
 </Project>

--- a/src/MongoDB.EntityFrameworkCore/Query/AGENTS.md
+++ b/src/MongoDB.EntityFrameworkCore/Query/AGENTS.md
@@ -24,7 +24,7 @@ IQueryable<T>  (EF Core)
    ▼  MongoQueryableMethodTranslatingExpressionVisitor
    │      ├─ accepts only Queryable / MongoQueryableExtensions / MongoDB.Driver.Linq.MongoQueryable
    │      ├─ builds a MongoQueryExpression with a ProjectionMapping
-   │      └─ rejects unsupported shapes (Join / GroupBy / set ops) early
+   │      └─ translates Join / LeftJoin / GroupJoin (cross-collection $lookup); rejects GroupBy / set ops early
    ▼  MongoQueryTranslationPostprocessor     (apply final ProjectionMapping)
    ▼  MongoShapedQueryCompilingExpressionVisitor
    │      ├─ ProjectionAnalyzer decides what can push down to driver-LINQ
@@ -64,7 +64,7 @@ IQueryable<T>  (EF Core)
 - **ProjectionMapping discipline.** The `_projectionMapping` keys (`ProjectionMember`s) must match exactly what the shaper expects. A mismatch between the post-processor mapping and the shaper compilation produces silent wrong-results, not crashes.
 - **`MongoQueryExpression.CapturedExpression`** must be a *complete* method chain — set once at the tail of `MongoQueryableMethodTranslatingExpressionVisitor.VisitMethodCall`. Setting it mid-chain truncates the query.
 - **Reference-equality on `MethodInfo`.** Translators that match by `MethodInfo` must use canonical constants — `QueryableMethods` for the top-level dispatch in `MongoQueryableMethodTranslatingExpressionVisitor`, `EnumerableMethods` inside the projection-binding visitors, and the driver's `*Method` reflection classes where the bridge to driver-LINQ needs them; open vs. constructed generic methods compare unequal.
-- **Unsupported shapes are detected, not silently translated.** Joins, `GroupBy`, set operations (`Intersect` / `Except`) throw early — see the early-fail branches in `MongoQueryableMethodTranslatingExpressionVisitor`.
+- **Joins are translated, not rejected.** `Join` / `LeftJoin` / `GroupJoin` over a cross-collection DbSet become `$lookup` (single reference navigations use the driver's native `MongoQueryable.LeftJoin`, 3.10+). `GroupBy` and set operations (`Intersect` / `Except`) still throw early. Some join *shapes* the driver would mistranslate or the provider can't materialise are rejected with a clean `CoreStrings.TranslationFailed` by dedicated guards in `MongoEFToLinqTranslatingExpressionVisitor` — `GuardAgainstLimitingOperatorInJoinInner` (a `Take`/`Skip`/`Distinct` in a join *inner* subquery, which driver 3.10 wrongly folds per-outer-row into the correlated `$lookup`) and `GuardAgainstMultiHopCrossCollectionNavigation` (a navigation chaining through a joined entity onto a further cross-collection entity/collection in a predicate/ordering). Prefer that fail-loud pattern over emitting a pipeline that returns wrong data.
 - **EF Core query cache.** Compiled queries are cached by EF Core by expression-tree shape; if you change a translator's output for a previously-translatable tree, you've quietly invalidated user caches.
 - **Multi-EF guards.** Some visitor signatures changed between EF8/EF9/EF10. For representative guard shapes elsewhere in the tree see `Storage/MongoTypeMappingSource.cs` (`#if EF8 || EF9`), the `ChangeTracking/StringDictionaryComparer*.cs` pair (legacy vs. EF10 split), and the `ChangeTracking/ListOf*Comparer.cs` files (`#if EF8`); in Query itself, `QueryingEnumerable.cs` has a `#if !EF8` block.
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
@@ -20,12 +20,8 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace MongoDB.EntityFrameworkCore.Query.Expressions;
 
-// TODO(EF-317): Cross-collection $lookup workaround state. The C# driver's LINQ provider has no native
-// LeftJoin translator and cannot express collection / multi-hop joins, so the provider registers manual
-// $lookup + $unwind stages and tracks the inner collections itself. When the driver ships native LeftJoin
-// support, the $lookup-emission members here (the pending-lookup list and its dependency ordering) are
-// expected to be removed; the inner-collection tracking and UsesDriverJoinFields decision are the
-// driver-native seam and will likely shrink rather than disappear.
+// Cross-collection $lookup state: the manual $lookup + $unwind stages and inner-collection tracking used for
+// collection and multi-hop navigations, which the driver's native single-reference LeftJoin can't express.
 internal sealed partial class MongoQueryExpression
 {
     private readonly List<LookupExpression> _pendingLookups = [];

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
@@ -34,31 +34,11 @@ using MongoDB.EntityFrameworkCore.Query.Expressions;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 
-// TODO(EF-317): Join rewriting for the C# driver's LINQ provider. This file groups the join-handling
-// helpers so the LeftJoin-related code is visible in one place ahead of native driver LeftJoin support.
-// It mixes two concerns that will diverge when the driver ships that support:
-//   * Driver-native LeftJoin rewrite (EXPECTED TO REMAIN / SIMPLIFY): StripOuterSelectForJoin,
-//     RewriteLeftJoins, RewriteJoinNode, TryBuildDriverNativeLeftJoinPipeline, BuildLeftJoinResultSerializer,
-//     BuildProjectedLeftOuterJoin, RewriteLambdaForLeftJoinResult, TransparentIdentifierToLeftJoinResultRewriter,
-//     TryGetKeyFieldPath, AppendRawStage. These rewrite EF's LeftJoin into
-//     the driver's Join (the driver has no LeftJoin translator today); they stay relevant but should shrink
-//     once the driver accepts LeftJoin directly.
-//   * $lookup fallback plumbing (EXPECTED TO BE REMOVED): StripJoinForLookup, IsJoinRelatedMethod,
-//     FindBaseSourceThroughJoin, and the $lookup-stage emission (AppendLookupStages,
-//     InjectAfterRootLookupStages, EmitLookupStages). These peel a Join chain back to its root and emit
-//     the manual $lookup + $unwind stages that stand in where the driver join cannot express the shape.
-// The Visit/VisitMethodCall dispatch remains in the main visitor file and calls into the helpers here.
 internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System.Linq.Expressions.ExpressionVisitor
 {
     /// <summary>
-    /// For join queries, strip the outermost Select that EF adds to extract from TransparentIdentifier,
-    /// then rewrite every LeftJoin in the residual chain. The driver's LINQ v3 pipeline has no LeftJoin
-    /// translator: it dispatches on method name and only recognizes "Join" (routed to
-    /// <c>JoinMethodToPipelineTranslator</c>, which requires <c>method.Is(QueryableMethod.Join)</c>).
-    /// So every <c>Queryable.LeftJoin</c> the provider emits must be
-    /// rewritten to <c>Queryable.Join</c> with a
-    /// <see cref="LeftJoinResult{TOuter,TInner}"/> result selector — the driver produces documents with
-    /// _outer/_inner fields which match the LeftJoinResult property names.
+    /// Strips the outermost Select that EF adds over a join's <c>TransparentIdentifier</c>, then hands the
+    /// residual join chain to <see cref="RewriteLeftJoins"/> for translation.
     /// </summary>
     private Expression? StripOuterSelectForJoin(Expression expression)
     {
@@ -105,21 +85,12 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     }
 
     /// <summary>
-    /// Recursively rewrites every <c>Queryable.LeftJoin</c> node in a
-    /// method-call chain into <c>Queryable.Join</c> with a
-    /// <see cref="LeftJoinResult{TOuter,TInner}"/> result selector, and cascades the resulting element-type
-    /// change (TransparentIdentifier&lt;O,I&gt; → LeftJoinResult&lt;O,I&gt;) into every downstream operator
-    /// (Select / Where / OrderBy / chained Join+LeftJoin / terminal ops) so member accesses
-    /// <c>.Outer</c>/<c>.Inner</c> become <c>._outer</c>/<c>._inner</c> and generic arguments stay consistent.
-    /// Works bottom-up so multi-level Includes (chained joins) and joins nested inside other operators are
-    /// all handled.
-    ///
-    /// <paramref name="convertExplicitJoins"/> controls whether an explicit user <c>Queryable.Join</c> also
-    /// gets a <see cref="LeftJoinResult{TOuter,TInner}"/> result selector. The shaped (entity-materializing)
-    /// path needs this — its client-side shaper reads <c>_outer</c>/<c>_inner</c> from the joined document.
-    /// The projected path must NOT convert explicit Joins: their result selector is the user's projection and
-    /// has to be emitted verbatim. (A <c>LeftJoin</c> is always converted regardless, since the driver has no
-    /// LeftJoin translator.)
+    /// Recursively rewrites every <c>Queryable.LeftJoin</c> in a method-call chain (bottom-up, so nested and
+    /// multi-level joins are handled) and cascades the resulting <c>TransparentIdentifier</c> →
+    /// <see cref="LeftJoinResult{TOuter,TInner}"/> element-type change into downstream operators. When
+    /// <paramref name="convertExplicitJoins"/> is set (the shaped path, whose shaper reads
+    /// <c>_outer</c>/<c>_inner</c>) an explicit user <c>Join</c> is also converted; the projected path leaves
+    /// it verbatim.
     /// </summary>
     private Expression RewriteLeftJoins(Expression expression, bool convertExplicitJoins)
     {
@@ -181,13 +152,10 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     }
 
     /// <summary>
-    /// Rewrites a single Join/LeftJoin node given its (possibly already-rewritten) source. A LeftJoin is
-    /// converted to a <c>Queryable.Join</c> with a <see cref="LeftJoinResult{TOuter,TInner}"/> result
-    /// selector so the driver's Join translator (which has no LeftJoin equivalent) accepts it. An explicit
-    /// user <c>Queryable.Join</c> keeps its own result selector — it must round-trip unchanged so the
-    /// emitted projection matches what the user wrote; only its parameter/generic types are remapped when a
-    /// nested join below it changed the outer element type. Key selectors are remapped when the outer element
-    /// type changed.
+    /// Rewrites a single Join/LeftJoin node given its (possibly already-rewritten) source. An explicit user
+    /// <c>Join</c> keeps its own result selector so the emitted projection matches what the user wrote; its
+    /// parameter/generic and key-selector types are remapped only when a nested join changed the outer element
+    /// type.
     /// </summary>
     private Expression RewriteJoinNode(
         MethodCallExpression call, Expression newSource, Type? newSourceItemType, bool convertToJoin, bool isLeftJoin, bool shapedPath)
@@ -207,13 +175,10 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         // When the outer source was rewritten, its element type changed (TransparentIdentifier → LeftJoinResult).
         var outerType = newSourceItemType ?? oldOuterType;
 
-        // A reference Include is a LEFT-OUTER join: the principal (outer) row must survive even when the
-        // related (inner) entity is absent (optional/nullable FK). For a bare single-reference LeftJoin (the
-        // outer is the root entity, not a nested LeftJoinResult from a prior join) emit the driver's native
-        // MongoQueryable.LeftJoin, which the driver (3.10+) renders as a left-outer $lookup preserving
-        // unmatched principals — producing the same root-level _outer/_inner document shape the shaper reads.
-        // The inner EntityQueryRootExpression is replaced with its driver collection source when the emitted
-        // tree is subsequently Visit()ed (see the EntityQueryRootExpression case in the main visitor).
+        // A bare single-reference LeftJoin (outer is the root entity, not a nested LeftJoinResult) emits the
+        // driver's native MongoQueryable.LeftJoin, which the driver renders as a left-outer $lookup that
+        // preserves unmatched principals in the same _outer/_inner shape the shaper reads. The inner
+        // EntityQueryRootExpression is resolved to its collection source when the emitted tree is re-Visit()ed.
         if (isLeftJoin && shapedPath && outerType == oldOuterType)
         {
             var shapedOuterKey = call.Arguments[2].UnwrapLambdaFromQuote();
@@ -222,11 +187,9 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
                 newSource, call.Arguments[1], shapedOuterKey, shapedInnerKey, outerType, innerType);
         }
 
-        // The PROJECTED (push-down, non-shaped) path keeps the GroupJoin+SelectMany+DefaultIfEmpty rewrite.
-        // It serves both reference and *collection* navigation projections, and the native single-reference
-        // MongoQueryable.LeftJoin does not reproduce a collection navigation's empty-collection → null
-        // semantics (it materializes a default entity instead of null). Migrating the projected path to native
-        // is deferred to EF-317 / Slice 4 (collection navigations). The shaped path is already native above.
+        // The projected (push-down) path keeps the GroupJoin+SelectMany+DefaultIfEmpty rewrite for both
+        // reference and collection navigations: native single-reference LeftJoin can't reproduce a collection
+        // navigation's empty-collection → null semantics (it materializes a default entity instead).
         if (convertToJoin && isLeftJoin && !shapedPath)
         {
             return BuildProjectedLeftOuterJoin(
@@ -256,7 +219,9 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
                 : resultSelector;
         }
 
-        // Emit Queryable.Join (the driver has no LeftJoin pipeline translator); an explicit Join stays a Join.
+        // Remaining shapes native LeftJoin doesn't cover — a nested/chained LeftJoin (outer is already a
+        // LeftJoinResult) or an explicit user Join — are emitted as Queryable.Join with a LeftJoinResult
+        // result selector; an explicit Join stays a Join.
         var joinDefinition = convertToJoin ? QueryableJoinMethod : call.Method.GetGenericMethodDefinition();
         var newMethod = joinDefinition.MakeGenericMethod(outerType, innerType, genericArgs[2], resultType);
 
@@ -274,18 +239,21 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         return Expression.Call(null, newMethod, newArgs);
     }
 
+    // Match the result-selector overload structurally (last param Expression<Func<TOuter,TInner,TResult>>)
+    // so the lookup stays unambiguous if the driver adds another 5-parameter LeftJoin overload.
     private static readonly MethodInfo MongoQueryableLeftJoinMethod =
         typeof(MongoQueryable).GetMethods()
-            .Single(m => m.Name == "LeftJoin" && m.GetParameters().Length == 5);
+            .Single(m => m.Name == nameof(MongoQueryable.LeftJoin)
+                         && m.GetParameters() is { Length: 5 } ps
+                         && ps[4].ParameterType.IsGenericType
+                         && ps[4].ParameterType.GetGenericArguments()[0].GetGenericArguments().Length == 3);
 
     /// <summary>
     /// Emits the driver-native <see cref="MongoQueryable.LeftJoin{TOuter,TInner,TKey,TResult}"/> for a
-    /// single-reference left-outer join, producing the same root-level <c>_outer</c>/<c>_inner</c> document
-    /// shape (via <see cref="LeftJoinResult{TOuter,TInner}"/>) the shaper already reads. This replaces both the
-    /// hand-rolled <c>$lookup</c>/<c>$unwind</c> pipeline (shaped path) and the
-    /// <c>GroupJoin(...).SelectMany(...DefaultIfEmpty())</c> rewrite (projected path): driver 3.10.0 renders
-    /// <c>LeftJoin</c> as a left-outer <c>$lookup</c> directly, preserving principals whose related entity is
-    /// absent, so no manual preserve-<c>$unwind</c> is needed.
+    /// single-reference left-outer join on the shaped path, producing the same <c>_outer</c>/<c>_inner</c>
+    /// shape (<see cref="LeftJoinResult{TOuter,TInner}"/>) the shaper reads. The driver renders it as a
+    /// left-outer <c>$lookup</c> that preserves principals whose related entity is absent, so no manual
+    /// preserve-<c>$unwind</c> is needed. The projected path uses <see cref="BuildProjectedLeftOuterJoin"/>.
     /// </summary>
     private Expression BuildDriverNativeLeftJoin(
         Expression outerSource, Expression innerSource,
@@ -327,13 +295,11 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             .Single(m => m.Name == nameof(Enumerable.DefaultIfEmpty) && m.GetParameters().Length == 1);
 
     /// <summary>
-    /// Builds the driver-translatable left-outer join for the PROJECTED (non-shaped) path via
-    /// <c>GroupJoin(...).SelectMany(c => c._inner.DefaultIfEmpty(), ...)</c>. The driver renders this as
-    /// <c>$lookup</c> (array) + <c>$map</c>/<c>$cond</c> (substituting a single <see langword="null"/> when the
-    /// matched array is empty) + <c>$unwind</c>. This is retained specifically for projected
-    /// <em>collection</em> navigations, whose empty-collection → <see langword="null"/> semantics the driver's
-    /// native single-reference <c>LeftJoin</c> does not reproduce (it materializes a default entity instead).
-    /// Single-reference projected joins use <see cref="BuildDriverNativeLeftJoin"/> instead. See EF-317 / Slice 4.
+    /// Builds the left-outer join for the projected (non-shaped) path via
+    /// <c>GroupJoin(...).SelectMany(c => c._inner.DefaultIfEmpty(), ...)</c>, which the driver renders as
+    /// <c>$lookup</c> + <c>$map</c>/<c>$cond</c> + <c>$unwind</c>. Used for all projected LeftJoins (reference
+    /// and collection); native single-reference <c>LeftJoin</c> (<see cref="BuildDriverNativeLeftJoin"/>) can't
+    /// reproduce a collection navigation's empty-collection → <see langword="null"/> semantics.
     /// </summary>
     private Expression BuildProjectedLeftOuterJoin(
         MethodCallExpression call, Expression newSource, Type outerType, Type innerType, Type keyType, Type oldOuterType)

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
@@ -208,31 +208,25 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         var outerType = newSourceItemType ?? oldOuterType;
 
         // A reference Include is a LEFT-OUTER join: the principal (outer) row must survive even when the
-        // related (inner) entity is absent (optional/nullable FK). The driver has no LeftJoin pipeline
-        // translator, and its Join translator emits a plain `$unwind` (INNER join — it silently drops
-        // null-FK principals). So for a bare single-reference LeftJoin (the outer is the root entity, not a
-        // nested LeftJoinResult from a prior join) we emit the equivalent `$lookup` + `$unwind` pipeline
-        // ourselves, but with `preserveNullAndEmptyArrays: true` — producing the same root-level
-        // _outer/_inner document shape the shaper already reads, only left-outer instead of inner.
+        // related (inner) entity is absent (optional/nullable FK). For a bare single-reference LeftJoin (the
+        // outer is the root entity, not a nested LeftJoinResult from a prior join) emit the driver's native
+        // MongoQueryable.LeftJoin, which the driver (3.10+) renders as a left-outer $lookup preserving
+        // unmatched principals — producing the same root-level _outer/_inner document shape the shaper reads.
+        // The inner EntityQueryRootExpression is replaced with its driver collection source when the emitted
+        // tree is subsequently Visit()ed (see the EntityQueryRootExpression case in the main visitor).
         if (isLeftJoin && shapedPath && outerType == oldOuterType)
         {
-            var leftOuter = TryBuildDriverNativeLeftJoinPipeline(call, newSource);
-            if (leftOuter != null)
-            {
-                return leftOuter;
-            }
+            var shapedOuterKey = call.Arguments[2].UnwrapLambdaFromQuote();
+            var shapedInnerKey = call.Arguments[3].UnwrapLambdaFromQuote();
+            return BuildDriverNativeLeftJoin(
+                newSource, call.Arguments[1], shapedOuterKey, shapedInnerKey, outerType, innerType);
         }
 
-        // The PROJECTED (push-down, non-shaped) path turns an Include/optional-navigation LeftJoin into a
-        // driver query whose element type is LeftJoinResult<TOuter,TInner>. Emitting Queryable.Join here would
-        // give the driver an INNER join ($unwind without preserve), silently dropping principals whose related
-        // entity is absent. Instead emit the canonical driver-translatable left-outer shape
-        // outer.GroupJoin(inner, ok, ik, (o, g) => carrier).SelectMany(c => c._inner.DefaultIfEmpty(),
-        //   (c, i) => new LeftJoinResult<TOuter,TInner>(c._outer, i))
-        // which the driver renders as $lookup (array) + $map/$cond + $unwind, preserving unmatched principals
-        // while producing the SAME root-level _outer/_inner document shape the inner-Join path produced (so the
-        // downstream result selector / shaper is unchanged). The shaped (entity-materializing) path keeps using
-        // its own manual $lookup + preserve-$unwind pipeline (TryBuildDriverNativeLeftJoinPipeline) above.
+        // The PROJECTED (push-down, non-shaped) path keeps the GroupJoin+SelectMany+DefaultIfEmpty rewrite.
+        // It serves both reference and *collection* navigation projections, and the native single-reference
+        // MongoQueryable.LeftJoin does not reproduce a collection navigation's empty-collection → null
+        // semantics (it materializes a default entity instead of null). Migrating the projected path to native
+        // is deferred to EF-317 / Slice 4 (collection navigations). The shaped path is already native above.
         if (convertToJoin && isLeftJoin && !shapedPath)
         {
             return BuildProjectedLeftOuterJoin(
@@ -280,161 +274,37 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         return Expression.Call(null, newMethod, newArgs);
     }
 
-    /// <summary>
-    /// Emits the driver-native left-outer join pipeline for a single-reference <c>LeftJoin</c> as raw
-    /// aggregation stages (via <see cref="MongoQueryable.AppendStage"/>), mirroring the driver's
-    /// <c>JoinMethodToPipelineTranslator</c> output but with a <c>preserveNullAndEmptyArrays: true</c>
-    /// <c>$unwind</c> so principals with a null/absent related entity are preserved:
-    /// <code>
-    /// { $project: { _outer: "$$ROOT", _id: 0 } }
-    /// { $lookup:  { from: &lt;inner collection&gt;, localField: "_outer.&lt;fk&gt;", foreignField: "&lt;pk&gt;", as: "_inner" } }
-    /// { $unwind:  { path: "$_inner", preserveNullAndEmptyArrays: true } }
-    /// { $project: { _outer: "$_outer", _inner: "$_inner", _id: 0 } }
-    /// </code>
-    /// The output document shape (root-level <c>_outer</c>/<c>_inner</c>) is identical to the driver's Join,
-    /// so the client-side shaper is unchanged. Returns <see langword="null"/> (falling back to the driver's
-    /// inner Join) for any join shape this builder does not recognise (e.g. composite/anonymous join keys),
-    /// preserving prior behaviour for those cases.
-    /// </summary>
-    private Expression? TryBuildDriverNativeLeftJoinPipeline(
-        MethodCallExpression call, Expression newSource)
-    {
-        // Inner source must be a bare DbSet root so we can resolve its collection name.
-        if (call.Arguments[1] is not EntityQueryRootExpression innerRoot)
-        {
-            return null;
-        }
-
-        var innerEntityType = innerRoot.EntityType;
-        var outerKey = call.Arguments[2].UnwrapLambdaFromQuote();
-        var innerKey = call.Arguments[3].UnwrapLambdaFromQuote();
-
-        var outerEntityType = _queryContext.Context.Model.FindEntityType(outerKey.Parameters[0].Type);
-        if (outerEntityType == null)
-        {
-            return null;
-        }
-
-        var outerField = TryGetKeyFieldPath(outerKey.Body, outerEntityType);
-        var innerField = TryGetKeyFieldPath(innerKey.Body, innerEntityType);
-        if (outerField == null || innerField == null)
-        {
-            return null;
-        }
-
-        var collectionName = innerEntityType.GetCollectionName();
-        var outerClrType = newSource.Type.TryGetItemType()!;
-        var innerClrType = innerEntityType.ClrType;
-
-        var projectOuter = new BsonDocument("$project", new BsonDocument { { "_outer", "$$ROOT" }, { "_id", 0 } });
-        var lookup = new BsonDocument("$lookup", new BsonDocument
-        {
-            { "from", collectionName },
-            { "localField", $"_outer.{outerField}" },
-            { "foreignField", innerField },
-            { "as", "_inner" }
-        });
-        var unwind = new BsonDocument("$unwind",
-            new BsonDocument { { "path", "$_inner" }, { "preserveNullAndEmptyArrays", true } });
-        var projectResult = new BsonDocument("$project",
-            new BsonDocument { { "_outer", "$_outer" }, { "_inner", "$_inner" }, { "_id", 0 } });
-
-        // Type the manual pipeline's final stage as LeftJoinResult<TOuter,TInner> — the SAME element type the
-        // driver's own Queryable.Join produces — so that any downstream operators (OrderBy/Where/etc.) that
-        // read LeftJoinResult.Outer/.Inner (rewritten to _outer/_inner member access) translate against a
-        // source that actually has those members, and the terminal shaper reads the same root-level
-        // _outer/_inner document shape as the driver Join path. The intermediate $project/$lookup/$unwind
-        // stages stay BsonDocument-typed; only the result-shaping $project carries the LeftJoinResult
-        // serializer (built from the outer/inner entity serializers, mirroring the driver's Join translator).
-        var resultType = typeof(LeftJoinResult<,>).MakeGenericType(outerClrType, innerClrType);
-        var resultSerializer = BuildLeftJoinResultSerializer(outerClrType, innerClrType, outerEntityType, innerEntityType);
-
-        var query = AppendRawStage(newSource, outerClrType, projectOuter, typeof(BsonDocument));
-        query = AppendRawStage(query, typeof(BsonDocument), lookup);
-        query = AppendRawStage(query, typeof(BsonDocument), unwind);
-        query = AppendRawStage(query, typeof(BsonDocument), projectResult, resultType, resultSerializer);
-        return query;
-    }
+    private static readonly MethodInfo MongoQueryableLeftJoinMethod =
+        typeof(MongoQueryable).GetMethods()
+            .Single(m => m.Name == "LeftJoin" && m.GetParameters().Length == 5);
 
     /// <summary>
-    /// Builds an <see cref="IBsonSerializer"/> for <see cref="LeftJoinResult{TOuter,TInner}"/> whose
-    /// <c>_outer</c>/<c>_inner</c> members serialize with the provider's entity serializers, mirroring the
-    /// serializer the driver's own Join translator synthesizes for its <c>_outer</c>/<c>_inner</c> result
-    /// documents. Returning a <see cref="BsonClassMapSerializer{TClass}"/> (an
-    /// <c>IBsonDocumentSerializer</c>) lets the driver translate downstream <c>_outer</c>/<c>_inner</c> member
-    /// access exactly as for the driver Join path.
+    /// Emits the driver-native <see cref="MongoQueryable.LeftJoin{TOuter,TInner,TKey,TResult}"/> for a
+    /// single-reference left-outer join, producing the same root-level <c>_outer</c>/<c>_inner</c> document
+    /// shape (via <see cref="LeftJoinResult{TOuter,TInner}"/>) the shaper already reads. This replaces both the
+    /// hand-rolled <c>$lookup</c>/<c>$unwind</c> pipeline (shaped path) and the
+    /// <c>GroupJoin(...).SelectMany(...DefaultIfEmpty())</c> rewrite (projected path): driver 3.10.0 renders
+    /// <c>LeftJoin</c> as a left-outer <c>$lookup</c> directly, preserving principals whose related entity is
+    /// absent, so no manual preserve-<c>$unwind</c> is needed.
     /// </summary>
-    private IBsonSerializer BuildLeftJoinResultSerializer(
-        Type outerClrType, Type innerClrType, IEntityType outerEntityType, IEntityType innerEntityType)
+    private Expression BuildDriverNativeLeftJoin(
+        Expression outerSource, Expression innerSource,
+        LambdaExpression outerKey, LambdaExpression innerKey,
+        Type outerType, Type innerType)
     {
-        var resultType = typeof(LeftJoinResult<,>).MakeGenericType(outerClrType, innerClrType);
-        var outerSerializer = _bsonSerializerFactory.GetEntitySerializer(outerEntityType);
-        var innerSerializer = _bsonSerializerFactory.GetEntitySerializer(innerEntityType);
+        var keyType = outerKey.ReturnType;
+        var resultType = typeof(LeftJoinResult<,>).MakeGenericType(outerType, innerType);
+        var ctor = resultType.GetConstructors()[0];
+        var outerParam = Expression.Parameter(outerType, "o");
+        var innerParam = Expression.Parameter(innerType, "i");
+        var resultSelector = Expression.Lambda(
+            Expression.New(ctor, outerParam, innerParam), outerParam, innerParam);
 
-        var classMap = new BsonClassMap(resultType);
-        classMap.MapMember(resultType.GetProperty(nameof(LeftJoinResult<object, object>._outer))!)
-            .SetElementName("_outer").SetSerializer(outerSerializer);
-        classMap.MapMember(resultType.GetProperty(nameof(LeftJoinResult<object, object>._inner))!)
-            .SetElementName("_inner").SetSerializer(innerSerializer);
-        classMap.Freeze();
-
-        var serializerType = typeof(BsonClassMapSerializer<>).MakeGenericType(resultType);
-        return (IBsonSerializer)Activator.CreateInstance(serializerType, classMap)!;
-    }
-
-    /// <summary>
-    /// Resolves the dotted BSON field path for a simple <c>EF.Property(p, "Name")</c> / member-access join
-    /// key selector body. Returns <see langword="null"/> for shapes we don't handle (composite/anonymous
-    /// keys, conversions, computed keys).
-    /// </summary>
-    private static string? TryGetKeyFieldPath(Expression keyBody, IEntityType entityType)
-    {
-        var propertyName = keyBody.TryGetSimplePropertyName();
-        if (propertyName == null)
-        {
-            return null;
-        }
-
-        var property = entityType.FindProperty(propertyName);
-        if (property == null)
-        {
-            return null;
-        }
-
-        var elementName = property.GetElementName();
-        if (property.IsPrimaryKey() && entityType.FindPrimaryKey()?.Properties.Count > 1)
-        {
-            return $"_id.{elementName}";
-        }
-
-        return elementName;
-    }
-
-    /// <summary>
-    /// Appends a single raw aggregation stage via <see cref="MongoQueryable.AppendStage"/>, keeping the
-    /// queryable's element type unless <paramref name="newElementType"/> changes it (used on the final
-    /// stage to surface the LeftJoinResult shape downstream). When <paramref name="outSerializer"/> is
-    /// supplied it is registered as the output serializer so the driver can introspect the new element type's
-    /// members for downstream operators; otherwise the driver resolves the serializer for the output type.
-    /// </summary>
-    private static Expression AppendRawStage(
-        Expression query, Type elementType, BsonDocument stage, Type? newElementType = null,
-        IBsonSerializer? outSerializer = null)
-    {
-        var outType = newElementType ?? elementType;
-        var appendStageMethod = typeof(MongoQueryable).GetMethod(nameof(MongoQueryable.AppendStage))!
-            .MakeGenericMethod(elementType, outType);
-        var outSerializerType = typeof(IBsonSerializer<>).MakeGenericType(outType);
-        var stageDefinitionType = typeof(BsonDocumentPipelineStageDefinition<,>).MakeGenericType(elementType, outType);
-        var stageConstructor = stageDefinitionType.GetConstructor([typeof(BsonDocument), outSerializerType])!;
-
-        var serializerExpression = Expression.Constant(outSerializer, outSerializerType);
-
-        return Expression.Call(null, appendStageMethod, query,
-            Expression.New(stageConstructor,
-                Expression.Constant(stage),
-                serializerExpression),
-            serializerExpression);
+        var method = MongoQueryableLeftJoinMethod.MakeGenericMethod(outerType, innerType, keyType, resultType);
+        return Expression.Call(null, method,
+            outerSource, innerSource,
+            Expression.Quote(outerKey), Expression.Quote(innerKey),
+            Expression.Quote(resultSelector));
     }
 
     private static readonly MethodInfo QueryableJoinMethod =
@@ -457,16 +327,13 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             .Single(m => m.Name == nameof(Enumerable.DefaultIfEmpty) && m.GetParameters().Length == 1);
 
     /// <summary>
-    /// Builds the canonical driver-translatable left-outer join for the PROJECTED (non-shaped) path:
-    /// <code>
-    /// outer.GroupJoin(inner, outerKey, innerKey, (o, g) => new LeftJoinResult&lt;TOuter, IEnumerable&lt;TInner&gt;&gt;(o, g))
-    ///      .SelectMany(c => c._inner.DefaultIfEmpty(), (c, i) => new LeftJoinResult&lt;TOuter, TInner&gt;(c._outer, i))
-    /// </code>
-    /// The driver renders this as <c>$lookup</c> (array) + <c>$map</c>/<c>$cond</c> (substituting a single
-    /// <see langword="null"/> when the matched array is empty) + <c>$unwind</c>, so principals with no matching
-    /// related entity survive — and the terminal element type / document shape is the same
-    /// <see cref="LeftJoinResult{TOuter,TInner}"/> (<c>_outer</c>/<c>_inner</c>) the inner-Join path produced,
-    /// keeping the downstream result selector and shaper unchanged.
+    /// Builds the driver-translatable left-outer join for the PROJECTED (non-shaped) path via
+    /// <c>GroupJoin(...).SelectMany(c => c._inner.DefaultIfEmpty(), ...)</c>. The driver renders this as
+    /// <c>$lookup</c> (array) + <c>$map</c>/<c>$cond</c> (substituting a single <see langword="null"/> when the
+    /// matched array is empty) + <c>$unwind</c>. This is retained specifically for projected
+    /// <em>collection</em> navigations, whose empty-collection → <see langword="null"/> semantics the driver's
+    /// native single-reference <c>LeftJoin</c> does not reproduce (it materializes a default entity instead).
+    /// Single-reference projected joins use <see cref="BuildDriverNativeLeftJoin"/> instead. See EF-317 / Slice 4.
     /// </summary>
     private Expression BuildProjectedLeftOuterJoin(
         MethodCallExpression call, Expression newSource, Type outerType, Type innerType, Type keyType, Type oldOuterType)

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -80,6 +80,8 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     public Expression TranslateProjected(Expression? efQueryExpression)
     {
         GuardAgainstMultiBranchNavigationCount(efQueryExpression);
+        GuardAgainstMultiHopCrossCollectionNavigation(efQueryExpression);
+        GuardAgainstLimitingOperatorInJoinInner(efQueryExpression);
 
         if (efQueryExpression == null)
         {
@@ -116,6 +118,8 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         ResultCardinality resultCardinality)
     {
         GuardAgainstMultiBranchNavigationCount(efQueryExpression);
+        GuardAgainstMultiHopCrossCollectionNavigation(efQueryExpression);
+        GuardAgainstLimitingOperatorInJoinInner(efQueryExpression);
 
         if (efQueryExpression == null) // No LINQ methods, e.g. Direct ToList() against DbSet
         {
@@ -604,6 +608,220 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     /// translation cleanly (an <see cref="InvalidOperationException"/>) instead of emitting a pipeline that
     /// crashes on the server.
     /// </summary>
+    /// <summary>
+    /// A multi-hop cross-collection navigation used in a <em>predicate or ordering</em> — e.g.
+    /// <c>where od.Order.Customer.City == "Seattle"</c> or a collection navigation such as
+    /// <c>od.Order.Customer.Orders</c> compared to null — is lowered by EF Core into a chain of joins whose
+    /// filter/ordering lambda reads a member of the SECOND-hop inner. The parameter of such a lambda is a
+    /// <em>nested</em> transparent identifier (<c>TransparentIdentifier&lt;TransparentIdentifier&lt;…&gt;, …&gt;</c>)
+    /// and the body reads <c>&lt;param&gt;.Inner.…</c>. The provider's single-level <c>$lookup</c> composition
+    /// cannot faithfully evaluate/materialise that shape (the root entity is read from the wrong doubly-nested
+    /// position — <c>Document element is missing…</c> — or an unevaluated collection subquery leaks to BSON
+    /// serialization). The MongoDB C# driver's LINQ v3 provider (3.10+) now <em>attempts</em> the chain, so
+    /// rather than emit a pipeline that fails opaquely at materialization/serialization, detect the second-hop
+    /// filter/order read here and fail as a standard EF Core translation failure. Tracked by EF-216.
+    ///
+    /// The detection requires BOTH signals, which is what isolates the broken shape from superficially similar
+    /// working ones:
+    /// <list type="bullet">
+    /// <item>a join whose <em>outer key</em> reaches <em>through</em> a prior join's <c>Inner</c> — i.e. a
+    /// genuine chain a→b→c (<c>o => EF.Property(o.Inner, "CustomerID")</c>), as opposed to two sibling joins
+    /// from the same root (whose later outer keys reach through <c>.Outer</c>); and</item>
+    /// <item>a <c>Where</c>/<c>OrderBy</c>/<c>ThenBy</c> lambda that reads <c>.Inner</c> of a nested transparent
+    /// identifier — i.e. it filters/orders on that second-hop inner.</item>
+    /// </list>
+    /// Multi-level <c>Include</c>/<c>ThenInclude</c> has the first signal (same join chain) but never the
+    /// second (it only materialises); an explicit <c>Join</c>+<c>GroupJoin</c> with a <c>Where</c> on the inner
+    /// has the second signal but not the first (its joins are root-siblings). Only a true multi-hop navigation
+    /// used in a predicate/ordering has both.
+    /// </summary>
+    private void GuardAgainstMultiHopCrossCollectionNavigation(Expression? efQueryExpression)
+    {
+        if (efQueryExpression == null)
+        {
+            return;
+        }
+
+        var joinFinder = new ReachThroughInnerJoinFinder();
+        joinFinder.Visit(efQueryExpression);
+        if (!joinFinder.Found)
+        {
+            return;
+        }
+
+        var readFinder = new MultiHopNavigationReadFinder();
+        readFinder.Visit(efQueryExpression);
+        if (readFinder.Found)
+        {
+            throw new InvalidOperationException(
+                Microsoft.EntityFrameworkCore.Diagnostics.CoreStrings.TranslationFailed(efQueryExpression.Print()));
+        }
+    }
+
+    /// <summary>
+    /// Finds a <c>Join</c>/<c>LeftJoin</c>/<c>GroupJoin</c> whose outer key selector reaches <em>through</em> a
+    /// prior join's <c>Inner</c> transparent-identifier member (the signature of a chained multi-hop
+    /// navigation a→b→c). Sibling joins from the same root reach through <c>.Outer</c> and do not match.
+    /// </summary>
+    private sealed class ReachThroughInnerJoinFinder : System.Linq.Expressions.ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.DeclaringType == typeof(Queryable)
+                && node.Method.Name is "Join" or "LeftJoin" or "GroupJoin"
+                && node.Arguments.Count >= 3
+                && node.Arguments[2] is UnaryExpression { Operand: LambdaExpression outerKeySelector }
+                && outerKeySelector.Parameters.Count > 0)
+            {
+                var reachThrough = new NestedInnerReadFinder(outerKeySelector.Parameters[0]);
+                reachThrough.Visit(outerKeySelector.Body);
+                if (reachThrough.Found)
+                {
+                    Found = true;
+                }
+            }
+
+            return base.VisitMethodCall(node);
+        }
+    }
+
+    private static bool IsTransparentIdentifier(Type type)
+        => type is { IsGenericType: true }
+           && type.Name.StartsWith("TransparentIdentifier", StringComparison.Ordinal);
+
+    /// <summary>Detects a member access to <c>Inner</c> on the given transparent-identifier parameter.</summary>
+    private sealed class NestedInnerReadFinder(ParameterExpression param) : System.Linq.Expressions.ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (node.Member.Name == "Inner"
+                && node.Expression is ParameterExpression p
+                && ReferenceEquals(p, param))
+            {
+                Found = true;
+            }
+
+            return base.VisitMember(node);
+        }
+    }
+
+    /// <summary>
+    /// Finds a <c>Where</c>/<c>OrderBy</c>/<c>ThenBy</c> (and descending variants) whose lambda parameter is a
+    /// <em>nested</em> transparent identifier (its <c>Outer</c> type argument is itself a transparent
+    /// identifier) and whose body reads <c>&lt;param&gt;.Inner</c> — i.e. it filters/orders on a second-hop
+    /// cross-collection inner.
+    /// </summary>
+    private sealed class MultiHopNavigationReadFinder : System.Linq.Expressions.ExpressionVisitor
+    {
+        private static readonly HashSet<string> FilterOrOrderMethods =
+            ["Where", "OrderBy", "OrderByDescending", "ThenBy", "ThenByDescending"];
+
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.DeclaringType == typeof(Queryable)
+                && FilterOrOrderMethods.Contains(node.Method.Name)
+                && node.Arguments.Count >= 2
+                && node.Arguments[1] is UnaryExpression { Operand: LambdaExpression lambda }
+                && lambda.Parameters.Count > 0)
+            {
+                var param = lambda.Parameters[0];
+                // Nested transparent identifier: TransparentIdentifier<TransparentIdentifier<...>, ...>.
+                if (IsTransparentIdentifier(param.Type)
+                    && param.Type.GetGenericArguments() is [var outerArg, ..]
+                    && IsTransparentIdentifier(outerArg))
+                {
+                    var innerReadFinder = new NestedInnerReadFinder(param);
+                    innerReadFinder.Visit(lambda.Body);
+                    if (innerReadFinder.Found)
+                    {
+                        Found = true;
+                    }
+                }
+            }
+
+            return base.VisitMethodCall(node);
+        }
+    }
+
+    /// <summary>
+    /// A <c>Join</c>/<c>LeftJoin</c>/<c>GroupJoin</c> whose <em>inner</em> sequence is a subquery carrying a
+    /// membership-changing (cardinality) operator — <c>Take</c>/<c>Skip</c>/<c>Distinct</c>/<c>TakeLast</c>/
+    /// <c>SkipLast</c> applied to the whole inner <em>before</em> the join, e.g.
+    /// <c>customers.Join(orders.OrderBy(o =&gt; o.OrderID).Take(5), …)</c> — is mistranslated by the MongoDB C#
+    /// driver's LINQ v3 provider (3.10): it folds the operator into the correlated <c>$lookup</c> sub-pipeline,
+    /// so the limit/skip/distinct is applied <em>per outer row</em> instead of once globally before the join.
+    /// That silently returns wrong results (see the driver bug repro in <c>DriverJoinSpikeTests</c>). Until the
+    /// driver is fixed, fail as a clean EF Core translation failure rather than emit a pipeline that returns
+    /// wrong data. Ordering/filtering-only inners (<c>OrderBy</c>/<c>Where</c>/<c>Select</c>) are
+    /// membership-preserving and unaffected.
+    /// </summary>
+    private void GuardAgainstLimitingOperatorInJoinInner(Expression? efQueryExpression)
+    {
+        if (efQueryExpression == null)
+        {
+            return;
+        }
+
+        var finder = new LimitedJoinInnerFinder();
+        finder.Visit(efQueryExpression);
+        if (finder.Found)
+        {
+            throw new InvalidOperationException(
+                Microsoft.EntityFrameworkCore.Diagnostics.CoreStrings.TranslationFailed(efQueryExpression.Print()));
+        }
+    }
+
+    /// <summary>
+    /// Finds a <c>Join</c>/<c>LeftJoin</c>/<c>GroupJoin</c> whose inner argument subtree contains a
+    /// membership-changing operator (<c>Take</c>/<c>Skip</c>/<c>Distinct</c>/<c>TakeLast</c>/<c>SkipLast</c>).
+    /// </summary>
+    private sealed class LimitedJoinInnerFinder : System.Linq.Expressions.ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.DeclaringType == typeof(Queryable)
+                && node.Method.Name is "Join" or "LeftJoin" or "GroupJoin"
+                && node.Arguments.Count >= 2)
+            {
+                var innerFinder = new LimitingOperatorFinder();
+                innerFinder.Visit(node.Arguments[1]);
+                if (innerFinder.Found)
+                {
+                    Found = true;
+                }
+            }
+
+            return base.VisitMethodCall(node);
+        }
+
+        private sealed class LimitingOperatorFinder : System.Linq.Expressions.ExpressionVisitor
+        {
+            private static readonly HashSet<string> LimitingOperators =
+                ["Take", "Skip", "Distinct", "TakeLast", "SkipLast"];
+
+            public bool Found { get; private set; }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if ((node.Method.DeclaringType == typeof(Queryable) || node.Method.DeclaringType == typeof(Enumerable))
+                    && LimitingOperators.Contains(node.Method.Name))
+                {
+                    Found = true;
+                }
+
+                return base.VisitMethodCall(node);
+            }
+        }
+    }
+
     private void GuardAgainstMultiBranchNavigationCount(Expression? efQueryExpression)
     {
         if (efQueryExpression == null || !_pendingLookups.Any(l => l.InjectAfterRoot))

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -89,9 +89,8 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             return AppendLookupStages(_source);
         }
 
-        // For explicit Join queries with pending lookups, strip the join and use $lookup instead.
-        // Otherwise rewrite any Include-generated LeftJoin into Queryable.Join + LeftJoinResult so the
-        // driver's pipeline translator (which has no LeftJoin translator) accepts it.
+        // For explicit Join queries with pending lookups, strip the join and use $lookup instead. Otherwise
+        // rewrite any Include-generated LeftJoin into a driver-translatable left-outer shape (see RewriteLeftJoins).
         Expression expressionToTranslate;
         if (_pendingLookups.Count > 0)
         {
@@ -727,7 +726,7 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     /// membership-changing (cardinality) operator — <c>Take</c>/<c>Skip</c>/<c>Distinct</c>/<c>TakeLast</c>/
     /// <c>SkipLast</c> applied to the whole inner <em>before</em> the join, e.g.
     /// <c>customers.Join(orders.OrderBy(o =&gt; o.OrderID).Take(5), …)</c> — is mistranslated by the MongoDB C#
-    /// driver's LINQ v3 provider (3.10): it folds the operator into the correlated <c>$lookup</c> sub-pipeline,
+    /// driver's LINQ v3 provider: it folds the operator into the correlated <c>$lookup</c> sub-pipeline,
     /// so the limit/skip/distinct is applied <em>per outer row</em> instead of once globally before the join.
     /// That silently returns wrong results (see the driver bug repro in <c>DriverJoinSpikeTests</c>). Until the
     /// driver is fixed, fail as a clean EF Core translation failure rather than emit a pipeline that returns
@@ -799,10 +798,9 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     /// A mismatched-type equality — <c>x.Equals(y)</c> through the <c>object</c> overload where <c>x</c> and
     /// <c>y</c> have different underlying integral types (e.g. <c>uint.Equals(ulong)</c> or
     /// <c>ReportsTo.Equals(longPrm)</c>, as in EF Core's <c>Where_equals_*_on_mismatched_types</c> tests) — is
-    /// mistranslated by the MongoDB C# driver's LINQ v3 provider (3.10): the CLR's <c>object.Equals</c> is
+    /// mistranslated by the MongoDB C# driver's LINQ v3 provider: the CLR's <c>object.Equals</c> is
     /// always <see langword="false"/> across distinct value types (the values are never equal), but the driver
-    /// emits a plain numeric match that returns rows anyway (previously the driver threw
-    /// <see cref="InvalidCastException"/>; 3.10 now silently returns wrong data). Until the driver coerces the
+    /// emits a plain numeric match that returns rows anyway (returning wrong data). Until the driver coerces the
     /// operand types correctly, reject this shape as a clean EF Core translation failure rather than run a
     /// query that returns wrong results. The strongly-typed <c>Equals</c> overload (used when the argument
     /// widens to the receiver's type, e.g. <c>uint.Equals(ushort)</c>) and same-underlying-type comparisons

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -82,6 +82,7 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         GuardAgainstMultiBranchNavigationCount(efQueryExpression);
         GuardAgainstMultiHopCrossCollectionNavigation(efQueryExpression);
         GuardAgainstLimitingOperatorInJoinInner(efQueryExpression);
+        GuardAgainstMismatchedTypeEquality(efQueryExpression);
 
         if (efQueryExpression == null)
         {
@@ -120,6 +121,7 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         GuardAgainstMultiBranchNavigationCount(efQueryExpression);
         GuardAgainstMultiHopCrossCollectionNavigation(efQueryExpression);
         GuardAgainstLimitingOperatorInJoinInner(efQueryExpression);
+        GuardAgainstMismatchedTypeEquality(efQueryExpression);
 
         if (efQueryExpression == null) // No LINQ methods, e.g. Direct ToList() against DbSet
         {
@@ -600,40 +602,11 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         new(StringComparer.Ordinal) { "Union", "Concat", "Except", "Intersect" };
 
     /// <summary>
-    /// A projected collection-navigation count is materialized by a single <c>$lookup</c> injected right
-    /// after the root source. Under a set operation (e.g. <c>Union</c>) where more than one branch reads
-    /// the looked-up collection, the non-leading branch becomes a <c>$unionWith</c> sub-pipeline that does
-    /// not see that root-level <c>$lookup</c>, so its server-side <c>{ $size: "$_lookup_&lt;Nav&gt;" }</c>
-    /// would fail at runtime with "argument to $size must be an array". Detect that shape and fail
-    /// translation cleanly (an <see cref="InvalidOperationException"/>) instead of emitting a pipeline that
-    /// crashes on the server.
-    /// </summary>
-    /// <summary>
-    /// A multi-hop cross-collection navigation used in a <em>predicate or ordering</em> — e.g.
-    /// <c>where od.Order.Customer.City == "Seattle"</c> or a collection navigation such as
-    /// <c>od.Order.Customer.Orders</c> compared to null — is lowered by EF Core into a chain of joins whose
-    /// filter/ordering lambda reads a member of the SECOND-hop inner. The parameter of such a lambda is a
-    /// <em>nested</em> transparent identifier (<c>TransparentIdentifier&lt;TransparentIdentifier&lt;…&gt;, …&gt;</c>)
-    /// and the body reads <c>&lt;param&gt;.Inner.…</c>. The provider's single-level <c>$lookup</c> composition
-    /// cannot faithfully evaluate/materialise that shape (the root entity is read from the wrong doubly-nested
-    /// position — <c>Document element is missing…</c> — or an unevaluated collection subquery leaks to BSON
-    /// serialization). The MongoDB C# driver's LINQ v3 provider (3.10+) now <em>attempts</em> the chain, so
-    /// rather than emit a pipeline that fails opaquely at materialization/serialization, detect the second-hop
-    /// filter/order read here and fail as a standard EF Core translation failure. Tracked by EF-216.
-    ///
-    /// The detection requires BOTH signals, which is what isolates the broken shape from superficially similar
-    /// working ones:
-    /// <list type="bullet">
-    /// <item>a join whose <em>outer key</em> reaches <em>through</em> a prior join's <c>Inner</c> — i.e. a
-    /// genuine chain a→b→c (<c>o => EF.Property(o.Inner, "CustomerID")</c>), as opposed to two sibling joins
-    /// from the same root (whose later outer keys reach through <c>.Outer</c>); and</item>
-    /// <item>a <c>Where</c>/<c>OrderBy</c>/<c>ThenBy</c> lambda that reads <c>.Inner</c> of a nested transparent
-    /// identifier — i.e. it filters/orders on that second-hop inner.</item>
-    /// </list>
-    /// Multi-level <c>Include</c>/<c>ThenInclude</c> has the first signal (same join chain) but never the
-    /// second (it only materialises); an explicit <c>Join</c>+<c>GroupJoin</c> with a <c>Where</c> on the inner
-    /// has the second signal but not the first (its joins are root-siblings). Only a true multi-hop navigation
-    /// used in a predicate/ordering has both.
+    /// Rejects a multi-hop cross-collection navigation in a predicate/ordering (e.g.
+    /// <c>where od.Order.Customer.City == "Seattle"</c>), which the single-level <c>$lookup</c> composition
+    /// can't evaluate. Requires BOTH a join reaching through a prior join's <c>Inner</c> (a real a→b→c chain)
+    /// and a Where/OrderBy that reads that second-hop <c>Inner</c> — the two signals distinguish it from
+    /// multi-level Include (chain only) and root-sibling Join+GroupJoin (read only). EF-216.
     /// </summary>
     private void GuardAgainstMultiHopCrossCollectionNavigation(Expression? efQueryExpression)
     {
@@ -822,6 +795,109 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         }
     }
 
+    /// <summary>
+    /// A mismatched-type equality — <c>x.Equals(y)</c> through the <c>object</c> overload where <c>x</c> and
+    /// <c>y</c> have different underlying integral types (e.g. <c>uint.Equals(ulong)</c> or
+    /// <c>ReportsTo.Equals(longPrm)</c>, as in EF Core's <c>Where_equals_*_on_mismatched_types</c> tests) — is
+    /// mistranslated by the MongoDB C# driver's LINQ v3 provider (3.10): the CLR's <c>object.Equals</c> is
+    /// always <see langword="false"/> across distinct value types (the values are never equal), but the driver
+    /// emits a plain numeric match that returns rows anyway (previously the driver threw
+    /// <see cref="InvalidCastException"/>; 3.10 now silently returns wrong data). Until the driver coerces the
+    /// operand types correctly, reject this shape as a clean EF Core translation failure rather than run a
+    /// query that returns wrong results. The strongly-typed <c>Equals</c> overload (used when the argument
+    /// widens to the receiver's type, e.g. <c>uint.Equals(ushort)</c>) and same-underlying-type comparisons
+    /// (e.g. <c>uint?.Equals(uint)</c>) are correct and left alone. Tracked by EF-221.
+    /// </summary>
+    private void GuardAgainstMismatchedTypeEquality(Expression? efQueryExpression)
+    {
+        if (efQueryExpression == null)
+        {
+            return;
+        }
+
+        var finder = new MismatchedTypeEqualityFinder();
+        finder.Visit(efQueryExpression);
+        if (finder.Found)
+        {
+            throw new InvalidOperationException(
+                Microsoft.EntityFrameworkCore.Diagnostics.CoreStrings.TranslationFailed(efQueryExpression.Print()));
+        }
+    }
+
+    /// <summary>
+    /// Finds an <c>Equals</c> call comparing two different underlying integral types (nullable and
+    /// boxing <c>Convert</c>-to-<c>object</c> wrappers unwrapped first). See
+    /// <see cref="GuardAgainstMismatchedTypeEquality"/>.
+    /// </summary>
+    private sealed class MismatchedTypeEqualityFinder : System.Linq.Expressions.ExpressionVisitor
+    {
+        private static readonly HashSet<Type> IntegralTypes =
+        [
+            typeof(byte), typeof(sbyte), typeof(short), typeof(ushort),
+            typeof(int), typeof(uint), typeof(long), typeof(ulong)
+        ];
+
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.Name == nameof(object.Equals))
+            {
+                Expression? left = null;
+                Expression? right = null;
+                if (node.Object != null && node.Arguments.Count == 1)
+                {
+                    // Instance call: x.Equals(y).
+                    left = node.Object;
+                    right = node.Arguments[0];
+                }
+                else if (node.Object == null && node.Arguments.Count == 2)
+                {
+                    // Static call: object.Equals(x, y).
+                    left = node.Arguments[0];
+                    right = node.Arguments[1];
+                }
+
+                if (left != null && right != null
+                    && UnwrapIntegralType(left) is { } leftType
+                    && UnwrapIntegralType(right) is { } rightType
+                    && leftType != rightType)
+                {
+                    Found = true;
+                }
+            }
+
+            return base.VisitMethodCall(node);
+        }
+
+        // Strips the boxing Convert-to-object that the object Equals overload wraps its operand in (and any
+        // Nullable<> wrapper), returning the underlying integral CLR type, or null if the operand is not an
+        // integral type. A widening Convert to a *concrete* numeric type (e.g. ushort->uint, when the argument
+        // binds to the strongly-typed Equals overload) is deliberately NOT stripped: that comparison unifies to
+        // the widened type and the driver translates it correctly, so it must not be flagged as mismatched.
+        private static Type? UnwrapIntegralType(Expression expression)
+        {
+            while (expression is UnaryExpression
+                   { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked, Type: var t } convert
+                   && t == typeof(object))
+            {
+                expression = convert.Operand;
+            }
+
+            var type = Nullable.GetUnderlyingType(expression.Type) ?? expression.Type;
+            return IntegralTypes.Contains(type) ? type : null;
+        }
+    }
+
+    /// <summary>
+    /// A projected collection-navigation count is materialized by a single <c>$lookup</c> injected right
+    /// after the root source. Under a set operation (e.g. <c>Union</c>) where more than one branch reads
+    /// the looked-up collection, the non-leading branch becomes a <c>$unionWith</c> sub-pipeline that does
+    /// not see that root-level <c>$lookup</c>, so its server-side <c>{ $size: "$_lookup_&lt;Nav&gt;" }</c>
+    /// would fail at runtime with "argument to $size must be an array". Detect that shape and fail
+    /// translation cleanly (an <see cref="InvalidOperationException"/>) instead of emitting a pipeline that
+    /// crashes on the server.
+    /// </summary>
     private void GuardAgainstMultiBranchNavigationCount(Expression? efQueryExpression)
     {
         if (efQueryExpression == null || !_pendingLookups.Any(l => l.InjectAfterRoot))

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -166,24 +166,40 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
     {
         result = null!;
 
-        if (mappedExpression is not MemberExpression memberExpression
-            || memberExpression.Expression is not StructuralTypeShaperExpression shaper
-            || shaper.StructuralType is not IEntityType targetEntityType)
+        // Two source shapes read a scalar off a joined entity:
+        //   * a CLR member access on the entity's shaper — e.g. select o.Customer.City; and
+        //   * an EF.Property(<shaper>, "Name") call — e.g. select EF.Property<DateTime>(o2, "OrderDate")
+        //     over an explicit-join inner entity.
+        // Both carry a StructuralTypeShaperExpression whose StructuralType is the joined entity plus the
+        // accessed property; resolve those and fall through to the shared "_inner" read below.
+        StructuralTypeShaperExpression? shaper = null;
+        IProperty? property = null;
+
+        if (mappedExpression is MemberExpression memberExpression
+            && memberExpression.Expression is StructuralTypeShaperExpression memberShaper
+            && memberShaper.StructuralType is IEntityType memberEntityType)
+        {
+            shaper = memberShaper;
+            property = memberEntityType.FindProperty(memberExpression.Member);
+        }
+        else if (mappedExpression is MethodCallExpression methodCall
+                 && methodCall.Method.IsEFPropertyMethod()
+                 && methodCall.Arguments is [StructuralTypeShaperExpression efShaper, ConstantExpression { Value: string propertyName }]
+                 && efShaper.StructuralType is IEntityType efEntityType)
+        {
+            shaper = efShaper;
+            property = efEntityType.FindProperty(propertyName);
+        }
+
+        if (shaper == null || property == null)
         {
             return false;
         }
 
-        // Only handle member access on a JOINED navigation target. A member access on the root entity's own
-        // shaper (e.g. select new { o, o.CustomerID }) is a root-level property and is handled by the
-        // existing TryResolveFieldAccess path, which reads it from "_outer". Reading it from "_inner" here
-        // would return the wrong (joined) document's value.
-        if (targetEntityType == _rootEntityType)
-        {
-            return false;
-        }
-
-        var property = targetEntityType.FindProperty(memberExpression.Member);
-        if (property == null)
+        // Only handle access on a JOINED entity. Access on the root entity's own shaper (e.g.
+        // select new { o, o.CustomerID }) is a root-level property handled by the existing TryResolveFieldAccess
+        // path, which reads it from "_outer"; reading it from "_inner" here would return the wrong document's value.
+        if (shaper.StructuralType == _rootEntityType)
         {
             return false;
         }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
@@ -31,13 +31,10 @@ using MongoDB.EntityFrameworkCore.Query.Expressions;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;
 
-// TODO(EF-317): Cross-collection $lookup Include machinery. EF Core lowers cross-collection collection
-// navigations (Include / projected collections / nested ThenInclude / filtered Include) onto manual
-// $lookup + $unwind pipeline stages because the C# driver's LINQ provider has no native LeftJoin and
-// cannot express collection or multi-hop joins. When the driver ships native LeftJoin support, the
-// members in this file are expected to be removed; the only entry points from the rest of the visitor
-// are the TryBindProjectedCollectionNavigation / TryBindProjectedCollectionNavigationCount dispatch
-// calls in VisitMethodCall.
+// Cross-collection $lookup Include machinery: binds collection and multi-hop navigations (Include /
+// projected collections / nested ThenInclude / filtered Include) onto manual $lookup + $unwind stages,
+// which the driver's native single-reference LeftJoin can't express. Entry points are the
+// TryBindProjectedCollectionNavigation / TryBindProjectedCollectionNavigationCount calls in VisitMethodCall.
 internal sealed partial class MongoProjectionBindingExpressionVisitor : ExpressionVisitor
 {
     /// <summary>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/DriverJoinSpikeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/DriverJoinSpikeTests.cs
@@ -85,33 +85,56 @@ public class DriverJoinSpikeTests(TemporaryDatabaseFixture database)
         Assert.Contains(result, r => r.Order.Description == "Order 1" && r.Customer!.Name == "Alice");
     }
 
-    [Fact(Skip = "Known driver limitation: GroupJoin/SelectMany with DefaultIfEmpty over BsonDocument collections "
-                 + "yields a null BsonDocument that the driver's serializer cannot serialize "
-                 + "(\"C# null values of type 'BsonDocument' cannot be serialized\").")]
-    public void Driver_GroupJoin_SelectMany_returns_BsonDocuments()
+    [Fact]
+    public void Driver_LeftJoin_preserves_unmatched_outer_and_serializes_null_inner()
     {
         var (orders, customers) = SetupData();
 
-        // Check the raw BsonDocument structure from the driver
+        // An order whose CustomerId matches no customer - must survive a left-outer join.
+        orders.InsertOne(new SpikeOrder
+        {
+            Id = ObjectId.GenerateNewId(), Description = "Orphan", CustomerId = ObjectId.GenerateNewId()
+        });
+
+        var result = orders.AsQueryable()
+            .LeftJoin(
+                customers.AsQueryable(),
+                o => o.CustomerId,
+                c => c.Id,
+                (o, c) => new { OrderDesc = o.Description, CustomerName = c == null ? null : c.Name })
+            .ToList();
+
+        Assert.Equal(4, result.Count);
+        Assert.Contains(result, r => r.OrderDesc == "Orphan" && r.CustomerName == null);
+        Assert.Contains(result, r => r.OrderDesc == "Order 1" && r.CustomerName == "Alice");
+        Assert.Contains(result, r => r.OrderDesc == "Order 3" && r.CustomerName == "Bob");
+    }
+
+    [Fact]
+    public void Driver_LeftJoin_over_BsonDocument_collections_serializes_null_inner()
+    {
+        var (orders, customers) = SetupData();
+        orders.InsertOne(new SpikeOrder
+        {
+            Id = ObjectId.GenerateNewId(), Description = "Orphan", CustomerId = ObjectId.GenerateNewId()
+        });
+
+        // The shaped Include path joins BsonDocument collections and reads _outer/_inner; probe that
+        // native LeftJoin over BsonDocument no longer hits "null BsonDocument cannot be serialized".
         var bsonOrders = database.MongoDatabase.GetCollection<BsonDocument>(orders.CollectionNamespace.CollectionName);
         var bsonCustomers = database.MongoDatabase.GetCollection<BsonDocument>(customers.CollectionNamespace.CollectionName);
 
         var result = bsonOrders.AsQueryable()
-            .GroupJoin(
+            .LeftJoin(
                 bsonCustomers.AsQueryable(),
                 o => o["CustomerId"],
                 c => c["_id"],
-                (o, group) => new { Outer = o, Group = group })
-            .SelectMany(
-                x => x.Group.DefaultIfEmpty(),
-                (x, c) => new { x.Outer, Inner = c })
+                (o, c) => new { Outer = o, Inner = c })
             .ToList();
 
-        Assert.Equal(3, result.Count);
-        // Check the structure - Outer should be a BsonDocument with order fields
-        var first = result.First();
-        Assert.NotNull(first.Outer);
-        Assert.True(first.Outer.Contains("Description"));
+        Assert.Equal(4, result.Count);
+        Assert.Contains(result, r => r.Outer["Description"] == "Orphan" && r.Inner == null);
+        Assert.All(result, r => Assert.True(r.Outer.Contains("Description")));
     }
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
@@ -2238,7 +2238,7 @@ Customers.{ "$match" : { "Region" : { "$regularExpression" : { "pattern" : "$", 
 
     public override async Task Static_equals_int_compared_to_long(bool async)
     {
-        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        // Fails: mismatched-type equality would silently return wrong results EF-221
         await AssertTranslationFailed(() => base.Static_equals_int_compared_to_long(async));
 
         AssertMql(

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindFunctionsQueryMongoTest.cs
@@ -2238,16 +2238,11 @@ Customers.{ "$match" : { "Region" : { "$regularExpression" : { "pattern" : "$", 
 
     public override async Task Static_equals_int_compared_to_long(bool async)
     {
-        // Fails: Equals with different types issue EF-221
-        Assert.Contains(
-            "Unable to cast object of type 'System.Int",
-            (await Assert.ThrowsAsync<InvalidCastException>(() => base.Static_equals_int_compared_to_long(async)))
-            .Message);
+        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        await AssertTranslationFailed(() => base.Static_equals_int_compared_to_long(async));
 
         AssertMql(
-            """
-            Orders.
-            """);
+        );
     }
 
     public override async Task Where_DateOnly_FromDateTime(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
@@ -148,86 +148,59 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
 
     public override async Task Join_customers_orders_with_subquery(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Join_customers_orders_with_subquery(async))).Message);
+        await base.Join_customers_orders_with_subquery(async);
 
         AssertMql(
             """
-Customers.
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$match" : { "Inner.CustomerID" : "ALFKI" } }, { "$project" : { "ContactName" : "$Outer.ContactName", "OrderID" : "$Inner._id", "_id" : 0 } }
 """);
     }
 
     public override async Task Join_customers_orders_with_subquery_with_take(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Join_customers_orders_with_subquery_with_take(async))).Message);
+        // Fails: Take/Skip/Distinct in join inner not supported EF-317
+        await AssertTranslationFailed(() => base.Join_customers_orders_with_subquery_with_take(async));
 
         AssertMql(
-            """
-Customers.
-""");
+        );
     }
 
     public override async Task Join_customers_orders_with_subquery_anonymous_property_method(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Join_customers_orders_with_subquery_anonymous_property_method(async))).Message);
+        await base.Join_customers_orders_with_subquery_anonymous_property_method(async);
 
         AssertMql(
             """
-Customers.
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner.CustomerID" : "ALFKI" } }
 """);
     }
 
     public override async Task Join_customers_orders_with_subquery_anonymous_property_method_with_take(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Join_customers_orders_with_subquery_anonymous_property_method_with_take(async))).Message);
+        // Fails: Take/Skip/Distinct in join inner not supported EF-317
+        await AssertTranslationFailed(() => base.Join_customers_orders_with_subquery_anonymous_property_method_with_take(async));
 
         AssertMql(
-            """
-Customers.
-""");
+        );
     }
 
     public override async Task Join_customers_orders_with_subquery_predicate(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Join_customers_orders_with_subquery_predicate(async))).Message);
+        await base.Join_customers_orders_with_subquery_predicate(async);
 
         AssertMql(
             """
-Customers.
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$match" : { "_id" : { "$gt" : 0 } } }, { "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$match" : { "Inner.CustomerID" : "ALFKI" } }, { "$project" : { "ContactName" : "$Outer.ContactName", "OrderID" : "$Inner._id", "_id" : 0 } }
 """);
     }
 
     public override async Task Join_customers_orders_with_subquery_predicate_with_take(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Join_customers_orders_with_subquery_predicate_with_take(async))).Message);
+        // Fails: Take/Skip/Distinct in join inner not supported EF-317
+        await AssertTranslationFailed(() => base.Join_customers_orders_with_subquery_predicate_with_take(async));
 
         AssertMql(
-            """
-Customers.
-""");
+        );
     }
 
     public override async Task Join_composite_key(bool async)
@@ -318,16 +291,11 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
 
     public override async Task GroupJoin_simple_subquery(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.GroupJoin_simple_subquery(async))).Message);
+        // Fails: Take/Skip/Distinct in join inner not supported EF-317
+        await AssertTranslationFailed(() => base.GroupJoin_simple_subquery(async));
 
         AssertMql(
-            """
-Customers.
-""");
+        );
     }
 
     public override async Task GroupJoin_as_final_operator(bool async)
@@ -402,14 +370,11 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
         AssertMql(
         );
 #else
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.GroupJoin_DefaultIfEmpty2(async))).Message);
+        await base.GroupJoin_DefaultIfEmpty2(async);
 
         AssertMql(
             """
-Employees.
+Employees.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "EmployeeID", "pipeline" : [{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }
 """);
 #endif
     }
@@ -499,15 +464,11 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
 
     public override async Task GroupJoin_SelectMany_subquery_with_filter(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.GroupJoin_SelectMany_subquery_with_filter(async))).Message);
+        await base.GroupJoin_SelectMany_subquery_with_filter(async);
 
         AssertMql(
             """
-Customers.
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$match" : { "_id" : { "$gt" : 5 } } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$project" : { "ContactName" : "$Outer.ContactName", "OrderID" : "$Inner._id", "_id" : 0 } }
 """);
     }
 
@@ -529,11 +490,11 @@ Customers.
         AssertMql(
         );
 #else
-        await Assert.ThrowsAnyAsync<Exception>(() => base.GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(async));
+        await base.GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(async);
 
         AssertMql(
             """
-Customers.
+Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$match" : { "_id" : { "$gt" : 5 } } }], "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }
 """);
 #endif
     }
@@ -548,51 +509,29 @@ Customers.
 
     public override async Task GroupJoin_Subquery_with_Take_Then_SelectMany_Where(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.GroupJoin_Subquery_with_Take_Then_SelectMany_Where(async))).Message);
+        // Fails: Take/Skip/Distinct in join inner not supported EF-317
+        await AssertTranslationFailed(() => base.GroupJoin_Subquery_with_Take_Then_SelectMany_Where(async));
 
         AssertMql(
-            """
-Customers.
-""");
+        );
     }
 
     public override async Task Inner_join_with_tautology_predicate_converts_to_cross_join(bool async)
     {
         // Fails: Multiple query roots issue EF-220
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Inner_join_with_tautology_predicate_converts_to_cross_join(async))).Message);
+        await AssertTranslationFailed(() => base.Inner_join_with_tautology_predicate_converts_to_cross_join(async));
 
         AssertMql(
-            """
-Customers.
-""");
+        );
     }
 
     public override async Task Left_join_with_tautology_predicate_doesnt_convert_to_cross_join(bool async)
     {
-#if EF8 || EF9
         // Fails: Multiple query roots issue EF-220
         await AssertTranslationFailed(() => base.Left_join_with_tautology_predicate_doesnt_convert_to_cross_join(async));
 
         AssertMql(
         );
-#else
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Left_join_with_tautology_predicate_doesnt_convert_to_cross_join(async))).Message);
-
-        AssertMql(
-            """
-Customers.
-""");
-#endif
     }
 
     public override async Task SelectMany_with_client_eval(bool async)
@@ -759,30 +698,21 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
 
     public override async Task GroupJoin_customers_employees_subquery_shadow(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.GroupJoin_customers_employees_subquery_shadow(async))).Message);
+        await base.GroupJoin_customers_employees_subquery_shadow(async);
 
         AssertMql(
             """
-Customers.
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Employees", "localField" : "_outer.City", "foreignField" : "City", "pipeline" : [{ "$sort" : { "City" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$project" : { "Title" : "$Inner.Title", "_id" : "$Inner._id" } }
 """);
     }
 
     public override async Task GroupJoin_customers_employees_subquery_shadow_take(bool async)
     {
-        // Fails: Subquery selection EF-X001
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.GroupJoin_customers_employees_subquery_shadow_take(async))).Message);
+        // Fails: Take/Skip/Distinct in join inner not supported EF-317
+        await AssertTranslationFailed(() => base.GroupJoin_customers_employees_subquery_shadow_take(async));
 
         AssertMql(
-            """
-Customers.
-""");
+        );
     }
 
     public override async Task GroupJoin_projection(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -3405,23 +3405,11 @@ Customers.{ "$match" : { "$and" : [{ "_id" : { "$ne" : "VAFFE" } }, { "_id" : { 
 
     public override async Task Comparing_collection_navigation_to_null_complex(bool async)
     {
-#if EF8 || EF9
-        // Fails: Cross-document navigation access issue EF-216
+        // Fails: Multi-hop cross-collection navigation not supported EF-216
         await AssertTranslationFailed(() => base.Comparing_collection_navigation_to_null_complex(async));
 
         AssertMql(
         );
-#else
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Comparing_collection_navigation_to_null_complex(async))).Message);
-
-        AssertMql(
-            """
-OrderDetails.
-""");
-#endif
     }
 
     public override async Task Compare_collection_navigation_with_itself(bool async)
@@ -3517,15 +3505,11 @@ OrderDetails.
 
     public override async Task Join_take_count_works(bool async)
     {
-        // Fails: Cross-document navigation access issue EF-216
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Join_take_count_works(async))).Message);
+        await base.Join_take_count_works(async);
 
         AssertMql(
             """
-Orders.
+Orders.{ "$match" : { "_id" : { "$gt" : 690, "$lt" : 710 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "_id" : "ALFKI" } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$limit" : 5 }, { "$count" : "_v" }
 """);
     }
 
@@ -3793,16 +3777,12 @@ Orders.{ "$match" : { "_id" : { "$lt" : 10300 } } }, { "$sort" : { "_id" : 1 } }
 
     public override async Task Checked_context_with_arithmetic_does_not_fail(bool async)
     {
-        // Fails: checked issue EF-249
-        Assert.Contains(
-            "Expression not supported: (ConvertChecked",
-            (await Assert.ThrowsAsync<ExpressionNotSupportedException>(() =>
-                base.Checked_context_with_arithmetic_does_not_fail(async))).Message);
+        await base.Checked_context_with_arithmetic_does_not_fail(async);
 
         AssertMql(
             """
-            OrderDetails.
-            """);
+OrderDetails.{ "$match" : { "$and" : [{ "$expr" : { "$eq" : [{ "$add" : [{ "$toInt" : "$Quantity" }, 1] }, 5] } }, { "$expr" : { "$eq" : [{ "$subtract" : [{ "$toInt" : "$Quantity" }, 1] }, 3] } }, { "$expr" : { "$eq" : [{ "$multiply" : [{ "$toInt" : "$Quantity" }, 1] }, { "$toInt" : "$Quantity" }] } }] } }, { "$sort" : { "_id.OrderID" : 1 } }
+""");
     }
 
     public override async Task Checked_context_with_case_to_same_nullable_type_does_not_fail(bool isAsync)
@@ -4174,15 +4154,11 @@ Customers.
 
     public override async Task OrderBy_Join(bool async)
     {
-        // Fails: Cross-document navigation access issue EF-216
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.OrderBy_Join(async))).Message);
+        await base.OrderBy_Join(async);
 
         AssertMql(
             """
-Customers.
+Customers.{ "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$project" : { "CustomerID" : "$Outer._id", "OrderID" : "$Inner._id", "_id" : 0 } }
 """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindNavigationsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindNavigationsQueryMongoTest.cs
@@ -69,23 +69,11 @@ Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "fro
 
     public override async Task Select_Where_Navigation_Deep(bool async)
     {
-#if EF8 || EF9
-        // Fails: Cross-document navigation access issue EF-216
+        // Fails: Multi-hop cross-collection navigation not supported EF-216
         await AssertTranslationFailed(() => base.Select_Where_Navigation_Deep(async));
 
         AssertMql(
         );
-#else
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Select_Where_Navigation_Deep(async))).Message);
-
-        AssertMql(
-            """
-OrderDetails.
-""");
-#endif
     }
 
     public override async Task Take_Select_Navigation(bool async)
@@ -611,21 +599,11 @@ Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "fro
 
     public override async Task Navigation_in_subquery_referencing_outer_query(bool async)
     {
-#if EF8 || EF9
-        // Fails: Cross-document navigation access issue EF-216
+        // Fails: Multi-hop cross-collection navigation not supported EF-216
         await AssertTranslationFailed(() => base.Navigation_in_subquery_referencing_outer_query(async));
 
         AssertMql(
         );
-#else
-        Assert.Contains(
-            "is not defined for type",
-            (await Assert.ThrowsAsync<ArgumentException>(() =>
-                base.Navigation_in_subquery_referencing_outer_query(async))).Message);
-
-        AssertMql(
-        );
-#endif
     }
 
     public override async Task Project_single_scalar_value_subquery_is_properly_inlined(bool async)
@@ -723,22 +701,12 @@ Orders.
 
     public override async Task Navigation_in_subquery_referencing_outer_query_with_client_side_result_operator_and_count(bool async)
     {
-#if EF8 || EF9
-        // Fails: Cross-document navigation access issue EF-216
+        // Fails: Multi-hop cross-collection navigation not supported EF-216
         await AssertTranslationFailed(() =>
             base.Navigation_in_subquery_referencing_outer_query_with_client_side_result_operator_and_count(async));
 
         AssertMql(
         );
-#else
-        Assert.Contains(
-            "is not defined for type",
-            (await Assert.ThrowsAsync<ArgumentException>(() =>
-                base.Navigation_in_subquery_referencing_outer_query_with_client_side_result_operator_and_count(async))).Message);
-
-        AssertMql(
-        );
-#endif
     }
 
     public override async Task Select_Where_Navigation_Scalar_Equals_Navigation_Scalar(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindQueryFiltersQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindQueryFiltersQueryMongoTest.cs
@@ -137,11 +137,11 @@ Customers.{ "$lookup" : { "from" : "Orders", "localField" : "_id", "foreignField
         AssertMql(
         );
 #else
-        await Assert.ThrowsAnyAsync<Exception>(() => base.Included_many_to_one_query(async));
+        await base.Included_many_to_one_query(async);
 
         AssertMql(
             """
-Orders.
+Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : "^B", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner" : { "$ne" : null }, "_inner.CompanyName" : { "$ne" : null } } }
 """);
 #endif
     }
@@ -197,14 +197,11 @@ Customers.{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : 
         AssertMql(
 );
 #else
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Entity_Equality(async))).Message);
+        await base.Entity_Equality(async);
 
         AssertMql(
             """
-Orders.
+Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : "^B", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner" : { "$ne" : null }, "_inner.CompanyName" : { "$ne" : null } } }
 """);
 #endif
     }
@@ -231,11 +228,11 @@ Products.
         AssertMql(
         );
 #else
-        await Assert.ThrowsAnyAsync<Exception>(() => base.Included_many_to_one_query2(async));
+        await base.Included_many_to_one_query2(async);
 
         AssertMql(
             """
-Orders.
+Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : "^B", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner" : { "$ne" : null }, "_inner.CompanyName" : { "$ne" : null } } }
 """);
 #endif
     }

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindSelectQueryMongoTest.cs
@@ -1412,22 +1412,10 @@ Customers.
 
     public override async Task Reverse_in_join_inner_with_skip(bool async)
     {
-#if EF8 || EF9
-        // Fails: Reverse not supported CSHARP-5836
+        // Fails: Skip in join inner not supported EF-317
         await AssertTranslationFailed(() => base.Reverse_in_join_inner_with_skip(async));
 
         AssertMql();
-#else
-        Assert.Contains(
-            "Expression not supported",
-            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
-                base.Reverse_in_join_inner_with_skip(async))).Message);
-
-        AssertMql(
-            """
-Customers.
-""");
-#endif
     }
 
     public override async Task Reverse_in_SelectMany(bool async)

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
@@ -504,19 +504,10 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
             """);
     }
 
+    [ConditionalTheory(Skip = "EF-221: mismatched-type equality returns wrong results")]
+    [MemberData(nameof(IsAsyncData))]
     public override async Task Where_equals_using_object_overload_on_mismatched_types(bool async)
-    {
-        // Fails: Equals with different types issue EF-221
-        Assert.Contains(
-            "Unable to cast object of type 'System.UInt64' to type 'System.UInt32'.",
-            (await Assert.ThrowsAsync<InvalidCastException>(() =>
-                base.Where_equals_using_object_overload_on_mismatched_types(async))).Message);
-
-        AssertMql(
-            """
-            Employees.
-            """);
-    }
+        => await base.Where_equals_using_object_overload_on_mismatched_types(async);
 
     public override async Task Where_equals_using_int_overload_on_mismatched_types(bool async)
     {
@@ -528,19 +519,10 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
             """);
     }
 
+    [ConditionalTheory(Skip = "EF-221: mismatched-type equality returns wrong results")]
+    [MemberData(nameof(IsAsyncData))]
     public override async Task Where_equals_on_mismatched_types_nullable_int_long(bool async)
-    {
-        // Fails: Equals with different types issue EF-221
-        Assert.Contains(
-            "Unable to cast object of type 'System.UInt64' to type 'System.Nullable`1[System.UInt32]'.",
-            (await Assert.ThrowsAsync<InvalidCastException>(() => base.Where_equals_on_mismatched_types_nullable_int_long(async)))
-            .Message);
-
-        AssertMql(
-            """
-            Employees.
-            """);
-    }
+        => await base.Where_equals_on_mismatched_types_nullable_int_long(async);
 
     public override async Task Where_equals_on_mismatched_types_nullable_long_nullable_int(bool async)
     {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
@@ -506,7 +506,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_equals_using_object_overload_on_mismatched_types(bool async)
     {
-        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        // Fails: mismatched-type equality would silently return wrong results EF-221
         await AssertTranslationFailed(() => base.Where_equals_using_object_overload_on_mismatched_types(async));
 
         AssertMql(
@@ -525,7 +525,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_equals_on_mismatched_types_nullable_int_long(bool async)
     {
-        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        // Fails: mismatched-type equality would silently return wrong results EF-221
         await AssertTranslationFailed(() => base.Where_equals_on_mismatched_types_nullable_int_long(async));
 
         AssertMql(
@@ -534,7 +534,7 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
 
     public override async Task Where_equals_on_mismatched_types_nullable_long_nullable_int(bool async)
     {
-        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        // Fails: mismatched-type equality would silently return wrong results EF-221
         await AssertTranslationFailed(() => base.Where_equals_on_mismatched_types_nullable_long_nullable_int(async));
 
         AssertMql(

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindWhereQueryMongoTest.cs
@@ -504,10 +504,14 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
             """);
     }
 
-    [ConditionalTheory(Skip = "EF-221: mismatched-type equality returns wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task Where_equals_using_object_overload_on_mismatched_types(bool async)
-        => await base.Where_equals_using_object_overload_on_mismatched_types(async);
+    {
+        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        await AssertTranslationFailed(() => base.Where_equals_using_object_overload_on_mismatched_types(async));
+
+        AssertMql(
+        );
+    }
 
     public override async Task Where_equals_using_int_overload_on_mismatched_types(bool async)
     {
@@ -519,23 +523,22 @@ Employees.{ "$match" : { "ReportsTo" : 2 } }
             """);
     }
 
-    [ConditionalTheory(Skip = "EF-221: mismatched-type equality returns wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task Where_equals_on_mismatched_types_nullable_int_long(bool async)
-        => await base.Where_equals_on_mismatched_types_nullable_int_long(async);
+    {
+        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        await AssertTranslationFailed(() => base.Where_equals_on_mismatched_types_nullable_int_long(async));
+
+        AssertMql(
+        );
+    }
 
     public override async Task Where_equals_on_mismatched_types_nullable_long_nullable_int(bool async)
     {
-        // Fails: Equals with different types issue EF-221
-        Assert.Contains(
-            "Unable to cast object of type 'System.UInt64' to type 'System.Nullable`1[System.UInt32]'.",
-            (await Assert.ThrowsAsync<InvalidCastException>(() =>
-                base.Where_equals_on_mismatched_types_nullable_long_nullable_int(async))).Message);
+        // Fails: mismatched-type equality would silently return wrong results on driver 3.10 EF-221
+        await AssertTranslationFailed(() => base.Where_equals_on_mismatched_types_nullable_long_nullable_int(async));
 
         AssertMql(
-            """
-            Employees.
-            """);
+        );
     }
 
     public override async Task Where_equals_on_mismatched_types_int_nullable_int(bool async)


### PR DESCRIPTION
Bump MongoDB.Driver 3.9.0 -> 3.10.0 and route reference-navigation Includes through the driver's native MongoQueryable.LeftJoin (available on all EF versions), replacing the workarounds that existed only because the driver's LINQ v3 provider had no LeftJoin translator.

As well as removing a bunch of workarounds for the lack of LeftJoin this PR also means we can now support more queries (hence the enabling of many tests).
