### PR TITLE
EF-333: Fix MongoOptionsExtension copy constructor dropping crypt options

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoClientSettingsHelper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoClientSettingsHelper.cs
@@ -72,14 +72,46 @@ internal static class MongoClientSettingsHelper
 
         if (usesEncryption)
         {
-            clientSettings.AutoEncryptionOptions = new AutoEncryptionOptions(
-                keyVaultNamespace,
-                kmsProviders,
-                encryptedFieldsMap: queryableEncryptionSchema?.ToDictionary(d => options?.DatabaseName + "." + d.Key, d => d.Value),
-                extraOptions: autoEncryptionExtraOptions);
+            var existingAutoEncryptionOptions = clientSettings.AutoEncryptionOptions;
+            var encryptedFieldsMap = MergeEncryptedFieldsMap(
+                existingAutoEncryptionOptions?.EncryptedFieldsMap, queryableEncryptionSchema, options?.DatabaseName);
+
+            clientSettings.AutoEncryptionOptions = existingAutoEncryptionOptions != null
+                ? existingAutoEncryptionOptions.With(
+                    keyVaultNamespace: new Optional<CollectionNamespace>(keyVaultNamespace!),
+                    kmsProviders: new Optional<IReadOnlyDictionary<string, IReadOnlyDictionary<string, object>>>(kmsProviders!),
+                    extraOptions: new Optional<IReadOnlyDictionary<string, object>>(autoEncryptionExtraOptions),
+                    encryptedFieldsMap: new Optional<IReadOnlyDictionary<string, BsonDocument>>(encryptedFieldsMap!))
+                : new AutoEncryptionOptions(
+                    keyVaultNamespace!,
+                    kmsProviders!,
+                    encryptedFieldsMap: new Optional<IReadOnlyDictionary<string, BsonDocument>>(encryptedFieldsMap!),
+                    extraOptions: new Optional<IReadOnlyDictionary<string, object>>(autoEncryptionExtraOptions));
         }
 
         return clientSettings;
