### PR TITLE
Bump dependencies, revise tests for 3.11 join sub-query behavior

### DIFF
--- a/Versions.props
+++ b/Versions.props
@@ -1,10 +1,10 @@
 ﻿<Project>
   <PropertyGroup>
-    <EF8Version>8.0.27</EF8Version>
-    <EF9Version>9.0.16</EF9Version>
-    <EF10Version>10.0.8</EF10Version>
+    <EF8Version>8.0.30</EF8Version>
+    <EF9Version>9.0.19</EF9Version>
+    <EF10Version>10.0.11</EF10Version>
     <!-- DRIVER_VERSION env variable could be set by the CI to test EF Provider compatibility with different (newer) versions of the MongoDB.Driver -->
-    <CSharpDriverVersion Condition="'$(DRIVER_VERSION)' == ''">3.10.0</CSharpDriverVersion>
+    <CSharpDriverVersion Condition="'$(DRIVER_VERSION)' == ''">3.11.0</CSharpDriverVersion>
     <CSharpDriverVersion Condition="'$(DRIVER_VERSION)' != ''">$(DRIVER_VERSION)</CSharpDriverVersion>
   </PropertyGroup>
 </Project>

--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -101,6 +101,7 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 | EF-X019 | Include on keyless entity not supported (no primary key for $lookup join) | 2 |
 | EF-X020 | Cross-collection Include/join/navigation not translated on EF8/EF9 (works on EF10) | 168 |
 | EF-X021 | Filtered Include / query filter on cross-collection target not translated | 0 |
+| EF-X022 | Join/GroupJoin whose inner source is a filtered or ordered sub-query is rejected | 18 |
 | EF-X016 | Bulk `ExecuteUpdate`/`ExecuteDelete` source restricted to a single collection scoped by `Where` | 47 |
 
 ### EF-X001 — Sub-query selection across DbSets is not translated
@@ -204,6 +205,54 @@ Affected: 2 tests (`NorthwindKeylessEntitiesQueryMongoTest.KeylessEntity_with_in
 Comment pattern: `// Fails: Cross-collection Include/join not translated on EF8/EF9 EF-X020`.
 Test-body pattern: the override is wrapped in `#if EF8 || EF9` / `#else`. The `#if EF8 || EF9` branch asserts the translation failure (`AssertTranslationFailed(() => base.X(...))`); the `#else` branch keeps the working EF10 baseline (the real `base` call plus its `AssertMql(...)`).
 Affected: 168 tests across `NorthwindEFPropertyIncludeQueryMongoTest`, `NorthwindStringIncludeQueryMongoTest`, `NorthwindIncludeQueryMongoTest`, `NorthwindIncludeNoTrackingQueryMongoTest`, `NorthwindNavigationsQueryMongoTest`, `NorthwindMiscellaneousQueryMongoTest`, `NorthwindJoinQueryMongoTest`, `NorthwindAggregateOperatorsQueryMongoTest`, `NorthwindAsNoTrackingQueryMongoTest`, `NorthwindKeylessEntitiesQueryMongoTest`, `NorthwindSelectQueryMongoTest`, `NorthwindSetOperationsQueryMongoTest`, `NorthwindWhereQueryMongoTest`, and `BuiltInDataTypesMongoTest`. These are the cross-collection Include/`ThenInclude`/join/navigation shapes implemented for the EF10-targeted query pipeline. On EF8/EF9 the upstream nav-expansion / query pipeline produces a different expression shape (e.g. an extra `.OrderBy(o => o.OrderID)` injected during navigation expansion) that the EF10-targeted translator does not handle, so translation fails with EF Core's `InvalidOperationException` "could not be translated" (a few also throw the provider's `ExpressionNotSupportedException`); the same query translates and runs on EF10. The provider's local `AssertTranslationFailed` helper swallows whichever exception is thrown, so both shapes are covered. Four `Include_reference_dependent_already_tracked` overrides (in the four Include suites) emit MQL from a first principal query *before* the Include sub-query fails to translate, so their `#if EF8 || EF9` branch asserts only the translation failure and omits the empty `AssertMql()`. `BuiltInDataTypesMongoTest.Can_read_back_bool_mapped_as_int_through_navigation` is split three ways (a nested `#if EF9` inside the file's `#if !EF8` branch, plus the `#else` EF8 branch) because that file uses async signatures on EF9/EF10 and sync `void` signatures on EF8.
