### PR TITLE
EF-359: Fix Count/LongCount over embedded collections in projections

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -616,7 +616,74 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             return sizeRewrite;
         }
 
+        // A bare/unfiltered embedded (owned) collection-navigation Count, e.g. `b.Posts.Count`, lowered by
+        // EF Core to Queryable.Count(Queryable.AsQueryable(EF.Property(shaper, "Posts"))). See
+        // TryRewriteEmbeddedCollectionNavigationCount for why this needs a null/missing-safe normalization
+        // the driver's own rendering of a bare Count (a server-side $size) doesn't provide.
+        if (TryRewriteEmbeddedCollectionNavigationCount(node, out var embeddedCountRewrite))
+        {
+            return embeddedCountRewrite;
+        }
+
         return base.VisitMethodCall(node);
+    }
+
+    /// <summary>
+    /// Rewrites a bare embedded (owned) collection-navigation <c>Count</c>/<c>LongCount</c> (e.g.
+    /// <c>b.Posts.Count</c>) into <c>Enumerable.Count</c> over a <c>??</c>-normalized array read — needed
+    /// because the driver's bare-Count translation is a server-side <c>$size</c>, which throws on a
+    /// missing or null array (unlike a predicated Count, translated as null-tolerant <c>$map</c>/<c>$sum</c>).
+    /// </summary>
+    private bool TryRewriteEmbeddedCollectionNavigationCount(MethodCallExpression node, out Expression result)
+    {
+        result = null!;
+
+        if (node.Method.DeclaringType != typeof(Queryable)
+            || node.Arguments.Count != 1
+            || node.Method.Name is not (nameof(Queryable.Count) or nameof(Queryable.LongCount)))
+        {
+            return false;
+        }
+
+        if (node.Arguments[0] is not MethodCallExpression
+            {
+                Method: { Name: nameof(Queryable.AsQueryable), DeclaringType: var asQueryableDeclaring }
+            } asQueryableCall
+            || asQueryableDeclaring != typeof(Queryable))
+        {
+            return false;
+        }
+
+        // Narrow to genuinely embedded (owned) collection navigations only: AsQueryable(...) also shows
+        // up wrapping other enumerable sources (e.g. an IGrouping in a GroupBy/Union pipeline) that are
+        // not a document field read at all, so rewriting unconditionally miscompiles those shapes.
+        if (asQueryableCall.Arguments[0] is not MethodCallExpression efPropertyCall
+            || !efPropertyCall.Method.IsEFPropertyMethod()
+            || efPropertyCall.Arguments[1] is not ConstantExpression { Value: string propertyName }
+            || _queryContext.Context.Model.FindEntityType(efPropertyCall.Arguments[0].Type) is not { } sourceEntityType
+            || sourceEntityType.FindNavigation(propertyName) is not { } navigation
+            || !navigation.IsEmbedded())
+        {
+            return false;
+        }
+
+        var fieldAccess = Visit(asQueryableCall.Arguments[0]);
+        var elementType = fieldAccess?.Type.TryGetItemType();
+        if (elementType == null)
+        {
+            return false;
+        }
+
+        var countMethod = (node.Method.Name == nameof(Queryable.LongCount)
+                ? EnumerableLongCountMethod
+                : EnumerableCountMethod)
+            .MakeGenericMethod(elementType);
+
+        var emptyCollection = Expression.Constant(Activator.CreateInstance(fieldAccess!.Type), fieldAccess.Type);
+        var normalizedFieldAccess = Expression.Coalesce(fieldAccess, emptyCollection);
+
+        result = Expression.Call(null, countMethod, normalizedFieldAccess);
+        return true;
     }
 
     /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -451,6 +451,39 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                         EnumerableMethods.Select.MakeGenericMethod(method.GetGenericArguments()),
                         shaper,
                         lambda);
