### PR TITLE
EF-356: Fix computed-arithmetic leaf clobbered by whole-entity mixed projection

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
@@ -74,6 +75,11 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
                         // (e.g. select new { o }) — hand back the BsonDocument for the entity shaper.
                         // But a scalar root-property binding (e.g. select p.name.ToArray()) also has no
                         // alias; resolve it to a field read instead of returning the whole document.
+                        if (TryBindArithmeticLeaf(sourceExpression, projectionBindingExpression.Type, out var rootArithmeticRead))
+                        {
+                            return rootArithmeticRead;
+                        }
+
                         var rootField = TryResolveFieldAccess(sourceExpression);
                         if (rootField.Property != null)
                             return CreateGetValueExpression(
@@ -100,6 +106,16 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
                 if (TryBindNavigationMemberAccess(sourceExpression, projectionBindingExpression.Type, out var navMemberRead))
                 {
                     return navMemberRead;
+                }
+
+                // A computed-arithmetic leaf (e.g. select new { c, Total = c.Age * c.Score }) mixed alongside
+                // a whole entity reference. MongoProjectionBindingExpressionVisitor registers the raw binary
+                // expression as a single projection-mapping leaf (see its arithmetic BinaryExpression case);
+                // evaluate it here by resolving each operand against the materialized document and rebuilding
+                // the arithmetic client-side, since the driver-LINQ Select was stripped in this mixed path.
+                if (TryBindArithmeticLeaf(sourceExpression, projectionBindingExpression.Type, out var arithmeticRead))
+                {
+                    return arithmeticRead;
                 }
 
                 var fieldAccess = TryResolveFieldAccess(sourceExpression);
@@ -198,5 +214,91 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
         var innerDoc = CreateGetValueExpression(_docParameter, "_inner", false, typeof(BsonDocument));
         result = CreateGetValueExpression(innerDoc, property, resultType);
         return true;
+    }
+
+    /// <summary>
+    /// Binds a computed-arithmetic projection leaf (e.g. <c>select new { c, Total = c.Age * c.Score }</c>).
+    /// <see cref="MongoProjectionBindingExpressionVisitor"/> registers such a leaf as the raw
+    /// <see cref="BinaryExpression"/> (not decomposed into independent operand bindings — see its arithmetic
+    /// case), because the mapped projection is stored once per <c>ProjectionMember</c> and decomposing would
+    /// have both operands clobber that single slot. In this mixed path the driver-LINQ Select was stripped
+    /// (full <see cref="BsonDocument"/>s come back), so the arithmetic must be evaluated client-side: each
+    /// operand is resolved to a document read (recursing for nested arithmetic) and the same operator is
+    /// rebuilt over the resolved reads. Returns <see langword="false"/> for anything that is not such an
+    /// arithmetic leaf so the caller can fall back to its other resolution paths.
+    /// </summary>
+    private bool TryBindArithmeticLeaf(Expression? mappedExpression, Type resultType, out Expression result)
+    {
+        result = null!;
+
+        if (mappedExpression is not BinaryExpression { NodeType: ExpressionType.Add or ExpressionType.Subtract
+                or ExpressionType.Multiply or ExpressionType.Divide or ExpressionType.Modulo } binaryExpression)
+        {
+            return false;
+        }
+
+        var left = ResolveArithmeticOperand(binaryExpression.Left);
+        var right = ResolveArithmeticOperand(binaryExpression.Right);
+
+        result = Expression.MakeBinary(binaryExpression.NodeType, left, right);
+        if (result.Type != resultType)
+        {
+            result = Expression.Convert(result, resultType);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves one operand of a computed-arithmetic projection leaf (see <see cref="TryBindArithmeticLeaf"/>)
+    /// to an expression that reads its value from the materialized document. Constants pass through unchanged;
+    /// nested arithmetic recurses; a scalar property access (member or <c>EF.Property</c>, on the root entity
+    /// or a joined navigation target) is resolved the same way a standalone scalar leaf would be.
+    /// </summary>
+    private Expression ResolveArithmeticOperand(Expression operand)
+    {
+        if (operand is ConstantExpression)
+        {
+            return operand;
+        }
+
+        var unwrapped = operand.RemoveConvert();
+
+        if (unwrapped is BinaryExpression { NodeType: ExpressionType.Add or ExpressionType.Subtract
+                or ExpressionType.Multiply or ExpressionType.Divide or ExpressionType.Modulo } nestedBinary)
+        {
+            Expression nestedResult = Expression.MakeBinary(
+                nestedBinary.NodeType,
+                ResolveArithmeticOperand(nestedBinary.Left),
+                ResolveArithmeticOperand(nestedBinary.Right));
+
+            return nestedResult.Type == operand.Type ? nestedResult : Expression.Convert(nestedResult, operand.Type);
+        }
+
+        if (TryBindNavigationMemberAccess(unwrapped, operand.Type, out var navRead))
+        {
+            return navRead;
+        }
+
+        var fieldAccess = TryResolveFieldAccess(unwrapped);
+        if (fieldAccess.Property != null)
+        {
+            var docExpr = fieldAccess.DocumentExpression ?? _docParameter;
+            if (_queryExpression.UsesDriverJoinFields
+                && ReferenceEquals(docExpr, _docParameter))
+            {
+                docExpr = CreateGetValueExpression(_docParameter, "_outer", true, typeof(BsonDocument));
+            }
+
+            return CreateGetValueExpression(docExpr, fieldAccess.Property, operand.Type);
+        }
+
+        if (fieldAccess.FieldName != null)
+        {
+            return BsonBinding.CreateGetElementValue(
+                fieldAccess.DocumentExpression ?? _docParameter, fieldAccess.FieldName, operand.Type);
+        }
+
+        throw new InvalidOperationException(CoreStrings.TranslationFailed(operand.Print()));
     }
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoMixedProjectionBindingRemovingExpressionVisitor.cs
@@ -240,7 +240,8 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
         var left = ResolveArithmeticOperand(binaryExpression.Left);
         var right = ResolveArithmeticOperand(binaryExpression.Right);
 
-        result = Expression.MakeBinary(binaryExpression.NodeType, left, right);
+        result = Expression.MakeBinary(
+            binaryExpression.NodeType, left, right, binaryExpression.IsLiftedToNull, binaryExpression.Method);
         if (result.Type != resultType)
         {
             result = Expression.Convert(result, resultType);
@@ -257,12 +258,12 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
     /// </summary>
     private Expression ResolveArithmeticOperand(Expression operand)
     {
-        if (operand is ConstantExpression)
+        var unwrapped = operand.RemoveConvert();
+
+        if (unwrapped is ConstantExpression)
         {
             return operand;
         }
-
-        var unwrapped = operand.RemoveConvert();
 
         if (unwrapped is BinaryExpression { NodeType: ExpressionType.Add or ExpressionType.Subtract
                 or ExpressionType.Multiply or ExpressionType.Divide or ExpressionType.Modulo } nestedBinary)
@@ -270,7 +271,9 @@ internal sealed class MongoMixedProjectionBindingRemovingExpressionVisitor
             Expression nestedResult = Expression.MakeBinary(
                 nestedBinary.NodeType,
                 ResolveArithmeticOperand(nestedBinary.Left),
-                ResolveArithmeticOperand(nestedBinary.Right));
+                ResolveArithmeticOperand(nestedBinary.Right),
+                nestedBinary.IsLiftedToNull,
+                nestedBinary.Method);
 
             return nestedResult.Type == operand.Type ? nestedResult : Expression.Convert(nestedResult, operand.Type);
         }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -127,9 +127,46 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
 
                 return new ProjectionBindingExpression(_queryExpression, projMember, expression.Type);
 
+            // A computed-arithmetic leaf (e.g. c.Age * c.Score) mixed into a projection alongside a whole
+            // entity reference (which forces the client-side "mixed projection" shaper — see
+            // MongoMixedProjectionBindingRemovingExpressionVisitor). Register the whole binary expression as
+            // a single projection-mapping leaf here, without visiting into its operands: the default walk
+            // (via base.Visit below) would visit Left and Right independently, each writing the SAME
+            // ProjectionMember dictionary slot (the current one hasn't changed), so the second operand would
+            // silently clobber the first (e.g. Age * Score would materialise as Score * Score).
+            // Scoped to operands that are themselves simple scalar reads / nested arithmetic over those
+            // (IsSimpleArithmeticLeaf) — NOT method calls such as a collection-navigation Sum()/Count(),
+            // which must still decompose through the normal walk so their own (more specific) translation
+            // failures / cross-collection guards continue to fire as before.
+            case BinaryExpression binaryExpression
+                when IsArithmeticNodeType(binaryExpression.NodeType) && IsSimpleArithmeticLeaf(binaryExpression):
+                var arithmeticMember = GetCurrentProjectionMember();
+                _projectionMapping[arithmeticMember] = binaryExpression;
+
+                return new ProjectionBindingExpression(_queryExpression, arithmeticMember, expression.Type);
+
             default:
                 return base.Visit(expression);
         }
+    }
+
+    private static bool IsArithmeticNodeType(ExpressionType nodeType)
+        => nodeType is ExpressionType.Add or ExpressionType.Subtract or ExpressionType.Multiply
+            or ExpressionType.Divide or ExpressionType.Modulo;
+
+    private static bool IsSimpleArithmeticLeaf(Expression expression)
+    {
+        expression = expression.RemoveConvert();
+
+        return expression switch
+        {
+            ConstantExpression => true,
+            MemberExpression => true,
+            MethodCallExpression methodCallExpression when methodCallExpression.TryGetEFPropertyArguments(out _, out _) => true,
+            BinaryExpression binaryExpression when IsArithmeticNodeType(binaryExpression.NodeType) =>
+                IsSimpleArithmeticLeaf(binaryExpression.Left) && IsSimpleArithmeticLeaf(binaryExpression.Right),
+            _ => false,
+        };
     }
 
     /// <inheritdoc />

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/MixedProjectionArithmeticTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/MixedProjectionArithmeticTests.cs
@@ -1,0 +1,60 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-353: a projection mixing a whole-entity reference with a computed-arithmetic leaf over two
+/// distinct scalar properties forces the client-side "mixed projection" shaper. That shaper's
+/// default expression walk decomposed the arithmetic binary expression into two independent member
+/// visits that clobbered a single projection-mapping slot, so the second operand silently overwrote
+/// the first (e.g. Age * Score materialised as Score * Score).
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class MixedProjectionArithmeticTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    class Entity
+    {
+        public ObjectId _id { get; set; }
+        public int Age { get; set; }
+        public int Score { get; set; }
+    }
+
+    [Fact]
+    public void Select_projection_entity_and_computed_arithmetic_leaf_uses_correct_operands()
+    {
+        using (var db = SingleEntityDbContext.Create<Entity>(database))
+        {
+            db.Set<Entity>().AddRange(
+                new Entity { Age = 3, Score = 7 },
+                new Entity { Age = 5, Score = 2 });
+            db.SaveChanges();
+        }
+
+        using var readDb = SingleEntityDbContext.Create<Entity>(database);
+        var results = readDb.Set<Entity>()
+            .Select(e => new { e, Total = e.Age * e.Score })
+            .ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal(r.e.Age * r.e.Score, r.Total));
+
+        Assert.Contains(results, r => r.e.Age == 3 && r.e.Score == 7 && r.Total == 21);
+        Assert.Contains(results, r => r.e.Age == 5 && r.e.Score == 2 && r.Total == 10);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/MixedProjectionArithmeticTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/MixedProjectionArithmeticTests.cs
@@ -38,16 +38,15 @@ public class MixedProjectionArithmeticTests(TemporaryDatabaseFixture database)
     [Fact]
     public void Select_projection_entity_and_computed_arithmetic_leaf_uses_correct_operands()
     {
-        using (var db = SingleEntityDbContext.Create<Entity>(database))
-        {
-            db.Set<Entity>().AddRange(
-                new Entity { Age = 3, Score = 7 },
-                new Entity { Age = 5, Score = 2 });
-            db.SaveChanges();
-        }
+        using var db = SingleEntityDbContext.Create<Entity>(database);
 
-        using var readDb = SingleEntityDbContext.Create<Entity>(database);
-        var results = readDb.Set<Entity>()
+        db.Set<Entity>().AddRange(
+            new Entity { Age = 3, Score = 7 },
+                new Entity { Age = 5, Score = 2 });
+        db.SaveChanges();
+        db.ChangeTracker.Clear();
+
+        var results = db.Set<Entity>()
             .Select(e => new { e, Total = e.Age * e.Score })
             .ToList();
 


### PR DESCRIPTION
A projection mixing a whole entity with an arithmetic leaf over two distinct properties (e.g. select new { c, Total = c.Age * c.Score }) forces the client-side mixed-projection shaper. The default expression walk decomposed the binary expression into two independent operand visits that wrote the same ProjectionMember slot, so the second operand silently clobbered the first (Total materialised as Score * Score instead of Age * Score).

Register a simple arithmetic leaf (constants, member/EF.Property reads, and nested arithmetic over those) as a single projection- mapping entry instead of decomposing it, and teach the mixed projection shaper to evaluate it client-side by resolving each operand against the materialized document. Method-call operands (e.g. a collection-navigation Sum()/Count()) are left to decompose through the normal walk so their existing translation-failure guards still fire.