### PR TITLE
EF-369: Fix silent drop of Where/OrderBy composed after multi-join Include

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
@@ -572,6 +572,15 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     /// <summary>
     /// For explicit Join queries, strip the Join chain and return just the base source.
     /// The $lookup stages appended by AppendLookupStages handle the actual join.
+    /// <para>
+    /// EF-369: a <c>Where</c>/<c>OrderBy</c>/etc. found between the outermost call and the join being
+    /// stripped is discarded along with the join chain (same as before this fix). When that discarded
+    /// operator's lambda reads through a <c>TransparentIdentifier.Inner</c> member - i.e. it filters/sorts
+    /// on data that only exists via the join being removed here - simply dropping it silently changes the
+    /// result set instead of raising an error. The provider does not yet rewrite such a lambda to read the
+    /// flattened <c>$lookup</c> fields the join is replaced with (TODO EF-317, tracked with the rest of this
+    /// $lookup fallback plumbing), so this shape now fails translation loudly instead.
+    /// </para>
     /// </summary>
     private static Expression? StripJoinForLookup(Expression expression)
     {
@@ -580,12 +589,17 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
 
         var baseSource = FindBaseSourceThroughJoin(outerCall);
         if (baseSource != null && IsJoinRelatedMethod(outerCall))
+        {
+            GuardAgainstDiscardedJoinShapeLambda(outerCall);
             return baseSource;
+        }
 
         var source = outerCall.Arguments[0];
         baseSource = FindBaseSourceThroughJoin(source);
         if (baseSource == null)
             return null;
+
+        GuardAgainstDiscardedJoinShapeLambda(source);
 
         var newArgs = outerCall.Arguments.ToArray();
         newArgs[0] = baseSource;
@@ -626,6 +640,64 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             return FindBaseSourceThroughJoin(call.Arguments[0]);
 
         return null;
+    }
+
+    /// <summary>
+    /// Walks the portion of the tree that <see cref="StripJoinForLookup"/> is about to discard (everything
+    /// from <paramref name="discarded"/> down to the base source) looking for a <c>Where</c>/<c>OrderBy</c>-
+    /// family call whose own lambda reads through a <c>TransparentIdentifier.Inner</c> member. Only that
+    /// operator's OWN lambda is checked at each level (not a nested projection's, e.g. a Select's) - a
+    /// projection/materialization node reading joined data is expected and handled separately by the
+    /// shaper/projection-binding visitors; a filter/sort actually needing to run as LINQ here is not.
+    /// </summary>
+    private static void GuardAgainstDiscardedJoinShapeLambda(Expression discarded)
+    {
+        if (discarded is not MethodCallExpression call)
+        {
+            return;
+        }
+
+        if (call.Method.Name is "Where" or "OrderBy" or "OrderByDescending" or "ThenBy" or "ThenByDescending"
+            && call.Arguments.Count > 1
+            && call.Arguments[1] is UnaryExpression { NodeType: ExpressionType.Quote, Operand: LambdaExpression lambda }
+            && ReferencesTransparentIdentifierInner(lambda.Body))
+        {
+            throw new InvalidOperationException(
+                Microsoft.EntityFrameworkCore.Diagnostics.CoreStrings.TranslationFailed(call.Print()));
+        }
+
+        if (call.Arguments.Count > 0)
+        {
+            GuardAgainstDiscardedJoinShapeLambda(call.Arguments[0]);
+        }
+    }
+
+    /// <summary>
+    /// Whether the expression reads through a <c>TransparentIdentifier.Inner</c> member anywhere - i.e.
+    /// reaches data that only exists via a join being stripped by <see cref="StripJoinForLookup"/>.
+    /// </summary>
+    private static bool ReferencesTransparentIdentifierInner(Expression body)
+    {
+        var finder = new TransparentIdentifierInnerAccessFinder();
+        finder.Visit(body);
+        return finder.Found;
+    }
+
+    private sealed class TransparentIdentifierInnerAccessFinder : System.Linq.Expressions.ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (node.Member.Name == "Inner"
+                && node.Member.DeclaringType is { IsGenericType: true } dt
+                && dt.Name.StartsWith("TransparentIdentifier", StringComparison.Ordinal))
+            {
+                Found = true;
+            }
+
+            return base.VisitMember(node);
+        }
     }
 
     /// <summary>

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
@@ -573,13 +573,9 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     /// For explicit Join queries, strip the Join chain and return just the base source.
     /// The $lookup stages appended by AppendLookupStages handle the actual join.
     /// <para>