+
+                // A Count/LongCount over an embedded/owned collection navigation in a projection (e.g.
+                // `b.Posts.Count(p => p.Rank > 0)`). Kept bound to the original method-call subtree, not
+                // the shaper, so it push-downs to the driver's native $size/$filter — routing through the
+                // shaper would materialize owned Post entities, which the tracking-materializer rejects.
+                case nameof(Queryable.Count) when genericMethod == QueryableMethods.CountWithoutPredicate:
+                case nameof(Queryable.LongCount) when genericMethod == QueryableMethods.LongCountWithoutPredicate:
+                case nameof(Queryable.Count) when genericMethod == QueryableMethods.CountWithPredicate:
+                case nameof(Queryable.LongCount) when genericMethod == QueryableMethods.LongCountWithPredicate:
+                    if (visitedSource is not CollectionShaperExpression
+                        || methodCallExpression.Arguments[0] is not MethodCallExpression
+                            {
+                                Method: { Name: nameof(Queryable.AsQueryable), DeclaringType: var asQueryableDeclaring }
+                            } asQueryableCall
+                        || asQueryableDeclaring != typeof(Queryable))
+                    {
+                        return null;
+                    }
+
+                    // A missing/null stored array materializes to a null reference, not an empty
+                    // collection (same gap as `.Select(e => e.Foo)`), so Count/LongCount must tolerate a
+                    // null source ($size/$filter both reject null) — guard on the raw field access, not
+                    // the AsQueryable-wrapped source.
+                    var countSource = asQueryableCall.Arguments[0];
+                    Expression nullSafeCount = Expression.Condition(
+                        Expression.Equal(countSource, Expression.Constant(null, countSource.Type)),
+                        Expression.Default(methodCallExpression.Type),
+                        methodCallExpression);
+
+                    var countProjectionMember = GetCurrentProjectionMember();
+                    _projectionMapping[countProjectionMember] = nullSafeCount;
+
+                    return new ProjectionBindingExpression(_queryExpression, countProjectionMember, methodCallExpression.Type);
             }
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -15,7 +15,9 @@
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
@@ -1477,6 +1479,174 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
             var thirdLevel = Assert.Single(secondLevel.children);
             Assert.Equal(expectedReference.name, thirdLevel.reference.name);
         }