+    }
+
+    private static IReadOnlyDictionary<string, BsonDocument>? MergeEncryptedFieldsMap(
+        IReadOnlyDictionary<string, BsonDocument>? existingEncryptedFieldsMap,
+        Dictionary<string, BsonDocument>? queryableEncryptionSchema,
+        string? databaseName)
+    {
+        if (queryableEncryptionSchema is not { Count: > 0 })
+        {
+            return existingEncryptedFieldsMap;
+        }
+
+        var mergedEncryptedFieldsMap = existingEncryptedFieldsMap != null
+            ? new Dictionary<string, BsonDocument>(existingEncryptedFieldsMap)
+            : new Dictionary<string, BsonDocument>();
+
+        foreach (var (collectionName, schema) in queryableEncryptionSchema)
+        {
+            mergedEncryptedFieldsMap[databaseName + "." + collectionName] = schema;
+        }
+
+        return mergedEncryptedFieldsMap;
     }
 
     private static void ApplyOptions(

--- a/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
+++ b/src/MongoDB.EntityFrameworkCore/Infrastructure/MongoOptionsExtension.cs
@@ -51,8 +51,10 @@ public class MongoOptionsExtension : IDbContextOptionsExtension
         MongoClient = copyFrom.MongoClient;
         CryptProvider = copyFrom.CryptProvider;
         CryptProviderPath = copyFrom.CryptProviderPath;
+        CryptExtraOptions = copyFrom.CryptExtraOptions;
         KeyVaultNamespace = copyFrom.KeyVaultNamespace;
         KmsProviders = copyFrom.KmsProviders;
+        QueryableEncryptionSchemaMode = copyFrom.QueryableEncryptionSchemaMode;
         _loggableConnectionString = SanitizeConnectionStringForLogging(ConnectionString);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoClientSettingsHelperTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoClientSettingsHelperTests.cs
@@ -1,0 +1,69 @@
+/* Copyright 2023-present MongoDB Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.EntityFrameworkCore.Infrastructure;
+
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Infrastructure;
+
+public static class MongoClientSettingsHelperTests
+{
+    [Fact]
+    public static void CreateSettings_preserves_existing_AutoEncryptionOptions_when_applying_queryable_encryption_schema()
+    {
+        var keyVaultNamespace = CollectionNamespace.FromFullName("keyvault.datakeys");
+        var kmsProviders = new Dictionary<string, IReadOnlyDictionary<string, object>>
+        {
+            ["local"] = new Dictionary<string, object> { ["key"] = new byte[96] }
+        };
+        var tlsOptions = new Dictionary<string, SslSettings> { ["local"] = new SslSettings() };
+        var schemaMap = new Dictionary<string, BsonDocument> { ["db.schema"] = new BsonDocument() };
+        var existingEncryptedFieldsMap = new Dictionary<string, BsonDocument> { ["db.other"] = new BsonDocument("fields", new BsonArray()) };
+
+        var clientSettings = new MongoClientSettings
+        {
+            AutoEncryptionOptions = new AutoEncryptionOptions(
+                keyVaultNamespace,
+                kmsProviders,
+                bypassAutoEncryption: true,
+                bypassQueryAnalysis: true,
+                tlsOptions: tlsOptions,
+                schemaMap: schemaMap,
+                encryptedFieldsMap: existingEncryptedFieldsMap)
+        };
+
+        var options = new MongoOptionsExtension()
+            .WithClientSettings(clientSettings)
+            .WithDatabaseName("db");
+
+        var queryableEncryptionSchema = new Dictionary<string, BsonDocument>
+        {
+            ["encrypted"] = new BsonDocument("fields", new BsonArray())
+        };
+
+        var result = MongoClientSettingsHelper.CreateSettings(options, queryableEncryptionSchema);
+
+        Assert.NotNull(result.AutoEncryptionOptions);
+        Assert.True(result.AutoEncryptionOptions.BypassAutoEncryption);
+        Assert.True(result.AutoEncryptionOptions.BypassQueryAnalysis);
+        Assert.Same(tlsOptions, result.AutoEncryptionOptions.TlsOptions);
+        Assert.Same(schemaMap, result.AutoEncryptionOptions.SchemaMap);
+        Assert.Equal(existingEncryptedFieldsMap["db.other"], result.AutoEncryptionOptions.EncryptedFieldsMap["db.other"]);
+        Assert.Equal(queryableEncryptionSchema["encrypted"], result.AutoEncryptionOptions.EncryptedFieldsMap["db.encrypted"]);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoOptionsExtensionTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Infrastructure/MongoOptionsExtensionTest.cs
@@ -88,4 +88,18 @@ public static class MongoOptionsExtensionTest
         Assert.Contains("ClientSettings", ex.Message);
         Assert.Contains(nameof(MongoClient), ex.Message);
     }
+
+    [Fact]
+    public static void Clone_preserves_crypt_extra_options_and_schema_mode_set_by_earlier_With_call()
+    {
+        var extraOptions = new Dictionary<string, object> {{"cryptSharedLibPath", "/some/path"}};
+
+        var options = new MongoOptionsExtension()
+            .WithCryptProvider(CryptProvider.AutoEncryptSharedLibrary, "/some/path", extraOptions)
+            .WithQueryableEncryptionSchemaMode(QueryableEncryptionSchemaMode.Ignore)
+            .WithDatabaseName("MyDatabase");
+
+        Assert.Same(extraOptions, options.CryptExtraOptions);
+        Assert.Equal(QueryableEncryptionSchemaMode.Ignore, options.QueryableEncryptionSchemaMode);
+    }
 }


### PR DESCRIPTION
The copy constructor omitted CryptExtraOptions and QueryableEncryptionSchemaMode, so any With* call chained after WithCryptProvider or WithQueryableEncryptionSchemaMode silently discarded them via cloning.