+
+### EF-X022 — Join/GroupJoin whose inner source is a filtered or ordered sub-query is rejected
+Comment pattern: `// Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022`.
+Test-body patterns: `Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>` asserting
+`"Expression not supported"`, or `Assert.ThrowsAnyAsync<Exception>` where the EF8/EF9 failure mode differs.
+
+The provider lowers a single-key `Join`/`GroupJoin` to `$lookup`. When the **inner** source is not a bare
+collection but a sub-query — `Orders.Where(...)`, `Orders.OrderBy(...)`, or a dependent-side query filter
+that lowers to the same `Where` — the driver's LINQ provider rejects the whole expression with
+`ExpressionNotSupportedException: ... because expression must be a MongoDB IQueryable against a collection`.
+This is an **intentional rejection**: these shapes were previously folded into the correlated `$lookup`
+sub-pipeline, which is not a faithful translation — the mis-folding formerly tracked as `CSHARP-6017`.
+Failing loudly is preferred over returning wrong results, so this is a documented boundary rather than a
+regression to fix in the test suite.
+
+Affected: 18 overrides, all asserting the rejection (none are `Skip`ped).
+
+- `NorthwindJoinQueryMongoTest` — `Join_customers_orders_with_subquery`,
+  `Join_customers_orders_with_subquery_predicate`, `Join_customers_orders_with_subquery_anonymous_property_method`,
+  `GroupJoin_customers_employees_subquery_shadow`, `GroupJoin_SelectMany_subquery_with_filter`, plus
+  EF10-only `GroupJoin_DefaultIfEmpty2` and `GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty`.
+- `NorthwindMiscellaneousQueryMongoTest` — `OrderBy_Join`, `Join_take_count_works`.
+- `NorthwindQueryFiltersQueryMongoTest` (EF10-only) — `Entity_Equality`, `Included_many_to_one_query`,
+  `Included_many_to_one_query2`, where the *query filter* on the `$lookup` target is what makes the inner
+  a filtered sub-query.
+- **Former `CSHARP-6017` skips**, now converted to the same assertion style rather than
+  `[ConditionalTheory(Skip = ...)]` — `Join_customers_orders_with_subquery_with_take`,
+  `Join_customers_orders_with_subquery_predicate_with_take`,
+  `Join_customers_orders_with_subquery_anonymous_property_method_with_take`, `GroupJoin_simple_subquery`,
+  `GroupJoin_Subquery_with_Take_Then_SelectMany_Where`, `GroupJoin_customers_employees_subquery_shadow_take`.
+  These were skipped while the driver silently mis-folded the `Take`/sub-query inner and returned wrong
+  results; the driver now rejects them, so they assert the rejection and no longer need a skip.
+
+Interaction with [EF-352](https://jira.mongodb.org/browse/EF-352): that fix (shadow/scalar `EF.Property`
+read on a joined entity in a projection) re-enabled
+`Join_customers_orders_with_subquery_anonymous_property_method` against driver 3.10, but the query's inner
+is an ordered sub-query, so 3.11 rejects it and the override now asserts the rejection instead. The
+underlying EF-352 fix is still covered functionally by
+`ShadowPropertyJoinProjectionTests` and `ShadowPropertyFlatJoinProjectionTests`; the first of those had the
+`orderby` dropped from its join inner (incidental to what it asserts) so it keeps exercising the non-root
+joined-entity shaper on a shape the driver still supports.
+
+The EF10-only entries carry a second ticket for their EF8/EF9 failure mode (`EF-X016`, `EF-X001`, `EF-202`,
+`EF-216`), because on those versions the query fails earlier in nav-expansion and logs no MQL at all —
+hence the `#if EF8 || EF9` split on the `AssertMql` baseline.
+
+Lifting this ticket requires translating the inner sub-query into the `$lookup` sub-pipeline correctly
+(correlated `let`/`pipeline` form), which overlaps with [EF-X021](#ef-x021--filtered-include--query-filter-on-cross-collection-target-not-translated).
 
 ### EF-216 — wrong-data on EF10 (cross-collection navigation), unsupported on EF8/EF9
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF10/SimpleContextModelBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF10/SimpleContextModelBuilder.cs
@@ -25,7 +25,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Design
             EveryTypeEntityType.CreateAnnotations(everyType);
             OwnedEntityEntityType.CreateAnnotations(ownedEntity);
 
-            AddAnnotation("ProductVersion", "10.0.8");
+            AddAnnotation("ProductVersion", "10.0.11");
         }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF8/SimpleContextModelBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF8/SimpleContextModelBuilder.cs
@@ -20,7 +20,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Design
             EveryTypeEntityType.CreateAnnotations(everyType);
             OwnedEntityEntityType.CreateAnnotations(ownedEntity);
 
