### PR TITLE
EF-367: Fix bare-catch AssertTranslationFailed masking wrong data in Include spec suites

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -153,8 +153,26 @@ Comment pattern: `// Fails: Unknown reasons EF-X009`.
 Affected: 1 test. Author was unsure of root cause when adding the override.
 
 ### EF-X010 — Provider-specific Include error message differs from EF baseline
-Pattern: tests for `Include_collection_with_client_filter` across all four Include variants use `Assert.ThrowsAsync<ContainsException>` and assert that `Assert.Contains` fails because the provider's error message differs from the generic EF message. The override carries an explanatory comment ("Throws with Mongo-specific message rather than the generic EF message.") but no `// Fails:` tag in the current codebase.
+Pattern: `Include_collection_with_client_filter` across all four Include variants asserts
+`Assert.Contains("ExpressionNotSupportedException", (await Assert.ThrowsAsync<ThrowsException>(...)).Message)`
+— the same shape as the 28 existing `EF-X002` sites. The base test expects EF's own
+`InvalidOperationException` translation-failed message for a client-evaluated member on an
+Include-d query; the provider instead throws the driver's `ExpressionNotSupportedException`,
+so `Assert.ThrowsAsync<InvalidOperationException>` inside the base method itself fails with a
+`ThrowsException` reporting the actual type. The mechanism is identical to `EF-X002` — see that
+entry for the general case; this one's trigger is specifically a client-evaluated member on an
+`Include`, not a plain unsupported operator.
 Affected: 4 tests (`NorthwindEFPropertyIncludeQueryMongoTest.cs`, `NorthwindIncludeNoTrackingQueryMongoTest.cs`, `NorthwindIncludeQueryMongoTest.cs`, `NorthwindStringIncludeQueryMongoTest.cs`).
+
+Until this was fixed, each of these four suites shadowed the upstream `AssertTranslationFailed`
+helper with a bare `try { await query(); } catch { return; }`, which — unlike the
+`Assert.ThrowsAsync<ThrowsException>` pattern above — swallowed *any* exception, including an
+assertion failure from wrong data returned by a query that didn't fail to translate at all. A
+full audit of all 234 call sites of the shadowed helper (across the four suites) found this one
+test as the only case actually masking a real failure; the other 230 call sites already threw a
+genuine non-assertion exception and are unaffected. The shadowed helpers now delegate to a
+corrected `MongoAssert.AssertTranslationFailed` (rejects any `XunitException`, so wrong data
+still fails the test) instead of duplicating the swallow-everything logic in each file.
 
 ### EF-X011 — Compiled query with non-query operator — wrong exception — **fixed by [EF-233](https://jira.mongodb.org/browse/EF-233)**
 Comment pattern (historical): `// Fails: Compiled query with non-query operator issue EF-X011`.

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindEFPropertyIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindEFPropertyIncludeQueryMongoTest.cs
@@ -1313,7 +1313,10 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
     public override async Task Include_collection_with_client_filter(bool async)
     {
         // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
-        await AssertTranslationFailed(() => base.Include_collection_with_client_filter(async));
+        Assert.Contains(
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Include_collection_with_client_filter(async)))
+            .Message);
         AssertMql(
             """
 Customers.
@@ -1321,18 +1324,7 @@ Customers.
     }
 
     protected new static async Task AssertTranslationFailed(Func<Task> query)
-    {
-        try
-        {
-            await query();
-        }
-        catch
-        {
-            return;
-        }
-
-        throw new Xunit.Sdk.XunitException("Expected query to fail but it succeeded.");
-    }
+        => await MongoAssert.AssertTranslationFailed(query);
 
     private void AssertMql(params string[] expected)
         => Fixture.TestMqlLoggerFactory.AssertBaseline(expected);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeNoTrackingQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeNoTrackingQueryMongoTest.cs
@@ -1190,7 +1190,10 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
     public override async Task Include_collection_with_client_filter(bool async)
     {
         // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
-        await AssertTranslationFailed(() => base.Include_collection_with_client_filter(async));
+        Assert.Contains(
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Include_collection_with_client_filter(async)))
+            .Message);
         AssertMql(
             """
 Customers.
@@ -1199,18 +1202,7 @@ Customers.
 
 
     protected new static async Task AssertTranslationFailed(Func<Task> query)
-    {
-        try
-        {
-            await query();
-        }
-        catch
-        {
-            return;
-        }
-
-        throw new Xunit.Sdk.XunitException("Expected query to fail but it succeeded.");
-    }
+        => await MongoAssert.AssertTranslationFailed(query);
 
     private void AssertMql(params string[] expected)
         => Fixture.TestMqlLoggerFactory.AssertBaseline(expected);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindIncludeQueryMongoTest.cs
@@ -1306,7 +1306,10 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
     public override async Task Include_collection_with_client_filter(bool async)
     {
         // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
-        await AssertTranslationFailed(() => base.Include_collection_with_client_filter(async));
+        Assert.Contains(
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Include_collection_with_client_filter(async)))
+            .Message);
         AssertMql(
             """
 Customers.
@@ -1315,18 +1318,7 @@ Customers.
 
 
     protected new static async Task AssertTranslationFailed(Func<Task> query)
-    {
-        try
-        {
-            await query();
-        }
-        catch
-        {
-            return;
-        }
-
-        throw new Xunit.Sdk.XunitException("Expected query to fail but it succeeded.");
-    }
+        => await MongoAssert.AssertTranslationFailed(query);
 
     private void AssertMql(params string[] expected)
         => Fixture.TestMqlLoggerFactory.AssertBaseline(expected);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindStringIncludeQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindStringIncludeQueryMongoTest.cs
@@ -1314,7 +1314,10 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
     public override async Task Include_collection_with_client_filter(bool async)
     {
         // Fails: Throws with Mongo-specific message rather than the generic EF message. EF-X010
-        await AssertTranslationFailed(() => base.Include_collection_with_client_filter(async));
+        Assert.Contains(
+            "ExpressionNotSupportedException",
+            (await Assert.ThrowsAsync<ThrowsException>(() => base.Include_collection_with_client_filter(async)))
+            .Message);
         AssertMql(
             """
 Customers.
@@ -1322,18 +1325,7 @@ Customers.
     }
 
     protected static new async Task AssertTranslationFailed(Func<Task> query)
