### PR TITLE
EF-349: Fix driver-LINQ discriminator filters to match converted/represented values

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
@@ -20,6 +20,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
 
 namespace MongoDB.EntityFrameworkCore.Serializers;
@@ -32,6 +33,7 @@ internal class MongoEFDiscriminator(IReadOnlyEntityType entityType) :
     IScalarDiscriminatorConvention
 {
     private readonly IReadOnlyModel _model = entityType.Model;
+    private readonly IReadOnlyProperty? _discriminatorProperty = entityType.FindDiscriminatorProperty();
 
     public Type GetActualType(IBsonReader bsonReader, Type nominalType)
         => throw new NotImplementedException($"Attempted to resolve type discriminator for '{nominalType.ShortDisplayName()}'.");
@@ -40,15 +42,37 @@ internal class MongoEFDiscriminator(IReadOnlyEntityType entityType) :
     {
         var actualEntityType = _model.FindEntityType(actualType)
                               ?? throw new InvalidOperationException($"Entity type '{actualType.ShortDisplayName()}' not found in model.");
-        return BsonValue.Create(actualEntityType.GetDiscriminatorValue());
+        return SerializeDiscriminatorValue(actualEntityType.GetDiscriminatorValue());
     }
 
     public BsonValue[] GetDiscriminatorsForTypeAndSubTypes(Type type)
     {
         var entityType = _model.FindEntityType(type)
                          ?? throw new InvalidOperationException($"Entity type '{type.ShortDisplayName()}' not found in model.");
-        return entityType.GetDerivedTypes().Prepend(entityType).Select(d => BsonValue.Create(d.GetDiscriminatorValue())).ToArray();
+        return entityType.GetDerivedTypes().Prepend(entityType)
+            .Select(d => SerializeDiscriminatorValue(d.GetDiscriminatorValue())).ToArray();
     }
 
     public string ElementName { get; } = entityType.FindDiscriminatorProperty()?.GetElementName() ?? "_t";
+
+    // The discriminator is a normal IProperty, so its stored value has already been transformed by any
+    // Mongo:BsonRepresentation or ValueConverter configured on it. Filters built from the raw discriminator
+    // value must be transformed the same way, or they won't match what's actually stored in "_t".
+    private BsonValue SerializeDiscriminatorValue(object? value)
+    {
+        if (value == null || _discriminatorProperty == null)
+        {
+            return BsonValue.Create(value);
+        }
+
+        var serializer = BsonSerializerFactory.CreateTypeSerializer(_discriminatorProperty);
+
+        var document = new BsonDocument();
+        using var writer = new BsonDocumentWriter(document);
+        writer.WriteStartDocument();
+        writer.WriteName("v");
+        serializer.Serialize(BsonSerializationContext.CreateRoot(writer), value);
+        writer.WriteEndDocument();
+        return document["v"];
+    }
 }

--- a/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
+++ b/src/MongoDB.EntityFrameworkCore/Serializers/MongoEFDiscriminator.cs
@@ -57,7 +57,7 @@ internal class MongoEFDiscriminator(IReadOnlyEntityType entityType) :
 
     // The discriminator is a normal IProperty, so its stored value has already been transformed by any
     // Mongo:BsonRepresentation or ValueConverter configured on it. Filters built from the raw discriminator
-    // value must be transformed the same way, or they won't match what's actually stored in "_t".
+    // value must be transformed the same way, or they won't match what's actually stored in the discriminator element.
     private BsonValue SerializeDiscriminatorValue(object? value)
     {
         if (value == null || _discriminatorProperty == null)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Mapping/DiscriminatorTests.cs
@@ -107,6 +107,70 @@ public class DiscriminatorTests(TemporaryDatabaseFixture database)
     }
 
     [Fact]
+    public void Returns_correct_entity_with_OfType_query_when_discriminator_has_value_converter()
+    {
+        var collection = database.CreateCollection<GuidKeyedEntity>();
+        var configuration = (ModelBuilder mb) =>
+        {
+            mb.Entity<GuidKeyedEntity>(e =>
+            {
+                e.HasDiscriminator(g => g.SubType)
+                    .HasValue<KeyedCustomer>(1)
+                    .HasValue<KeyedOrder>(2);
+                e.Property(g => g.SubType).HasConversion(v => v + 100, v => v - 100);
+            });
+        };
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, configuration);
+            db.Add(new KeyedCustomer {Name = "Customer 1"});
+            db.Add(new KeyedOrder {OrderReference = "Order 1"});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, configuration);
+            var customer = Assert.Single(db.Entities.OfType<KeyedCustomer>());
+            Assert.Equal("Customer 1", customer.Name);
+
+            var order = Assert.Single(db.Entities.OfType<KeyedOrder>());
+            Assert.Equal("Order 1", order.OrderReference);
+        }
+    }
+
+    [Fact]
+    public void Returns_correct_entity_with_OfType_query_when_discriminator_has_bson_representation()
+    {
+        var collection = database.CreateCollection<GuidKeyedEntity>();
+        var configuration = (ModelBuilder mb) =>
+        {
+            mb.Entity<GuidKeyedEntity>(e =>
+            {
+                e.HasDiscriminator(g => g.SubType)
+                    .HasValue<KeyedCustomer>(1)
+                    .HasValue<KeyedOrder>(2);
+                e.Property(g => g.SubType).HasBsonRepresentation(BsonType.String);
+            });
+        };
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, configuration);
+            db.Add(new KeyedCustomer {Name = "Customer 1"});
+            db.Add(new KeyedOrder {OrderReference = "Order 1"});
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection, configuration);
+            var customer = Assert.Single(db.Entities.OfType<KeyedCustomer>());
+            Assert.Equal("Customer 1", customer.Name);
+
+            var order = Assert.Single(db.Entities.OfType<KeyedOrder>());
+            Assert.Equal("Order 1", order.OrderReference);
+        }
+    }
+
+    [Fact]
     public void Can_configure_type_discriminator_element_name()
     {
         var configuration = (ModelBuilder mb) =>


### PR DESCRIPTION
MongoEFDiscriminator built filter values via BsonValue.Create on the raw discriminator value, but a value-converted or BsonRepresentation-configured discriminator property is written through its normal property serializer, so the stored _t holds the converted value. The mismatch made OfType<T>() and other discriminator-narrowed queries return empty results on the driver-LINQ path. Route the filter value through the discriminator property's serializer so it matches what's actually stored.