### PR TITLE
EF-360: fix ArgumentException projecting a collection leaf whose element has a nested embedded navigation

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -203,17 +203,11 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                 {
                     var visited = base.Visit(materializeCollectionNavigationExpression.Subquery);
 
-                    // When an element of the collection has an embedded navigation of its own (e.g. a nested
-                    // OwnsMany/OwnsOne), EF's nav-expansion wraps the collection access in a Queryable.Select
-                    // carrying the auto-included IncludeExpression. The Select arm above rebuilds that against
-                    // EnumerableMethods.Select, which is IEnumerable<T>-typed, not the navigation's declared
-                    // List<T>-typed collection. MatchTypes deliberately leaves collection-typed targets alone
-                    // (see its TryGetItemType() guard), so left uncorrected this fails Expression.New's
-                    // member-type validation wherever this leaf feeds an anonymous type / MemberInit member.
-                    // MongoProjectionBindingRemovingExpressionVisitor.VisitMethodCall already discards this
-                    // exact Select-over-IncludeExpression shape and hands back the properly List<T>-typed
-                    // CollectionShaperExpression, so wrapping it here in a Convert is a no-op by the time it's
-                    // actually consumed - it only exists to satisfy the static-type check at this stage.
+                    // If the element type has its own embedded navigation, the Select arm above rebuilds this
+                    // as an IEnumerable<T>-typed Enumerable.Select rather than the navigation's declared List<T>,
+                    // which fails Expression.New's member-type check. Convert is a no-op at runtime:
+                    // MongoProjectionBindingRemovingExpressionVisitor discards this shape later for the
+                    // correctly-typed CollectionShaperExpression.
                     return visited != null && visited.Type != materializeCollectionNavigationExpression.Type
                         ? Expression.Convert(visited, materializeCollectionNavigationExpression.Type)
                         : visited;

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -198,10 +198,28 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                 }
 
             case MaterializeCollectionNavigationExpression materializeCollectionNavigationExpression:
-                return materializeCollectionNavigationExpression.Navigation is INavigation embeddableNavigation
-                       && embeddableNavigation.IsEmbedded()
-                    ? base.Visit(materializeCollectionNavigationExpression.Subquery)
-                    : base.VisitExtension(materializeCollectionNavigationExpression);
+                if (materializeCollectionNavigationExpression.Navigation is INavigation embeddableNavigation
+                    && embeddableNavigation.IsEmbedded())
+                {
+                    var visited = base.Visit(materializeCollectionNavigationExpression.Subquery);
+
+                    // When an element of the collection has an embedded navigation of its own (e.g. a nested
+                    // OwnsMany/OwnsOne), EF's nav-expansion wraps the collection access in a Queryable.Select
+                    // carrying the auto-included IncludeExpression. The Select arm above rebuilds that against
+                    // EnumerableMethods.Select, which is IEnumerable<T>-typed, not the navigation's declared
+                    // List<T>-typed collection. MatchTypes deliberately leaves collection-typed targets alone
+                    // (see its TryGetItemType() guard), so left uncorrected this fails Expression.New's
+                    // member-type validation wherever this leaf feeds an anonymous type / MemberInit member.
+                    // MongoProjectionBindingRemovingExpressionVisitor.VisitMethodCall already discards this
+                    // exact Select-over-IncludeExpression shape and hands back the properly List<T>-typed
+                    // CollectionShaperExpression, so wrapping it here in a Convert is a no-op by the time it's
+                    // actually consumed - it only exists to satisfy the static-type check at this stage.
+                    return visited != null && visited.Type != materializeCollectionNavigationExpression.Type
+                        ? Expression.Convert(visited, materializeCollectionNavigationExpression.Type)
+                        : visited;
+                }
+
+                return base.VisitExtension(materializeCollectionNavigationExpression);
 
             case IncludeExpression includeExpression:
                 {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -1145,6 +1145,62 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
         }
     }
 