-    /// EF-369: a <c>Where</c>/<c>OrderBy</c>/etc. found between the outermost call and the join being
-    /// stripped is discarded along with the join chain (same as before this fix). When that discarded
-    /// operator's lambda reads through a <c>TransparentIdentifier.Inner</c> member - i.e. it filters/sorts
-    /// on data that only exists via the join being removed here - simply dropping it silently changes the
-    /// result set instead of raising an error. The provider does not yet rewrite such a lambda to read the
-    /// flattened <c>$lookup</c> fields the join is replaced with (TODO EF-317, tracked with the rest of this
-    /// $lookup fallback plumbing), so this shape now fails translation loudly instead.
+    /// EF-369: a discarded <c>Where</c>/<c>OrderBy</c>/etc. whose lambda reads through the join via
+    /// <c>TransparentIdentifier.Inner</c> would otherwise be silently dropped instead of failing loudly.
+    /// No rewrite to the flattened <c>$lookup</c> fields yet exists (TODO EF-317).
     /// </para>
     /// </summary>
     private static Expression? StripJoinForLookup(Expression expression)
@@ -643,12 +639,8 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
     }
 
     /// <summary>
-    /// Walks the portion of the tree that <see cref="StripJoinForLookup"/> is about to discard (everything
-    /// from <paramref name="discarded"/> down to the base source) looking for a <c>Where</c>/<c>OrderBy</c>-
-    /// family call whose own lambda reads through a <c>TransparentIdentifier.Inner</c> member. Only that
-    /// operator's OWN lambda is checked at each level (not a nested projection's, e.g. a Select's) - a
-    /// projection/materialization node reading joined data is expected and handled separately by the
-    /// shaper/projection-binding visitors; a filter/sort actually needing to run as LINQ here is not.
+    /// Throws if the discarded subtree contains a <c>Where</c>/<c>OrderBy</c>-family call whose own lambda
+    /// (not a nested Select's) reads through a <c>TransparentIdentifier.Inner</c> member.
     /// </summary>
     private static void GuardAgainstDiscardedJoinShapeLambda(Expression discarded)
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -299,6 +299,28 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     }
 
     [Fact]