+    }
+
+    [Fact]
+    public void OwnedEntity_filtered_count_in_projection_translates()
+    {
+        var collection = database.CreateCollection<CountBlog>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new CountBlog
+            {
+                _id = "1",
+                Title = "Blog1",
+                Posts = [new CountPost { Rank = 1 }, new CountPost { Rank = 0 }, new CountPost { Rank = 2 }]
+            });
+            db.SaveChanges();
+        }
+
+        {
+            // Assert the count is evaluated server-side (a $map/$sum over the array, equivalent to
+            // filter+size) rather than by materializing the owned CountPost entities and counting client-side.
+            var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+            using var db = SingleEntityDbContext.Create(collection, loggerFactory,
+                optionsBuilderAction: o => o.EnableSensitiveDataLogging());
+            var result = Assert.Single(db.Entities.Select(b => new { b.Title, N = b.Posts.Count(p => p.Rank > 0) }));
+
+            Assert.Equal("Blog1", result.Title);
+            Assert.Equal(2, result.N);
+
+            var message = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutedMqlQuery);
+            Assert.Contains("$map", message);
+            Assert.Contains("$sum", message);
+        }
+    }
+
+    [Fact]
+    public void OwnedEntity_unfiltered_count_in_projection_translates()
+    {
+        var collection = database.CreateCollection<CountBlog>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.Add(new CountBlog
+            {
+                _id = "1",
+                Title = "Blog1",
+                Posts = [new CountPost { Rank = 1 }, new CountPost { Rank = 0 }]
+            });
+            db.SaveChanges();
+        }
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            var result = Assert.Single(db.Entities.Select(b => new { b.Title, N = b.Posts.Count() }));
+
+            Assert.Equal("Blog1", result.Title);
+            Assert.Equal(2, result.N);
+        }
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_bare_count_projection_returns_element_count()
+    {
+        var collection = database.CreateCollection<A>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new A { _id = "1", children = [new B { name = "child1" }, new B { name = "child2" }] },
+                new A { _id = "2", children = [] },
+                new A { _id = "3", children = null! });
+            db.SaveChanges();
+        }
+
+        // Deliberately a default *tracking* query (unlike EF-357's own tests, which required
+        // AsNoTracking): the bare Count must stay a server-side scalar, not a materialized owned-entity
+        // shaper, or EF Core's tracking-materializer rejects it ("owned entity without a corresponding
+        // owner").
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        using var db2 = SingleEntityDbContext.Create(collection, loggerFactory,
+            optionsBuilderAction: o => o.EnableSensitiveDataLogging());
+
+        var counts = db2.Entities.OrderBy(e => e._id).Select(e => e.children.Count).ToList();
+        Assert.Equal([2, 0, 0], counts);
+
+        // A null stored array must report 0, not throw: the driver renders a bare Count as a server-side
+        // $size, which rejects a null array, so this needs an $ifNull normalization first.
+        var message = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutedMqlQuery);
+        Assert.Contains("$ifNull", message);
+        Assert.Contains("$size", message);
+
+        var longCounts = db2.Entities.OrderBy(e => e._id).Select(e => e.children.LongCount()).ToList();
+        Assert.Equal([2L, 0L, 0L], longCounts);
+
+        var filteredLongCounts = db2.Entities.OrderBy(e => e._id)
+            .Select(e => e.children.LongCount(c => c.name == "child1"))
+            .ToList();
+        Assert.Equal([1L, 0L, 0L], filteredLongCounts);
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_bare_count_projection_over_missing_element_returns_zero()
+    {
+        // A document where the array element is OMITTED entirely (not stored as BSON null) is a distinct
+        // case from an explicit null: in an aggregation expression a missing field is not equal to BSON
+        // null, so a plain null-equality guard does not catch it and $size still throws on "missing". Only
+        // $ifNull (which normalizes missing the same as null) handles both.
+        var collection = database.CreateCollection<A>();
+        database.GetCollection<BsonDocument>(collection.CollectionNamespace).InsertOne(new BsonDocument("_id", "1"));
+
+        using var db = SingleEntityDbContext.Create(collection);
+        var counts = db.Entities.Select(e => e.children.Count).ToList();
+
+        Assert.Equal([0], counts);
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_count_projection_wrapped_in_arithmetic_returns_element_count()
+    {
+        var collection = database.CreateCollection<A>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new A { _id = "1", children = [new B { name = "child1" }, new B { name = "child2" }] },
+                new A { _id = "2", children = null! });
+            db.SaveChanges();
+        }
+
+        using var db2 = SingleEntityDbContext.Create(collection);
+        var doubled = db2.Entities.OrderBy(e => e._id)
+            .Select(e => new { e._id, N = e.children.Count * 2 })
+            .ToList();
+
+        Assert.Equal([4, 0], doubled.Select(r => r.N).ToArray());
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_filtered_count_projection_with_null_children_returns_zero()
+    {
+        var collection = database.CreateCollection<A>();
+
+        {
+            using var db = SingleEntityDbContext.Create(collection);
+            db.Entities.AddRange(
+                new A { _id = "1", children = [new B { name = "child1" }, new B { name = "child2" }] },
+                new A { _id = "2", children = null! });
+            db.SaveChanges();
+        }
+
+        using var db2 = SingleEntityDbContext.Create(collection);
+        var counts = db2.Entities.OrderBy(e => e._id)
+            .Select(e => e.children.Count(c => c.name == "child1"))
+            .ToList();
+
+        Assert.Equal([1, 0], counts);
+    }
+
+    record CountBlog
+    {
+        public string _id { get; set; }
+        public string Title { get; set; }
+        public List<CountPost> Posts { get; set; }
+    }
+
+    record CountPost
+    {
+        public int Rank { get; set; }
     }
 
     record A


### PR DESCRIPTION
Supersedes https://github.com/mongodb/mongo-efcore-provider/pull/337

`b.Posts.Count(p => p.Rank > 0)` and `b.Posts.Count()` inside a Select projection over an owned (embedded) collection threw InvalidOperationException at translation time in every MongoQueryMode, because MongoProjectionBindingExpressionVisitor had no case for the lowered Queryable.Count(Queryable.AsQueryable(EF.Property(...))) shape and fell into the generic fallback, which tried to visit the predicate lambda's own parameter as an unbound reference.

Bind Count/LongCount (with or without a predicate) to the original method-call subtree instead of the materializing shaper, so it stays push-down-able to the driver's own LINQ v3 translation rather than materializing owned entities (which EF Core's tracking-materializer rejects without an owner in the result).

That push-down path also has a null-safety gap for the bare/unfiltered form: the driver renders it as a server-side $size, which throws on a missing/null stored array (unlike the predicated form, which renders as a null-tolerant $map/$sum). Add a narrowly-scoped rewrite in
MongoEFToLinqTranslatingExpressionVisitor that null-guards genuinely embedded navigations with $cond, without touching other AsQueryable(...) shapes (e.g. IGrouping sources in GroupBy/Union pipelines).

This also fixes and subsumes EF-357 (bare/arithmetic-wrapped Count over an embedded collection), including a tracking-query case EF-357's own fix did not handle (its client-side materialization approach hits the same owned-entity-without-owner rejection under a tracking query).