### PR TITLE
EF-352: Fix shadow/scalar EF.Property read on joined entity in projection

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -653,10 +653,36 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
         // When a projection lambda does `new { o.Prop }`, EF stores MemberExpr(STS_root, "Prop")
         // in the projection mapping. Recognise the root entity's shaper here so we can resolve
         // the property and use its own BSON element name instead of the projected alias.
-        if (expression is StructuralTypeShaperExpression { StructuralType: IEntityType shaperEntityType }
-            && shaperEntityType == _rootEntityType)
+        if (expression is StructuralTypeShaperExpression { StructuralType: IEntityType shaperEntityType })
         {
-            return (shaperEntityType, DocParameter);
+            if (shaperEntityType == _rootEntityType)
+            {
+                return (shaperEntityType, DocParameter);
+            }
+
+            // A non-root entity shaper in a join query is the inner side of the join — e.g. reading a
+            // scalar or shadow property off the joined entity via `o.Prop` or `EF.Property(o, "Prop")`
+            // in a mixed projection. Resolve the read against the joined sub-document rather than the
+            // query root (which has no such top-level field and would otherwise materialise the value
+            // as null — EF-352). Which sub-document depends on the emitted join shape:
+            //   * driver-native join   -> the lone joined reference is nested under "_inner";
+            //   * flat $lookup+$unwind -> each join lands in its own root-level "_lookup_<Navigation>".
+            if (_queryExpression.IsJoinQuery)
+            {
+                if (_queryExpression.UsesDriverJoinFields)
+                {
+                    var innerDocument = CreateGetValueExpression(DocParameter, "_inner", false, typeof(BsonDocument));
+                    return (shaperEntityType, innerDocument);
+                }
+
+                var joinField = _queryExpression.GetPendingLookups()
+                    .FirstOrDefault(l => l.Navigation.TargetEntityType == shaperEntityType)?.As;
+                if (joinField != null)
+                {
+                    var lookupDocument = CreateGetValueExpression(DocParameter, joinField, false, typeof(BsonDocument));
+                    return (shaperEntityType, lookupDocument);
+                }
+            }
         }
 
         if (expression is ParameterExpression parameterExpression)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ShadowPropertyFlatJoinProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ShadowPropertyFlatJoinProjectionTests.cs