+    public void Include_multi_join_then_root_only_where_with_no_other_operator_is_reattached_correctly()
+    {
+        // A bare root-only Where (no OrderBy after it) composed after a multi-hop Include chain. EF Core's
+        // own query preprocessor hoists a predicate that doesn't reference a navigation BELOW the Include's
+        // joins before this provider ever sees the tree (confirmed via the captured efQueryExpression: the
+        // Where ends up as the join chain's source, not wrapping it) - so this never reaches the "discard
+        // the join chain" branch of StripJoinForLookup at all. Guards against a regression of that hoisting
+        // assumption: if it ever stopped happening, this predicate would go back to being silently dropped.
+        var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
+
+        using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);
+        var orders = db.Orders
+            .Include(o => o.Customer)
+                .ThenInclude(c => c.Region)
+            .Where(o => o.OrderDescription != "Order 1")
+            .ToList();
+
+        Assert.Equal(2, orders.Count);
+        Assert.All(orders, o => Assert.NotNull(o.Customer?.Region));
+    }
+
+    [Fact]
     public void Include_multi_join_then_root_only_where_and_orderby_are_reattached_correctly()
     {
         // A Where/OrderBy composed after a multi-hop Include chain that only reads a property of the root

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -261,6 +261,90 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
 
 #if !EF8 && !EF9
     [Fact]
+    public void Include_multi_join_then_where_composed_after_is_not_silently_dropped()
+    {
+        // EF-369 repro: a multi-hop reference Include chain (two reference joins) flattens to forced-unwind
+        // $lookup stages (see MongoQueryableMethodTranslatingExpressionVisitor's isSecondOrLaterJoin path).
+        // A Where composed AFTER the Include chain reads through the joined-in navigation properties, which
+        // the provider does not yet rewrite to read the flattened $lookup fields (TODO EF-317). It must fail
+        // loudly (translation failure) rather than silently drop the predicate and return every order.
+        var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
+
+        using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            db.Orders
+                .Include(o => o.Customer)
+                    .ThenInclude(c => c.Region)
+                .Where(o => o.Customer.Region.RegionName == "West")
+                .ToList());
+    }
+
+    [Fact]
+    public void Include_multi_join_then_orderby_composed_after_is_not_silently_dropped()
+    {
+        // Same EF-369 gap for OrderBy: a sort key selector reaching through the joined-in navigation
+        // properties composed after a multi-hop reference Include chain must also fail loudly rather than
+        // silently sort against the wrong (un-joined) source.
+        var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
+
+        using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            db.Orders
+                .Include(o => o.Customer)
+                    .ThenInclude(c => c.Region)
+                .OrderBy(o => o.Customer.Region.RegionName)
+                .ToList());
+    }
+
+    [Fact]
+    public void Include_multi_join_then_root_only_where_and_orderby_are_reattached_correctly()
+    {
+        // A Where/OrderBy composed after a multi-hop Include chain that only reads a property of the root
+        // entity (never crossing into the joined-in Customer/Region data) doesn't need any $lookup field -
+        // it must be correctly reattached to the un-joined base source and actually applied, not silently
+        // dropped (which would happen to look like it "worked" if left unverified, since dropping a no-op
+        // filter/sort is indistinguishable from a correctly-applied one unless the assertions are specific
+        // enough to catch it).
+        var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
+
+        using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);
+        var orders = db.Orders
+            .Include(o => o.Customer)
+                .ThenInclude(c => c.Region)
+            .Where(o => o.OrderDescription != "Order 1")
+            .OrderByDescending(o => o.OrderDescription)
+            .ToList();
+
+        Assert.Equal(["Order 3", "Order 2"], orders.Select(o => o.OrderDescription).ToArray());
+        Assert.All(orders, o => Assert.NotNull(o.Customer?.Region));
+    }
+
+    [Fact]
+    public void Include_multi_join_then_skip_take_composed_after_still_works()
+    {
+        // Skip/Take carry no lambda over the joined shape, so unlike Where/OrderBy above they can be
+        // (and must continue to be) safely reattached to the un-joined base source instead of being
+        // silently discarded.
+        var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
+
+        using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);
+        var orders = db.Orders
+            .Include(o => o.Customer)
+                .ThenInclude(c => c.Region)
+            .OrderBy(o => o.OrderDescription)
+            .Skip(1)
+            .Take(2)
+            .ToList();
+
+        Assert.Equal(["Order 2", "Order 3"], orders.Select(o => o.OrderDescription).ToArray());
+        Assert.All(orders, o => Assert.NotNull(o.Customer?.Region));
+    }
+#endif
+
+#if !EF8 && !EF9
+    [Fact]
     public void Include_self_join_materializes_related_entity()
     {
         var staffName = TemporaryDatabaseFixtureBase.CreateCollectionName("Staff") + Guid.NewGuid().ToString("N")[..8];
@@ -315,6 +399,42 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
             db.Customers
                 .Include(c => c.Orders)
                 .First(c => c.FullName == "Alice"));