-            AddAnnotation("ProductVersion", "8.0.27");
+            AddAnnotation("ProductVersion", "8.0.30");
         }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF9/SimpleContextModelBuilder.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Design/Generated/EF9/SimpleContextModelBuilder.cs
@@ -25,7 +25,7 @@ namespace MongoDB.EntityFrameworkCore.FunctionalTests.Design
             EveryTypeEntityType.CreateAnnotations(everyType);
             OwnedEntityEntityType.CreateAnnotations(ownedEntity);
 
-            AddAnnotation("ProductVersion", "9.0.16");
+            AddAnnotation("ProductVersion", "9.0.19");
         }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ShadowPropertyJoinProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ShadowPropertyJoinProjectionTests.cs
@@ -38,11 +38,13 @@ public class ShadowPropertyJoinProjectionTests(TemporaryDatabaseFixture database
 
         using var db = new JoinDbContext(database, ordersName, customersName);
 
+        // The join inner is a bare collection projection: an ordered/filtered sub-query inner is
+        // rejected by the driver (EF-X022), and the ordering is incidental to what this test covers
+        // — the non-root joined-entity shaper nested in an anonymous type.
         var query =
             from c in db.Customers
             join o1 in
                 (from o2 in db.Orders
-                 orderby o2.OrderId
                  select new { o2 }) on c.CustomerId equals o1.o2.CustomerId
             where EF.Property<string>(o1.o2, "CustomerId") == "ALFKI"
             select new

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindJoinQueryMongoTest.cs
@@ -148,48 +148,87 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
 
     public override async Task Join_customers_orders_with_subquery(bool async)
     {
-        await base.Join_customers_orders_with_subquery(async);
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.Join_customers_orders_with_subquery(async))).Message);
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$match" : { "Inner.CustomerID" : "ALFKI" } }, { "$project" : { "ContactName" : "$Outer.ContactName", "OrderID" : "$Inner._id", "_id" : 0 } }
+Customers.
 """);
     }
 
-    [ConditionalTheory(Skip = "CSHARP-6017: driver 3.10 folds an uncorrelated Take/subquery join inner into the correlated $lookup sub-pipeline, returning wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task Join_customers_orders_with_subquery_with_take(bool async)
-        => await base.Join_customers_orders_with_subquery_with_take(async);
+    {
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.Join_customers_orders_with_subquery_with_take(async))).Message);
+
+        AssertMql(
+            """
+Customers.
+""");
+    }
 
     public override async Task Join_customers_orders_with_subquery_anonymous_property_method(bool async)
     {
-        await base.Join_customers_orders_with_subquery_anonymous_property_method(async);
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.Join_customers_orders_with_subquery_anonymous_property_method(async))).Message);
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner.CustomerID" : "ALFKI" } }
+Customers.
 """);
     }
 
-    [ConditionalTheory(Skip = "CSHARP-6017: driver 3.10 folds an uncorrelated Take/subquery join inner into the correlated $lookup sub-pipeline, returning wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task Join_customers_orders_with_subquery_anonymous_property_method_with_take(bool async)
-        => await base.Join_customers_orders_with_subquery_anonymous_property_method_with_take(async);
+    {
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.Join_customers_orders_with_subquery_anonymous_property_method_with_take(async))).Message);
+
+        AssertMql(
+            """
+Customers.
+""");
+    }
 
     public override async Task Join_customers_orders_with_subquery_predicate(bool async)
     {
-        await base.Join_customers_orders_with_subquery_predicate(async);
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.Join_customers_orders_with_subquery_predicate(async))).Message);
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$match" : { "_id" : { "$gt" : 0 } } }, { "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$match" : { "Inner.CustomerID" : "ALFKI" } }, { "$project" : { "ContactName" : "$Outer.ContactName", "OrderID" : "$Inner._id", "_id" : 0 } }
+Customers.
 """);
     }
 
-    [ConditionalTheory(Skip = "CSHARP-6017: driver 3.10 folds an uncorrelated Take/subquery join inner into the correlated $lookup sub-pipeline, returning wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task Join_customers_orders_with_subquery_predicate_with_take(bool async)
-        => await base.Join_customers_orders_with_subquery_predicate_with_take(async);
+    {
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.Join_customers_orders_with_subquery_predicate_with_take(async))).Message);
+
+        AssertMql(
+            """
+Customers.
+""");
+    }
 
     public override async Task Join_composite_key(bool async)
     {
@@ -277,10 +316,19 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
 """);
     }
 