+    public class Blog
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public List<Post> Posts { get; set; }
+    }
+
+    public class Post
+    {
+        public string Content { get; set; }
+        public List<Comment> Comments { get; set; }
+    }
+
+    public class Comment
+    {
+        public string Text { get; set; }
+    }
+
+    [Fact]
+    public void OwnedEntity_collection_leaf_projection_with_nested_collection_element()
+    {
+        // The Comments navigation on Post (the Posts element type) is the trigger: EF's nav-expansion
+        // wraps the Posts collection access in a Queryable.Select carrying the auto-included Comments,
+        // which the projection binding visitor rebuilds as an IEnumerable<Post>-typed Enumerable.Select
+        // rather than the List<Post> the anonymous-type member requires. Regression test for the
+        // ArgumentException this used to throw from Expression.New's member-type validation.
+        var collection = database.CreateCollection<Blog>();
+        var expected = new Blog
+        {
+            Id = "1",
+            Title = "t",
+            Posts =
+            [
+                new Post { Content = "c1", Comments = [new Comment { Text = "x" }] },
+                new Post { Content = "c2", Comments = [] }
+            ]
+        };
+
+        using var db = SingleEntityDbContext.Create(collection, mb =>
+        {
+            mb.Entity<Blog>().OwnsMany(b => b.Posts, p => p.OwnsMany(x => x.Comments));
+        });
+        db.Entities.Add(expected);
+        db.SaveChanges();
+
+        var result = db.Entities.AsNoTracking().Select(b => new { b.Title, b.Posts }).ToList();
+        var single = Assert.Single(result);
+        Assert.Equal("t", single.Title);
+        Assert.Equal(2, single.Posts.Count);
+        Assert.Equal("c1", single.Posts[0].Content);
+        Assert.Single(single.Posts[0].Comments);
+        Assert.Equal("x", single.Posts[0].Comments[0].Text);
+        Assert.Equal("c2", single.Posts[1].Content);
+        Assert.Empty(single.Posts[1].Comments);
+    }
+
     [Fact]
     public void OwnedEntity_collection_can_be_tested_for_not_null()
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -1166,11 +1166,8 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     [Fact]
     public void OwnedEntity_collection_leaf_projection_with_nested_collection_element()
     {
-        // The Comments navigation on Post (the Posts element type) is the trigger: EF's nav-expansion
-        // wraps the Posts collection access in a Queryable.Select carrying the auto-included Comments,
-        // which the projection binding visitor rebuilds as an IEnumerable<Post>-typed Enumerable.Select
-        // rather than the List<Post> the anonymous-type member requires. Regression test for the
-        // ArgumentException this used to throw from Expression.New's member-type validation.
+        // Regression test: Post's own Comments navigation used to make this leaf mistyped as
+        // IEnumerable<Post>, throwing ArgumentException from Expression.New's member-type check.
         var collection = database.CreateCollection<Blog>();
         var expected = new Blog
         {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/AdHocJsonQueryMongoTest.cs
@@ -51,12 +51,15 @@ public class AdHocJsonQueryMongoTest : AdHocJsonQueryTestBase
     {
         // Fails: No support for nested JSON EF-X008
         Assert.Contains(
-            "Argument type 'System.Collections.Generic.IEnumerable`1[Microsoft.EntityFrameworkCore.Query.AdHocJsonQueryTestBase+Context21006+JsonEntity]' does not match",
-            (await Assert.ThrowsAsync<ArgumentException>(
+            "Document element is missing for required",
+            (await Assert.ThrowsAsync<InvalidOperationException>(
                 () => base.Project_top_level_json_entity_with_missing_scalars(async)))
             .Message);
 
-        AssertMql();
+        AssertMql(
+            """
+            Entities.{ "$match" : { "_id" : { "$lt" : 4 } } }
+            """);
     }
 
     public override async Task Project_nested_json_entity_with_missing_scalars(bool async)


### PR DESCRIPTION
An embedded (OwnsMany) collection whose element type has its own navigation (e.g. a nested OwnsMany/OwnsOne) crashed when projected as an anonymous-type/MemberInit leaf, e.g. Select(b => new { b.Title, b.Posts }) where Post has its own Comments collection.

EF's nav-expansion wraps the collection access in a Queryable.Select carrying the auto-included nested navigation; MongoProjectionBindingExpressionVisitor's Select arm rebuilds that against EnumerableMethods.Select, producing an IEnumerable<T>-typed result instead of the navigation's declared List<T>. MatchTypes deliberately skips collection-typed targets, so the mismatch reached Expression.New's member-type validation as an ArgumentException instead of failing (or succeeding) cleanly.

Fix: in the embedded-navigation branch of the MaterializeCollectionNavigationExpression case, wrap the visited subquery in a Convert to the navigation's declared type when it differs. This is a no-op at runtime: MongoProjectionBindingRemovingExpressionVisitor already special-cases this exact Select-over-IncludeExpression shape later in the pipeline and discards it for the correctly-typed CollectionShaperExpression.