+    }
+
+    // BSON uses: desc, cust_id, region_id for Orders/Customers; region_name for Regions.
+    // C# uses:   OrderDescription, CustomerId, RegionId for Orders/Customers; RegionName for Regions.
+    private (string ordersCollection, string customersCollection, string regionsCollection) SetupOrdersCustomersAndRegions()
+    {
+        var customersName = TemporaryDatabaseFixtureBase.CreateCollectionName("MultiJoinCustomers") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("MultiJoinOrders") + Guid.NewGuid().ToString("N")[..8];
+        var regionsName = TemporaryDatabaseFixtureBase.CreateCollectionName("MultiJoinRegions") + Guid.NewGuid().ToString("N")[..8];
+
+        var westRegionId = ObjectId.GenerateNewId();
+        var eastRegionId = ObjectId.GenerateNewId();
+
+        var regions = database.MongoDatabase.GetCollection<BsonDocument>(regionsName);
+        regions.InsertMany([
+            new BsonDocument { { "_id", westRegionId }, { "region_name", "West" } },
+            new BsonDocument { { "_id", eastRegionId }, { "region_name", "East" } }
+        ]);
+
+        var westCustomerId = ObjectId.GenerateNewId();
+        var eastCustomerId = ObjectId.GenerateNewId();
+
+        var customers = database.MongoDatabase.GetCollection<BsonDocument>(customersName);
+        customers.InsertMany([
+            new BsonDocument { { "_id", westCustomerId }, { "name", "Alice" }, { "region_id", westRegionId } },
+            new BsonDocument { { "_id", eastCustomerId }, { "name", "Bob" }, { "region_id", eastRegionId } }
+        ]);
+
+        var orders = database.MongoDatabase.GetCollection<BsonDocument>(ordersName);
+        orders.InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order 1" }, { "cust_id", westCustomerId } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order 2" }, { "cust_id", westCustomerId } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order 3" }, { "cust_id", eastCustomerId } }
+        ]);
+
+        return (ordersName, customersName, regionsName);
     }
 
     // BSON uses: desc, cust_id for Orders; name for Customers
@@ -468,6 +588,89 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     }
 
 #if !EF8 && !EF9