@@ -1,0 +1,157 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Extensions;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-352: the shadow-via-<c>EF.Property</c>-in-join-projection defect also occurs in the FLAT
+/// (<c>$lookup</c> + <c>$unwind</c>) cross-collection mode, which is triggered by a SECOND
+/// cross-collection join (more than one inner collection). Flat mode sets
+/// <c>UsesDriverJoinFields = false</c> and places each joined document under its own root-level
+/// <c>_lookup_&lt;Navigation&gt;</c> field instead of <c>_inner</c>, so the shaper must read the joined
+/// entity's scalars from that field. Translates and reproduces on all supported EF versions, so this
+/// is not version-guarded.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class ShadowPropertyFlatJoinProjectionTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    [Fact]
+    public void Shadow_property_via_EF_Property_in_flat_multi_join_projection_materializes_value()
+    {
+        var (customersName, ordersName, itemsName) = Seed();
+
+        using var db = new FlatJoinDbContext(database, customersName, ordersName, itemsName);
+
+        var query =
+            from c in db.Customers
+            join o in db.Orders on c.CustomerId equals o.CustomerId
+            join i in db.Items on o.OrderId equals i.OrderId
+            where c.CustomerId == "ALFKI"
+            select new
+            {
+                o,
+                i,
+                Shadow = EF.Property<DateTime?>(o, "OrderDate")
+            };
+
+        var results = query.ToList();
+
+        Assert.NotEmpty(results);
+        Assert.All(results, r => Assert.NotNull(r.o));
+        Assert.All(results, r => Assert.NotNull(r.i));
+        Assert.All(results, r => Assert.NotNull(r.Shadow));
+    }
+
+    private (string customersName, string ordersName, string itemsName) Seed()
+    {
+        var customersName = TemporaryDatabaseFixtureBase.CreateCollectionName("FlatCustomers") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("FlatOrders") + Guid.NewGuid().ToString("N")[..8];
+        var itemsName = TemporaryDatabaseFixtureBase.CreateCollectionName("FlatItems") + Guid.NewGuid().ToString("N")[..8];
+
+        database.MongoDatabase.GetCollection<BsonDocument>(customersName).InsertMany([
+            new BsonDocument { { "_id", "ALFKI" }, { "name", "Alfreds" } }
+        ]);
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertMany([
+            new BsonDocument { { "_id", 10643 }, { "cust_id", "ALFKI" }, { "OrderDate", new DateTime(1997, 8, 25, 0, 0, 0, DateTimeKind.Utc) } }
+        ]);
+        database.MongoDatabase.GetCollection<BsonDocument>(itemsName).InsertMany([
+            new BsonDocument { { "_id", 1 }, { "ord_id", 10643 }, { "sku", "A" } },
+            new BsonDocument { { "_id", 2 }, { "ord_id", 10643 }, { "sku", "B" } }
+        ]);
+
+        return (customersName, ordersName, itemsName);
+    }
+
+    class FjCustomer
+    {
+        public string CustomerId { get; set; }
+        public string Name { get; set; }
+        public List<FjOrder> Orders { get; set; }
+    }
+
+    class FjOrder
+    {
+        public int OrderId { get; set; }
+        public string CustomerId { get; set; }
+        public FjCustomer Customer { get; set; }
+        public List<FjItem> Items { get; set; }
+    }
+
+    class FjItem
+    {
+        public int ItemId { get; set; }
+        public int OrderId { get; set; }
+        public FjOrder Order { get; set; }
+        public string Sku { get; set; }
+    }
+
+    class FlatJoinDbContext(TemporaryDatabaseFixture database, string customersCollection, string ordersCollection, string itemsCollection)
+        : DbContext(new DbContextOptionsBuilder<FlatJoinDbContext>()
+            .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+            .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options)
+    {
+        public DbSet<FjCustomer> Customers { get; set; }
+        public DbSet<FjOrder> Orders { get; set; }
+        public DbSet<FjItem> Items { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<FjCustomer>(b =>
+            {
+                b.ToCollection(customersCollection);
+                b.HasKey(c => c.CustomerId);
+                b.Property(c => c.CustomerId).HasElementName("_id");
+                b.Property(c => c.Name).HasElementName("name");
+                b.HasMany(c => c.Orders).WithOne(o => o.Customer).HasForeignKey(o => o.CustomerId);
+            });
+
+            modelBuilder.Entity<FjOrder>(b =>
+            {
+                b.ToCollection(ordersCollection);
+                b.HasKey(o => o.OrderId);
+                b.Property(o => o.OrderId).HasElementName("_id");
+                b.Property(o => o.CustomerId).HasElementName("cust_id");
+                b.Property<DateTime?>("OrderDate").HasElementName("OrderDate");
+                b.HasMany(o => o.Items).WithOne(i => i.Order).HasForeignKey(i => i.OrderId);
+            });
+
+            modelBuilder.Entity<FjItem>(b =>
+            {
+                b.ToCollection(itemsCollection);
+                b.HasKey(i => i.ItemId);
+                b.Property(i => i.ItemId).HasElementName("_id");
+                b.Property(i => i.OrderId).HasElementName("ord_id");
+                b.Property(i => i.Sku).HasElementName("sku");
+            });
+        }
+
+        private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime) => Interlocked.Increment(ref _count);
+        }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ShadowPropertyJoinProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ShadowPropertyJoinProjectionTests.cs
@@ -1,0 +1,158 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Extensions;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-352: reading a shadow property via <c>EF.Property&lt;T&gt;(...)</c> inside a client-side
+/// cross-collection join projection must materialise the stored value, not null. The explicit
+/// LINQ <c>join</c> translates on all supported EF versions (EF8/EF9/EF10), and the defect
+/// reproduced on all three, so these tests are not version-guarded.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class ShadowPropertyJoinProjectionTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    [Fact]
+    public void Shadow_property_via_EF_Property_in_join_projection_materializes_value()
+    {
+        var (ordersName, customersName) = Seed();
+
+        using var db = new JoinDbContext(database, ordersName, customersName);
+
+        var query =
+            from c in db.Customers
+            join o1 in
+                (from o2 in db.Orders
+                 orderby o2.OrderId
+                 select new { o2 }) on c.CustomerId equals o1.o2.CustomerId
+            where EF.Property<string>(o1.o2, "CustomerId") == "ALFKI"
+            select new
+            {
+                o1,
+                o1.o2,
+                Shadow = EF.Property<DateTime?>(o1.o2, "OrderDate")
+            };
+
+        var results = query.ToList();
+
+        Assert.NotEmpty(results);
+        // The joined order entity itself materialises fine...
+        Assert.All(results, r => Assert.NotNull(r.o2));
+        // ...but the shadow property read through EF.Property must not come back null.
+        Assert.All(results, r => Assert.NotNull(r.Shadow));
+        Assert.Contains(results, r => r.Shadow == new DateTime(1997, 8, 25));
+    }
+
+    [Fact]
+    public void Shadow_property_via_EF_Property_in_direct_join_projection_materializes_value()
+    {
+        var (ordersName, customersName) = Seed();
+
+        using var db = new JoinDbContext(database, ordersName, customersName);
+
+        var query =
+            from c in db.Customers
+            join o in db.Orders on c.CustomerId equals o.CustomerId
+            where c.CustomerId == "ALFKI"
+            select new
+            {
+                o,
+                Shadow = EF.Property<DateTime?>(o, "OrderDate")
+            };
+
+        var results = query.ToList();
+
+        Assert.NotEmpty(results);
+        Assert.All(results, r => Assert.NotNull(r.o));
+        Assert.All(results, r => Assert.NotNull(r.Shadow));
+    }
+
+    private (string ordersName, string customersName) Seed()
+    {
+        var customersName = TemporaryDatabaseFixtureBase.CreateCollectionName("ShadowJoinCustomers") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("ShadowJoinOrders") + Guid.NewGuid().ToString("N")[..8];
+
+        database.MongoDatabase.GetCollection<BsonDocument>(customersName).InsertMany([
+            new BsonDocument { { "_id", "ALFKI" }, { "name", "Alfreds" } },
+            new BsonDocument { { "_id", "ANATR" }, { "name", "Ana Trujillo" } }
+        ]);
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertMany([
+            new BsonDocument { { "_id", 10643 }, { "cust_id", "ALFKI" }, { "OrderDate", new DateTime(1997, 8, 25, 0, 0, 0, DateTimeKind.Utc) } },
+            new BsonDocument { { "_id", 10692 }, { "cust_id", "ALFKI" }, { "OrderDate", new DateTime(1997, 10, 3, 0, 0, 0, DateTimeKind.Utc) } },
+            new BsonDocument { { "_id", 10308 }, { "cust_id", "ANATR" }, { "OrderDate", new DateTime(1996, 9, 18, 0, 0, 0, DateTimeKind.Utc) } }
+        ]);
+
+        return (ordersName, customersName);
+    }
+
+    class JCustomer
+    {
+        public string CustomerId { get; set; }
+        public string Name { get; set; }
+    }
+
+    class JOrder
+    {
+        public int OrderId { get; set; }
+        public string CustomerId { get; set; }
+    }
+
+    class JoinDbContext(TemporaryDatabaseFixture database, string ordersCollection, string customersCollection)
+        : DbContext(new DbContextOptionsBuilder<JoinDbContext>()
+            .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+            .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options)
+    {
+        public DbSet<JOrder> Orders { get; set; }
+        public DbSet<JCustomer> Customers { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<JCustomer>(b =>
+            {
+                b.ToCollection(customersCollection);
+                b.HasKey(c => c.CustomerId);
+                b.Property(c => c.CustomerId).HasElementName("_id");
+                b.Property(c => c.Name).HasElementName("name");
+            });
+
+            modelBuilder.Entity<JOrder>(b =>
+            {
+                b.ToCollection(ordersCollection);
+                b.HasKey(o => o.OrderId);
+                b.Property(o => o.OrderId).HasElementName("_id");
+                b.Property(o => o.CustomerId).HasElementName("cust_id");
+                // OrderDate is a SHADOW property (no CLR member on JOrder).
+                b.Property<DateTime?>("OrderDate").HasElementName("OrderDate");
+            });
+        }
+
+        private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime) => Interlocked.Increment(ref _count);
+        }
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
@@ -161,10 +161,15 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
     public override async Task Join_customers_orders_with_subquery_with_take(bool async)
         => await base.Join_customers_orders_with_subquery_with_take(async);
 
