### PR TITLE
EF-358: a missing or null embedded array materializes as an empty collection

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -4,8 +4,6 @@ Please note that this provider **does not follow traditional semantic versioning
 
 In order to evolve the provider as we introduce new features, we will be using the minor version number for breaking and significant changes to our EF Core provider. Please bear this in mind when upgrading to newer versions of the MongoDB EF Core Provider and ensure you read the release notes and this document for the latest in breaking change information.
 
-## Breaking changes in 8.5.0 / 9.2.0 / 10.1.0
-
 ### Entity types with their own `DbSet` are no longer embedded when reached by a navigation
 
 #### Old behavior

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/BsonDocumentInjectingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/BsonDocumentInjectingExpressionVisitor.cs
@@ -77,6 +77,10 @@ internal sealed class BsonDocumentInjectingExpressionVisitor : ExpressionVisitor
 
                     AllVariables.Add(arrayVariable);
 
+                    // A missing/null array must become an empty collection, not null. That coalescing
+                    // happens in MongoProjectionBindingRemovingExpressionVisitor at point of use, not here:
+                    // its VisitBinary hard-casts this Assign's right-hand side to UnaryExpression, so it
+                    // must stay one (no Coalesce/Condition wrapper).
                     var expressions = new List<Expression>
                     {
                         Expression.Assign(
@@ -84,10 +88,7 @@ internal sealed class BsonDocumentInjectingExpressionVisitor : ExpressionVisitor
                             Expression.TypeAs(
                                 collectionShaperExpression.Projection,
                                 typeof(BsonArray))),
-                        Expression.Condition(
-                            Expression.Equal(arrayVariable, Expression.Constant(null, arrayVariable.Type)),
-                            Expression.Constant(null, collectionShaperExpression.Type),
-                            collectionShaperExpression)
+                        collectionShaperExpression
                     };
 
                     return Expression.Block(

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -162,6 +162,12 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                         bsonArrayExpression = BsonBinding.CreateGetBsonArray(parentDoc, objectArrayProjection.Name!);
                         arrayName = objectArrayProjection.Name!;
                     }
+
+                    // Coalesce a missing/null array to empty so the shaper enumerates zero elements instead
+                    // of returning null. Kept here rather than folded into the Assign below: VisitBinary
+                    // hard-casts that Assign's right-hand side to UnaryExpression, and Coalesce isn't one.
+                    bsonArrayExpression = Expression.Coalesce(bsonArrayExpression, Expression.New(typeof(BsonArray)));
+
                     var jObjectParameter = Expression.Parameter(typeof(BsonDocument), arrayName + "Object");
                     var ordinalParameter = Expression.Parameter(typeof(int), arrayName + "Ordinal");
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Compatibility/StoredDataStillReadableTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Compatibility/StoredDataStillReadableTests.cs
@@ -15,6 +15,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
+using MongoDB.Driver;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Compatibility;
 
@@ -125,7 +126,23 @@ public class StoredDataStillReadableTests(TemporaryDatabaseFixture database)
         using var db = SingleEntityDbContext.Create(collection);
         db.Entities.Add(_nullableSet);
         db.Entities.Add(_nullableDefault);
+        // A THIRD row, write-only: OwnedMany left at its CLR default (null). _nullableDefault used to be this
+        // suite's only coverage of writing a null collection navigation, but it is also the READ expectation for
+        // nullDefaultDoc, and EF-358 moved that expectation to "= []" — which silently deleted the null-write
+        // shape from the suite. Keeping the two roles in separate instances is what stops that recurring.
+        db.Entities.Add(_nullableNullCollection);
         db.SaveChanges();
+
+        // Assert the persisted BYTES for both collection-write shapes, rather than only that SaveChanges did not
+        // throw: writing null persists "OwnedMany": null and writing an empty collection persists [] — the write
+        // side is unchanged by EF-358, which only affects how stored bytes are READ back.
+        var raw = database.GetCollection<BsonDocument>(collection.CollectionNamespace);
+        Assert.Equal(
+            BsonNull.Value,
+            raw.Find(Builders<BsonDocument>.Filter.Eq("_id", _nullableNullCollection.id)).Single()["OwnedMany"]);
+        Assert.Equal(
+            new BsonArray(),
+            raw.Find(Builders<BsonDocument>.Filter.Eq("_id", _nullableDefault.id)).Single()["OwnedMany"]);
     }
 
     private static void ConfigureDefaults(ModelBuilder mb)
@@ -322,7 +339,25 @@ public class StoredDataStillReadableTests(TemporaryDatabaseFixture database)
         ]
     };
 