+    class MultiJoinRegion
+    {
+        public ObjectId _id { get; set; }
+        public string RegionName { get; set; }
+    }
+
+    class MultiJoinCustomer
+    {
+        public ObjectId _id { get; set; }
+        public string FullName { get; set; }
+        public ObjectId? RegionId { get; set; }
+        public MultiJoinRegion Region { get; set; }
+    }
+
+    class MultiJoinOrder
+    {
+        public ObjectId _id { get; set; }
+        public string OrderDescription { get; set; }
+        public ObjectId? CustomerId { get; set; }
+        public MultiJoinCustomer Customer { get; set; }
+    }
+
+    class OrderCustomerRegionDbContext : DbContext
+    {
+        private readonly string _ordersCollection;
+        private readonly string _customersCollection;
+        private readonly string _regionsCollection;
+
+        public DbSet<MultiJoinOrder> Orders { get; set; }
+        public DbSet<MultiJoinCustomer> Customers { get; set; }
+        public DbSet<MultiJoinRegion> Regions { get; set; }
+
+        public OrderCustomerRegionDbContext(
+            TemporaryDatabaseFixture database,
+            string ordersCollection,
+            string customersCollection,
+            string regionsCollection)
+            : base(new DbContextOptionsBuilder<OrderCustomerRegionDbContext>()
+                .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+                .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options)
+        {
+            _ordersCollection = ordersCollection;
+            _customersCollection = customersCollection;
+            _regionsCollection = regionsCollection;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<MultiJoinRegion>(b =>
+            {
+                b.ToCollection(_regionsCollection);
+                b.Property(r => r.RegionName).HasElementName("region_name");
+            });
+
+            modelBuilder.Entity<MultiJoinCustomer>(b =>
+            {
+                b.ToCollection(_customersCollection);
+                b.Property(c => c.FullName).HasElementName("name");
+                b.Property(c => c.RegionId).HasElementName("region_id");
+                b.HasOne(c => c.Region).WithMany().HasForeignKey(c => c.RegionId);
+            });
+
+            modelBuilder.Entity<MultiJoinOrder>(b =>
+            {
+                b.ToCollection(_ordersCollection);
+                b.Property(o => o.OrderDescription).HasElementName("desc");
+                b.Property(o => o.CustomerId).HasElementName("cust_id");
+                b.HasOne(o => o.Customer).WithMany().HasForeignKey(o => o.CustomerId);
+            });
+        }
+
+        sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime)
+                => Interlocked.Increment(ref _count);
+        }
+    }
+
     class StaffMember
     {
         public ObjectId _id { get; set; }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -263,11 +263,8 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     [Fact]
     public void Include_multi_join_then_where_composed_after_is_not_silently_dropped()
     {
-        // EF-369 repro: a multi-hop reference Include chain (two reference joins) flattens to forced-unwind
-        // $lookup stages (see MongoQueryableMethodTranslatingExpressionVisitor's isSecondOrLaterJoin path).
-        // A Where composed AFTER the Include chain reads through the joined-in navigation properties, which
-        // the provider does not yet rewrite to read the flattened $lookup fields (TODO EF-317). It must fail
-        // loudly (translation failure) rather than silently drop the predicate and return every order.
+        // EF-369 repro: a Where reading through the joined-in navigation properties after a multi-hop
+        // Include chain must fail loudly (TODO EF-317) rather than silently drop the predicate.
         var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
 
         using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);
@@ -301,12 +298,9 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     [Fact]
     public void Include_multi_join_then_root_only_where_with_no_other_operator_is_reattached_correctly()
     {
-        // A bare root-only Where (no OrderBy after it) composed after a multi-hop Include chain. EF Core's
-        // own query preprocessor hoists a predicate that doesn't reference a navigation BELOW the Include's
-        // joins before this provider ever sees the tree (confirmed via the captured efQueryExpression: the
-        // Where ends up as the join chain's source, not wrapping it) - so this never reaches the "discard
-        // the join chain" branch of StripJoinForLookup at all. Guards against a regression of that hoisting
-        // assumption: if it ever stopped happening, this predicate would go back to being silently dropped.
+        // EF Core's query preprocessor hoists this predicate below the Include's joins before we see the
+        // tree, so StripJoinForLookup's discard branch is never reached here. Guards against a regression
+        // of that hoisting assumption, which would otherwise silently drop the predicate.
         var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
 
         using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);
@@ -323,12 +317,8 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     [Fact]
     public void Include_multi_join_then_root_only_where_and_orderby_are_reattached_correctly()
     {
-        // A Where/OrderBy composed after a multi-hop Include chain that only reads a property of the root
-        // entity (never crossing into the joined-in Customer/Region data) doesn't need any $lookup field -
-        // it must be correctly reattached to the un-joined base source and actually applied, not silently
-        // dropped (which would happen to look like it "worked" if left unverified, since dropping a no-op
-        // filter/sort is indistinguishable from a correctly-applied one unless the assertions are specific
-        // enough to catch it).
+        // Root-only Where/OrderBy needs no $lookup field, so it must be reattached and actually applied -
+        // assertions are specific because a dropped no-op filter/sort looks identical to a correct one.
         var (ordersCollection, customersCollection, regionsCollection) = SetupOrdersCustomersAndRegions();
 
         using var db = new OrderCustomerRegionDbContext(database, ordersCollection, customersCollection, regionsCollection);


### PR DESCRIPTION
StripJoinForLookup peels join-scaffolding nodes back to the base source for multi-hop reference Include chains (flattened to forced-unwind $lookup stages), but discarded any Where/OrderBy sitting in between along with the joins - including a genuine user predicate reading the joined-in data - with no result other than silently returning the wrong (unfiltered/unsorted) rows.

Guard the strip: when a discarded Where/OrderBy-family node's own lambda reads through the join-produced TransparentIdentifier.Inner, fail translation loudly instead, matching this file's existing convention for other not-yet-supported shapes. Predicates that only touch the root entity are unaffected.