-    [ConditionalTheory(Skip = "CSHARP-6017: driver 3.10 folds an uncorrelated Take/subquery join inner into the correlated $lookup sub-pipeline, returning wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task GroupJoin_simple_subquery(bool async)
-        => await base.GroupJoin_simple_subquery(async);
+    {
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.GroupJoin_simple_subquery(async))).Message);
+
+        AssertMql(
+            """
+Customers.
+""");
+    }
 
     public override async Task GroupJoin_as_final_operator(bool async)
     {
@@ -347,18 +395,17 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
 
     public override async Task GroupJoin_DefaultIfEmpty2(bool async)
     {
-#if EF8 || EF9
-        // Fails: GroupJoin shape not translated EF-X016
-        await AssertTranslationFailed(() => base.GroupJoin_DefaultIfEmpty2(async));
+        // Fails: GroupJoin shape not translated on EF8/EF9 EF-X016; on EF10 the flattened
+        // GroupJoin's inner is a filtered sub-query, which is not supported EF-X022
+        await Assert.ThrowsAnyAsync<Exception>(() => base.GroupJoin_DefaultIfEmpty2(async));
 
+#if EF8 || EF9
         AssertMql(
         );
 #else
-        await base.GroupJoin_DefaultIfEmpty2(async);
-
         AssertMql(
             """
-Employees.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "EmployeeID", "pipeline" : [{ "$match" : { "CustomerID" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }
+Employees.
 """);
 #endif
     }
@@ -448,11 +495,15 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
 
     public override async Task GroupJoin_SelectMany_subquery_with_filter(bool async)
     {
-        await base.GroupJoin_SelectMany_subquery_with_filter(async);
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.GroupJoin_SelectMany_subquery_with_filter(async))).Message);
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$match" : { "_id" : { "$gt" : 5 } } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$project" : { "ContactName" : "$Outer.ContactName", "OrderID" : "$Inner._id", "_id" : 0 } }
+Customers.
 """);
     }
 
@@ -467,18 +518,16 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
 
     public override async Task GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(bool async)
     {
-        // Fails: Subquery selection EF-X001
-#if EF8 || EF9
+        // Fails: Subquery selection EF-X001; on EF10 the join inner is a filtered sub-query EF-X022
         await Assert.ThrowsAnyAsync<Exception>(() => base.GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(async));
 
+#if EF8 || EF9
         AssertMql(
         );
 #else
-        await Assert.ThrowsAnyAsync<Exception>(() => base.GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(async));
-
         AssertMql(
             """
-Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "options" : "s" } } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$match" : { "_id" : { "$gt" : 5 } } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }
+Customers.
 """);
 #endif
     }
@@ -491,10 +540,19 @@ Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^F", "o
         );
     }
 
-    [ConditionalTheory(Skip = "CSHARP-6017: driver 3.10 folds an uncorrelated Take/subquery join inner into the correlated $lookup sub-pipeline, returning wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task GroupJoin_Subquery_with_Take_Then_SelectMany_Where(bool async)
-        => await base.GroupJoin_Subquery_with_Take_Then_SelectMany_Where(async);
+    {
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.GroupJoin_Subquery_with_Take_Then_SelectMany_Where(async))).Message);
+
+        AssertMql(
+            """
+Customers.
+""");
+    }
 
     public override async Task Inner_join_with_tautology_predicate_converts_to_cross_join(bool async)
     {
@@ -695,18 +753,31 @@ Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
 
     public override async Task GroupJoin_customers_employees_subquery_shadow(bool async)
     {
-        await base.GroupJoin_customers_employees_subquery_shadow(async);
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.GroupJoin_customers_employees_subquery_shadow(async))).Message);
 
         AssertMql(
             """
-Customers.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Employees", "localField" : "_outer.City", "foreignField" : "City", "pipeline" : [{ "$sort" : { "City" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$project" : { "Title" : "$Inner.Title", "_id" : "$Inner._id" } }
+Customers.
 """);
     }
 
-    [ConditionalTheory(Skip = "CSHARP-6017: driver 3.10 folds an uncorrelated Take/subquery join inner into the correlated $lookup sub-pipeline, returning wrong results")]
-    [MemberData(nameof(IsAsyncData))]
     public override async Task GroupJoin_customers_employees_subquery_shadow_take(bool async)
-        => await base.GroupJoin_customers_employees_subquery_shadow_take(async);
+    {
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.GroupJoin_customers_employees_subquery_shadow_take(async))).Message);
+
+        AssertMql(
+            """
+Customers.
+""");
+    }
 
     public override async Task GroupJoin_projection(bool async)
     {

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -3514,11 +3514,15 @@ OrderDetails.
 
     public override async Task Join_take_count_works(bool async)
     {
-        await base.Join_take_count_works(async);
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.Join_take_count_works(async))).Message);
 
         AssertMql(
             """