-    private readonly Nullables _nullableDefault = new() {id = ObjectId.Parse("670d7d952112a60d7fa17d99")};
+    // "OwnedMany = []" below is the read expectation for nullDefaultDoc ("OwnedMany":null, written by provider
+    // 8.1). Pre-EF-358 the provider never materialized a collection for a missing/null stored array, so this
+    // used to read back as null purely because Nullables.OwnedMany has no "= []" initializer — not because of
+    // any provider contract (same mechanism as the "RENAMED (EF-358)" block in OwnedEntityTests.cs). The stored
+    // bytes are unchanged; only this expectation moves to match the now-uniform empty-collection read.
+    private readonly Nullables _nullableDefault = new()
+    {
+        id = ObjectId.Parse("670d7d952112a60d7fa17d99"),
+        OwnedMany = []
+    };
+
+    // WRITE-ONLY fixture, never a read expectation: OwnedMany left at its CLR default (null) so
+    // Can_write_nullable_clr_types still covers WRITING a null collection navigation. _nullableDefault above
+    // doubles as the read expectation for nullDefaultDoc, and moving that expectation to "= []" (EF-358) took
+    // the null-write shape with it; splitting the two roles keeps both write shapes covered.
+    private readonly Nullables _nullableNullCollection = new()
+    {
+        id = ObjectId.Parse("670d7d952112a60d7fa17d9a")
+    };
 
     public record Owned
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -686,11 +686,17 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         Assert.Empty(actual.children);
     }
 