-    [ConditionalTheory(Skip = "EF-352: shadow property read via EF.Property in a client-side join projection materialises as null")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task Join_customers_orders_with_subquery_anonymous_property_method(bool async)
-        => await base.Join_customers_orders_with_subquery_anonymous_property_method(async);
+    {
+        await base.Join_customers_orders_with_subquery_anonymous_property_method(async);
+
+        AssertMql(
+            """
+Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner.CustomerID" : "ALFKI" } }
+""");
+    }
 
     [ConditionalTheory(Skip = "CSHARP-6017: driver 3.10 folds an uncorrelated Take/subquery join inner into the correlated $lookup sub-pipeline, returning wrong results")]
     [MemberData(nameof(IsAsyncData))]


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EF-352

### Problem
Reading a scalar or shadow property via `EF.Property<T>(o, "…")` (or `o.Prop`) off the **joined (inner)** entity of a cross-collection join projection materialised as `null`, even though the rows and the joined entity itself came back correctly.

Example (the exact spec repro):
```csharp
from c in ss.Set<Customer>()
join o1 in (from o2 in ss.Set<Order>() orderby o2.OrderID select new { o2 })
    on c.CustomerID equals o1.o2.CustomerID
where EF.Property<string>(o1.o2, "CustomerID") == "ALFKI"
select new { o1, o1.o2, Shadow = EF.Property<DateTime?>(o1.o2, "OrderDate") }
// Shadow == null for every row
```

### Root cause
`MongoProjectionBindingRemovingExpressionVisitor.TryResolveFieldAccessSource` only resolved the **query root** entity's `StructuralTypeShaperExpression`. A **non-root** (joined/inner) entity shaper fell through to `(null, null)`, so the mixed-projection visitor could neither find the property nor its owning document and fell back to reading the element off the **root** document — which in a join holds only the join sub-documents (`_outer`/`_inner` or `_lookup_*`), never the property at top level. The joined entity materialised fine because it binds to the joined document through a different path.

### Fix
Resolve a non-root joined-entity shaper to the correct joined sub-document, chosen by the emitted join shape (single source of truth = `UsesDriverJoinFields`):

- **driver-native join** → the lone joined reference under `_inner`;
- **flat `$lookup` + `$unwind`** (2+ joins) → the join's own root-level `_lookup_<Navigation>` field, derived from the same `LookupExpression` the pipeline emits (matched by target entity type).

Gated on `IsJoinQuery`, so non-join queries and embedded/owned non-root shapers are byte-for-byte unchanged.

### Tests
- Re-enables the previously-skipped spec test `NorthwindJoinQueryMongoTest.Join_customers_orders_with_subquery_anonymous_property_method` (was `[Skip = "EF-352: …"]`) with its MQL baseline.
- Adds `ShadowPropertyJoinProjectionTests` (driver-native join) and `ShadowPropertyFlatJoinProjectionTests` (flat multi-join). Both modes were confirmed to fail (`null`) pre-fix and pass post-fix.

### Verification
Full suites green on all three EF targets:

| Version | Passed | Failed | Skipped |
|---|---|---|---|
| EF8  | 6656 | 0 | 75 |
| EF9  | 7017 | 0 | 76 |
| EF10 | 6604 | 0 | 79 |

The explicit `join` translates on all supported versions (EF8/EF9/EF10) — this is not EF10-only.

### Notes
- No public API or annotation changes; the modified type is `internal`. No breaking changes.