-    {
-        try
-        {
-            await query();
-        }
-        catch
-        {
-            return;
-        }
-
-        throw new Xunit.Sdk.XunitException("Expected query to fail but it succeeded.");
-    }
+        => await MongoAssert.AssertTranslationFailed(query);
 
     private void AssertMql(params string[] expected)
         => Fixture.TestMqlLoggerFactory.AssertBaseline(expected);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Utilities/MongoAssert.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Utilities/MongoAssert.cs
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+using Xunit.Sdk;
+
 namespace MongoDB.EntityFrameworkCore.SpecificationTests.Utilities;
 
 internal static class MongoAssert
@@ -26,6 +28,20 @@ internal static class MongoAssert
         var exception = await Assert.ThrowsAnyAsync<Exception>(query);
         var message = GetInnermostException(exception).Message;
         Assert.Contains("Unsupported cross-DbSet query", message);
+    }
+
+    /// <summary>
+    /// Assert that a query throws because the MongoDB provider could not translate it.
+    /// Unlike a bare try/catch, this does not treat a result-mismatch assertion thrown by the
+    /// query's own caller (e.g. from <c>AssertQuery</c> comparing wrong data) as a translation
+    /// failure: only a non-xUnit exception escaping the query counts as "failed to translate".
+    /// </summary>
+    public static async Task AssertTranslationFailed(Func<Task> query)
+    {
+        var exception = await Assert.ThrowsAnyAsync<Exception>(query);
+        Assert.False(
+            exception is XunitException,
+            $"Expected the query to fail to translate, but it instead failed this assertion: {exception}");
     }
 
     private static Exception GetInnermostException(Exception exception)


### PR DESCRIPTION
The four Include spec suites (NorthwindIncludeQueryMongoTest, NorthwindIncludeNoTrackingQueryMongoTest, NorthwindStringIncludeQueryMongoTest, NorthwindEFPropertyIncludeQueryMongoTest) each shadowed the upstream AssertTranslationFailed with try { await query(); } catch { return; }, which swallowed any exception - including a wrong-data assertion failure from the base test itself - so a query that executed and returned wrong rows counted as a pass.

Add a correct MongoAssert.AssertTranslationFailed that rethrows XunitException (wrong data/assertion failures) and only treats non-assertion exceptions as a genuine translation failure; the four shadowed helpers now delegate to it.

Auditing all 234 call sites of the shadowed helper surfaced exactly one masked failure: Include_collection_with_client_filter, which is the already-tracked EF-X010 case. Update its assertion to the same EF-X002-style pattern used elsewhere, and update docs/failing-spec-tests.md accordingly.