+    // RENAMED (EF-358) from "..._is_null_when_null" / "..._is_null_when_missing". The old names asserted a
+    // provider contract that never existed: the old "null" was produced by EF Core's IncludeExpression fixup
+    // (in MongoProjectionBindingRemovingExpressionVisitor.IncludeCollection) being skipped because the
+    // provider's computed value was null, leaving `children` at the POCO's own default — not by any provider
+    // guarantee. EF-358 always materializes a real (possibly empty) collection, so the fixup always runs and
+    // every class reads back the same regardless of its field initializer.
     [Theory]
     [InlineData(QueryTrackingBehavior.TrackAll)]
     [InlineData(QueryTrackingBehavior.NoTracking)]
     [InlineData(QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
-    public void OwnedEntity_non_nullable_collection_is_null_when_null(QueryTrackingBehavior queryTrackingBehavior)
+    public void OwnedEntity_non_nullable_collection_is_empty_when_null(QueryTrackingBehavior queryTrackingBehavior)
     {
         var collection = database.CreateCollection<SimpleNonNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([
@@ -701,14 +707,14 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             optionsBuilderAction: x => x.UseQueryTrackingBehavior(queryTrackingBehavior));
 
         var actual = db.Entities.First();
-        Assert.Null(actual.children);
+        Assert.Empty(actual.children);
     }
 
     [Theory]
     [InlineData(QueryTrackingBehavior.TrackAll)]
     [InlineData(QueryTrackingBehavior.NoTracking)]
     [InlineData(QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
-    public void OwnedEntity_nullable_collection_is_null_when_null(QueryTrackingBehavior queryTrackingBehavior)
+    public void OwnedEntity_nullable_collection_is_empty_when_null(QueryTrackingBehavior queryTrackingBehavior)
     {
         var collection = database.CreateCollection<SimpleNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([
@@ -719,14 +725,15 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             optionsBuilderAction: x => x.UseQueryTrackingBehavior(queryTrackingBehavior));
 
         var actual = db.Entities.First();
-        Assert.Null(actual.children);
+        Assert.NotNull(actual.children);
+        Assert.Empty(actual.children);
     }
 
     [Theory]
     [InlineData(QueryTrackingBehavior.TrackAll)]
     [InlineData(QueryTrackingBehavior.NoTracking)]
     [InlineData(QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
-    public void OwnedEntity_non_nullable_collection_is_null_when_missing(QueryTrackingBehavior queryTrackingBehavior)
+    public void OwnedEntity_non_nullable_collection_is_empty_when_missing(QueryTrackingBehavior queryTrackingBehavior)
     {
         var collection = database.CreateCollection<MissingNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([new MissingNullableCollection()]);
@@ -735,14 +742,14 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             optionsBuilderAction: x => x.UseQueryTrackingBehavior(queryTrackingBehavior));
 
         var actual = db.Entities.First();
-        Assert.Null(actual.children);
+        Assert.Empty(actual.children);
     }
 
     [Theory]
     [InlineData(QueryTrackingBehavior.TrackAll)]
     [InlineData(QueryTrackingBehavior.NoTracking)]
     [InlineData(QueryTrackingBehavior.NoTrackingWithIdentityResolution)]
-    public void OwnedEntity_nullable_collection_is_null_when_missing(QueryTrackingBehavior queryTrackingBehavior)
+    public void OwnedEntity_nullable_collection_is_empty_when_missing(QueryTrackingBehavior queryTrackingBehavior)
     {
         var collection = database.CreateCollection<MissingNullableCollection>(values: queryTrackingBehavior);
         collection.WriteTestDocs([new MissingNullableCollection()]);
@@ -751,7 +758,84 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             optionsBuilderAction: x => x.UseQueryTrackingBehavior(queryTrackingBehavior));
 
         var actual = db.Entities.First();
-        Assert.Null(actual.children);
+        Assert.NotNull(actual.children);
+        Assert.Empty(actual.children);
+    }
+
+    // EF-358: the projection path (Select over a CollectionShaperExpression) used to disagree with whole-entity
+    // materialization for a missing or explicitly-null stored array — it produced a null CLR collection instead
+    // of an empty one. Owned-collection projections require AsNoTracking (EF Core cannot track an owned entity
+    // without its owner in the result), so this covers the same "missing"/"null" states as the whole-entity
+    // theories above, but through Select rather than whole-entity materialization.
+    [Fact]
+    public void OwnedEntity_collection_projection_is_empty_when_missing()
+    {
+        var collection = database.CreateCollection<MissingNullableCollection>();
+        collection.WriteTestDocs([new MissingNullableCollection()]);
+        using var db = SingleEntityDbContext.Create<MissingNullableCollection, SimpleNonNullableCollection>(collection);
+
+        var actual = db.Entities.AsNoTracking().Select(e => e.children).First();
+        Assert.NotNull(actual);
+        Assert.Empty(actual);
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_projection_is_empty_when_null()
+    {
+        var collection = database.CreateCollection<SimpleNonNullableCollection>();
+        collection.WriteTestDocs([new SimpleNonNullableCollection { children = null! }]);
+        using var db = SingleEntityDbContext.Create(collection);
+
+        var actual = db.Entities.AsNoTracking().Select(e => e.children).First();
+        Assert.NotNull(actual);
+        Assert.Empty(actual);
+    }
+
+    // EF-358: a collection shaper nested inside another owned collection's item (FirstLevel.children[i].children)
+    // never gets a bound bsonArray variable — BsonDocumentInjectingExpressionVisitor doesn't recurse into a
+    // CollectionShaperExpression's InnerShaper — so it always takes the "else" branch that reads the BsonArray
+    // straight off the parent element via CreateGetBsonArray. That's a different code path from the root-level
+    // case above, so it needs its own missing/null coverage.
+    [Fact]
+    public void OwnedEntity_nested_collection_is_empty_when_grandchild_array_missing()
+    {
+        var collection = database.CreateCollection<FirstLevelWithMissingGrandchildren>();
+        collection.WriteTestDocs([
+            new FirstLevelWithMissingGrandchildren
+            {
+                _id = Guid.NewGuid(),
+                day = DayOfWeek.Monday,
+                reference = new() { name = "ref", day = DayOfWeek.Friday },
+                children = [new SecondLevelMissingChildren { day = DayOfWeek.Tuesday }]
+            }
+        ]);
+        using var db = SingleEntityDbContext.Create<FirstLevelWithMissingGrandchildren, FirstLevel>(collection);
+
+        var actual = db.Entities.First();
+        var secondLevel = Assert.Single(actual.children);
+        Assert.NotNull(secondLevel.children);
+        Assert.Empty(secondLevel.children);
+    }
+
+    [Fact]
+    public void OwnedEntity_nested_collection_is_empty_when_grandchild_array_null()
+    {
+        var collection = database.CreateCollection<FirstLevelWithNullGrandchildren>();
+        collection.WriteTestDocs([
+            new FirstLevelWithNullGrandchildren
+            {
+                _id = Guid.NewGuid(),
+                day = DayOfWeek.Monday,
+                reference = new() { name = "ref", day = DayOfWeek.Friday },
+                children = [new SecondLevelNullChildren { day = DayOfWeek.Tuesday, children = null! }]
+            }
+        ]);
+        using var db = SingleEntityDbContext.Create<FirstLevelWithNullGrandchildren, FirstLevel>(collection);
+
+        var actual = db.Entities.First();
+        var secondLevel = Assert.Single(actual.children);
+        Assert.NotNull(secondLevel.children);
+        Assert.Empty(secondLevel.children);
     }
 
     [Fact]
@@ -1350,12 +1434,17 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     [Fact]
     public void OwnedEntity_collection_can_be_tested_for_null()
     {
+        // The predicate `e.children == null` is unaffected by EF-358 — only the materialized value of the
+        // matched row flips from `null` to `[]`. `inserted` and `expected` must stay separate objects: setting
+        // `children = []` on `inserted` would write an empty array to the document instead of leaving the
+        // field unset, changing what gets seeded rather than just what gets asserted.
         var collection = database.CreateCollection<A>();
-        var expected = new A { _id = "1" };
+        var inserted = new A { _id = "1" };
+        var expected = new A { _id = "1", children = [] };
 
         {
             using var db = SingleEntityDbContext.Create(collection);
-            db.Entities.AddRange(expected, new A { _id = "2", children = [new B { name = "child1" }, new B { name = "child2" }] });
+            db.Entities.AddRange(inserted, new A { _id = "2", children = [new B { name = "child1" }, new B { name = "child2" }] });
             db.SaveChanges();
         }
 
@@ -1369,12 +1458,17 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     [Fact]
     public void OwnedEntity_collection_field_can_be_tested_for_null()
     {
+        // Same reasoning as OwnedEntity_collection_can_be_tested_for_null immediately above: the predicate
+        // `e.children == null` is unaffected (still matches row "1" by its missing stored field); only the
+        // MATERIALIZED value flips from `null` to `[]` post-EF-358. `inserted` (children left unset) is what
+        // gets written, unchanged; `expected` (children = []) is the separate comparison value.
         var collection = database.CreateCollection<AField>();
-        var expected = new AField { _id = "1" };
+        var inserted = new AField { _id = "1" };
+        var expected = new AField { _id = "1", children = [] };
 
         {
             using var db = SingleEntityDbContext.Create(collection, mb => mb.Entity<AField>().OwnsMany(f => f.children));
-            db.Entities.AddRange(expected,
+            db.Entities.AddRange(inserted,
                 new AField { _id = "2", children = [new B { name = "child1" }, new B { name = "child2" }] });
             db.SaveChanges();
         }
@@ -1595,6 +1689,38 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     private record Reference
     {
         public string name { get; set; }
+        public DayOfWeek day { get; set; }
+    }
+
+    // Write-side shapes for OwnedEntity_nested_collection_is_empty_when_grandchild_array_missing/null: mirror
+    // FirstLevel/SecondLevel but the SecondLevel-equivalent either omits its `children` element entirely
+    // (SecondLevelMissingChildren) or is written with it explicitly null (SecondLevelNullChildren), so the
+    // stored document's grandchild array is absent/null exactly as MissingNullableCollection does for the
+    // root-level case above. Read back through FirstLevel/SecondLevel/ThirdLevel, unchanged.
+    private record FirstLevelWithMissingGrandchildren
+    {
+        public Guid _id { get; set; }
+        public List<SecondLevelMissingChildren> children { get; set; }
+        public DayOfWeek day { get; set; }
+        public Reference reference { get; set; }
+    }
+
+    private record SecondLevelMissingChildren
+    {
+        public DayOfWeek day { get; set; }
+    }
+
+    private record FirstLevelWithNullGrandchildren
+    {
+        public Guid _id { get; set; }
+        public List<SecondLevelNullChildren> children { get; set; }
+        public DayOfWeek day { get; set; }
+        public Reference reference { get; set; }
+    }
+
+    private record SecondLevelNullChildren
+    {
+        public List<ThirdLevel> children { get; set; }
         public DayOfWeek day { get; set; }
     }
 


### PR DESCRIPTION
The driver-LINQ collection shaper left a missing or explicitly-BSON-null stored owned-collection array as a null CLR value: BsonDocumentInjectingExpressionVisitor collapsed the whole CollectionShaperExpression to a null constant, and MongoProjectionBindingRemovingExpressionVisitor never coalesced the raw BsonArray read before enumerating it. Because whole-entity materialization, Include, and projections all compile through this same shaper, every one of them was affected - what looked like a working whole-entity path was really each POCO's own field initializer papering over the null.

Removes the null-collapsing condition and coalesces the BsonArray read to a fresh empty array at its point of use (kept there rather than folded into the assignment, since VisitBinary hard-casts that assignment's right-hand side to UnaryExpression). A collection navigation now uniformly materializes empty, matching EF Core's contract, and a projected .Count/.Any() on such a collection no longer throws.

Native/streaming shader materialization and the Count-projection translation fix are out of scope here - the native query pipeline isn't on this branch, and Count-projection translation is a separate, unimplemented effort.