-Orders.{ "$match" : { "_id" : { "$gt" : 690, "$lt" : 710 } } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "_id" : "ALFKI" } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$limit" : 5 }, { "$count" : "_v" }
+Orders.
 """);
     }
 
@@ -4163,11 +4167,15 @@ Customers.
 
     public override async Task OrderBy_Join(bool async)
     {
-        await base.OrderBy_Join(async);
+        // Fails: Join/GroupJoin inner sub-query (filtered/ordered) not supported EF-X022
+        Assert.Contains(
+            "Expression not supported",
+            (await Assert.ThrowsAsync<MongoDB.Driver.Linq.ExpressionNotSupportedException>(() =>
+                base.OrderBy_Join(async))).Message);
 
         AssertMql(
             """
-Customers.{ "$sort" : { "_id" : 1 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Orders", "localField" : "_outer._id", "foreignField" : "CustomerID", "pipeline" : [{ "$sort" : { "_id" : 1 } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "Outer" : "$_outer", "Inner" : "$_inner", "_id" : 0 } }, { "$project" : { "CustomerID" : "$Outer._id", "OrderID" : "$Inner._id", "_id" : 0 } }
+Customers.
 """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindQueryFiltersQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindQueryFiltersQueryMongoTest.cs
@@ -130,18 +130,17 @@ Customers.{ "$lookup" : { "from" : "Orders", "localField" : "_id", "foreignField
 
     public override async Task Included_many_to_one_query(bool async)
     {
-        // Fails: Cross-document navigation access issue EF-216
-#if EF8 || EF9
+        // Fails: Cross-document navigation access issue EF-216; on EF10 the query filter on the
+        // $lookup target makes the join inner a filtered sub-query, which is not supported EF-X022
         await Assert.ThrowsAnyAsync<Exception>(() => base.Included_many_to_one_query(async));
 
+#if EF8 || EF9
         AssertMql(
         );
 #else
-        await base.Included_many_to_one_query(async);
-
         AssertMql(
             """
-Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : "^B", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner" : { "$ne" : null }, "_inner.CompanyName" : { "$ne" : null } } }
+Orders.
 """);
 #endif
     }
@@ -190,18 +189,17 @@ Customers.{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : 
 
     public override async Task Entity_Equality(bool async)
     {
+        // Fails: Entity equality issue EF-202; on EF10 the query filter on the $lookup target
+        // makes the join inner a filtered sub-query, which is not supported EF-X022
+        await Assert.ThrowsAnyAsync<Exception>(() => base.Entity_Equality(async));
+
 #if EF8 || EF9
-        // Fails: Entity equality issue EF-202
-        await AssertTranslationFailed(() => base.Entity_Equality(async));
-
         AssertMql(
-);
+        );
 #else
-        await base.Entity_Equality(async);
-
         AssertMql(
             """
-Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : "^B", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner" : { "$ne" : null }, "_inner.CompanyName" : { "$ne" : null } } }
+Orders.
 """);
 #endif
     }
@@ -221,18 +219,17 @@ Products.
 
     public override async Task Included_many_to_one_query2(bool async)
     {
-        // Fails: Cross-document navigation access issue EF-216
-#if EF8 || EF9
+        // Fails: Cross-document navigation access issue EF-216; on EF10 the query filter on the
+        // $lookup target makes the join inner a filtered sub-query, which is not supported EF-X022
         await Assert.ThrowsAnyAsync<Exception>(() => base.Included_many_to_one_query2(async));
 
+#if EF8 || EF9
         AssertMql(
         );
 #else
-        await base.Included_many_to_one_query2(async);
-
         AssertMql(
             """
-Orders.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Customers", "localField" : "_outer.CustomerID", "foreignField" : "_id", "pipeline" : [{ "$match" : { "CompanyName" : { "$regularExpression" : { "pattern" : "^B", "options" : "s" } } } }], "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner" : { "$ne" : null }, "_inner.CompanyName" : { "$ne" : null } } }
+Orders.
 """);
 #endif
     }


### PR DESCRIPTION
* Update to latest versions of Entity Framework Core (EF8, EF9, EF10) 
* Update to latest version of the MongoDB C# Driver
* Update tests to assert that filtering on joins is not yet supported