### PR TITLE
EF-372: Fix unprefixed localField at 3+ hop ThenInclude chains

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
@@ -31,6 +31,7 @@ internal sealed partial class MongoQueryExpression
     private readonly List<LookupExpression> _pendingLookups = [];
     private readonly Dictionary<IEntityType, MongoCollectionExpression> _innerCollections = new();
     private readonly Dictionary<IEntityType, bool> _innerCollectionIsLeftOuter = new();
+    private readonly Dictionary<IEntityType, INavigation> _innerCollectionNavigations = new();
     private bool _hasInterleavingOperatorSinceLastJoin;
     private int _joinRegistrationCount;
 
@@ -176,4 +177,19 @@ internal sealed partial class MongoQueryExpression
     /// </summary>
     public bool TryGetJoinIsLeftOuter(IEntityType entityType, out bool isLeftOuter)
         => _innerCollectionIsLeftOuter.TryGetValue(entityType, out isLeftOuter);
+
+    /// <summary>
+    /// Records which navigation actually introduced an inner collection's $lookup, so its
+    /// "_lookup_&lt;Navigation&gt;" alias can be recovered later. Re-deriving this from metadata is unsafe
+    /// when more than one navigation targets the same entity type.
+    /// </summary>
+    public void RegisterInnerCollectionNavigation(IEntityType entityType, INavigation navigation)
+        => _innerCollectionNavigations[entityType] = navigation;
+
+    /// <summary>
+    /// Get the navigation that was registered (via <see cref="RegisterInnerCollectionNavigation"/>) as
+    /// having introduced the given inner collection, or <see langword="null"/> if none was recorded.
+    /// </summary>
+    public INavigation? GetInnerCollectionNavigation(IEntityType entityType)
+        => _innerCollectionNavigations.GetValueOrDefault(entityType);
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -699,7 +699,10 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         // previously-joined intermediate (e.g. OrderDetail.Order.Customer — the join's outer key
         // selector is "o.Inner.CustomerID"). When no direct navigation exists, resolve the navigation
         // on a prior inner collection and remember the intermediate so the $lookup's localField can be
-        // prefixed with that intermediate's "_lookup_<Intermediate>" path.
+        // prefixed with that intermediate's "_lookup_<Intermediate>" path (the intermediate may itself be
+        // reached transitively, so the prefix must come from the navigation actually joined through —
+        // recorded via RegisterInnerCollectionNavigation, not re-derived from metadata, which could
+        // resolve to an unrelated navigation never emitted as a $lookup).
         INavigation? throughNavigation = null;
         if (navigation == null && fkPropertyName != null)
         {
@@ -716,11 +719,15 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                 if (candidate != null)
                 {
                     navigation = candidate;
-                    throughNavigation = outerEntityType.GetNavigations()
-                        .FirstOrDefault(n => n.TargetEntityType == priorInnerEntityType);
+                    throughNavigation = outerQueryExpression.GetInnerCollectionNavigation(priorInnerEntityType);
                     break;
                 }
             }
+        }
+
+        if (navigation != null)
+        {
+            outerQueryExpression.RegisterInnerCollectionNavigation(innerEntityType, navigation);
         }
 
         // Document-shape decision (single source of truth): the driver's native LeftJoin
@@ -754,7 +761,9 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                 outerQueryExpression.AddLookup(lookup);
             }
 
-            // ...and retroactively for every PRIOR inner collection so the whole document is flat.
+            // ...and retroactively for every PRIOR inner collection so the whole document is flat. Use
+            // the navigation actually registered for each prior collection (not a metadata re-derivation)
+            // for the same reason as above: the wrong navigation would emit under the wrong alias.
             foreach (var priorInnerEntityType in outerQueryExpression.InnerCollections.Keys)
             {
                 if (priorInnerEntityType == innerEntityType)
@@ -762,8 +771,7 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                     continue;
                 }
 
-                var priorNavigation = outerEntityType.GetNavigations()
-                    .FirstOrDefault(n => n.TargetEntityType == priorInnerEntityType);
+                var priorNavigation = outerQueryExpression.GetInnerCollectionNavigation(priorInnerEntityType);
                 if (priorNavigation != null)
                 {
                     // Use the left-outer/inner-ness recorded when THAT join was translated

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -261,6 +261,33 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
 
 #if !EF8 && !EF9
     [Fact]
+    public void Include_three_hop_then_include_materializes_nested_entities()
+    {
+        // EF-372 regression test: a THIRD hop reference Include must prefix its $lookup localField with
+        // the second hop's alias too, not just the first. Getting this wrong doesn't throw — it silently
+        // returns zero rows — so assert row counts/identities rather than MQL.
+        var (linesCollection, ordersCollection, buyersCollection, regionsCollection) = SetupThreeHopChain();
+
+        using var db = new ThreeHopDbContext(database, linesCollection, ordersCollection, buyersCollection, regionsCollection);
+        var lines = db.HopLines
+            .Include(l => l.Order)
+                .ThenInclude(o => o.Buyer)
+                    .ThenInclude(b => b.Region)
+            .ToList();
+
+        Assert.Equal(4, lines.Count);
+        Assert.All(lines, l =>
+        {
+            Assert.NotNull(l.Order);
+            Assert.NotNull(l.Order.Buyer);
+            Assert.NotNull(l.Order.Buyer.Region);
+        });
+        Assert.Equal(2, lines.Select(l => l.Order.Buyer.Region.RegionName).Distinct().Count());
+    }
+#endif
+
+#if !EF8 && !EF9
+    [Fact]
     public void Include_self_join_materializes_related_entity()
     {
         var staffName = TemporaryDatabaseFixtureBase.CreateCollectionName("Staff") + Guid.NewGuid().ToString("N")[..8];
@@ -341,6 +368,47 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
         ]);
 
         return (ordersName, customersName);
+    }
+
+    // BSON uses: ord_id for Lines; buyer_id for Orders; b_name, region_id for Buyers; r_name for Regions
+    // C# uses:   OrderId for Lines; BuyerId for Orders; BuyerName, RegionId for Buyers; RegionName for Regions
+    private (string linesCollection, string ordersCollection, string buyersCollection, string regionsCollection) SetupThreeHopChain()
+    {
+        var regionsName = TemporaryDatabaseFixtureBase.CreateCollectionName("HopRegions") + Guid.NewGuid().ToString("N")[..8];
+        var buyersName = TemporaryDatabaseFixtureBase.CreateCollectionName("HopBuyers") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("HopOrders") + Guid.NewGuid().ToString("N")[..8];
+        var linesName = TemporaryDatabaseFixtureBase.CreateCollectionName("HopLines") + Guid.NewGuid().ToString("N")[..8];
+
+        var regionId1 = ObjectId.GenerateNewId();
+        var regionId2 = ObjectId.GenerateNewId();
+        var buyerId1 = ObjectId.GenerateNewId();
+        var buyerId2 = ObjectId.GenerateNewId();
+        var orderId1 = ObjectId.GenerateNewId();
+        var orderId2 = ObjectId.GenerateNewId();
+
+        database.MongoDatabase.GetCollection<BsonDocument>(regionsName).InsertMany([
+            new BsonDocument { { "_id", regionId1 }, { "r_name", "East" } },
+            new BsonDocument { { "_id", regionId2 }, { "r_name", "West" } }
+        ]);
+
+        database.MongoDatabase.GetCollection<BsonDocument>(buyersName).InsertMany([
+            new BsonDocument { { "_id", buyerId1 }, { "b_name", "Buyer 1" }, { "region_id", regionId1 } },
+            new BsonDocument { { "_id", buyerId2 }, { "b_name", "Buyer 2" }, { "region_id", regionId2 } }
+        ]);
+
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertMany([
+            new BsonDocument { { "_id", orderId1 }, { "buyer_id", buyerId1 } },
+            new BsonDocument { { "_id", orderId2 }, { "buyer_id", buyerId2 } }
+        ]);
+
+        database.MongoDatabase.GetCollection<BsonDocument>(linesName).InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "ord_id", orderId1 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "ord_id", orderId1 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "ord_id", orderId2 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "ord_id", orderId2 } }
+        ]);
+
+        return (linesName, ordersName, buyersName, regionsName);
     }
 
     class Order
@@ -466,6 +534,104 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
                 => Interlocked.Increment(ref _count);
         }
     }
+
+#if !EF8 && !EF9
+    class HopRegion
+    {
+        public ObjectId _id { get; set; }
+        public string RegionName { get; set; }
+    }
+
+    class HopBuyer
+    {
+        public ObjectId _id { get; set; }
+        public string BuyerName { get; set; }
+        public ObjectId? RegionId { get; set; }
+        public HopRegion Region { get; set; }
+    }
+
+    class HopOrder
+    {
+        public ObjectId _id { get; set; }
+        public ObjectId? BuyerId { get; set; }
+        public HopBuyer Buyer { get; set; }
+    }
+
+    class HopLine
+    {
+        public ObjectId _id { get; set; }
+        public ObjectId? OrderId { get; set; }
+        public HopOrder Order { get; set; }
+    }
+
+    class ThreeHopDbContext : DbContext
+    {
+        private readonly string _linesCollection;
+        private readonly string _ordersCollection;
+        private readonly string _buyersCollection;
+        private readonly string _regionsCollection;
+
+        public DbSet<HopLine> HopLines { get; set; }
+
+        public ThreeHopDbContext(
+            TemporaryDatabaseFixture database,
+            string linesCollection,
+            string ordersCollection,
+            string buyersCollection,
+            string regionsCollection)
+            : base(new DbContextOptionsBuilder<ThreeHopDbContext>()
+                .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+                .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options)
+        {
+            _linesCollection = linesCollection;
+            _ordersCollection = ordersCollection;
+            _buyersCollection = buyersCollection;
+            _regionsCollection = regionsCollection;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<HopRegion>(b =>
+            {
+                b.ToCollection(_regionsCollection);
+                b.Property(r => r.RegionName).HasElementName("r_name");
+            });
+
+            modelBuilder.Entity<HopBuyer>(b =>
+            {
+                b.ToCollection(_buyersCollection);
+                b.Property(x => x.BuyerName).HasElementName("b_name");
+                b.Property(x => x.RegionId).HasElementName("region_id");
+                b.HasOne(x => x.Region).WithMany().HasForeignKey(x => x.RegionId);
+            });
+
+            modelBuilder.Entity<HopOrder>(b =>
+            {
+                b.ToCollection(_ordersCollection);
+                b.Property(x => x.BuyerId).HasElementName("buyer_id");
+                b.HasOne(x => x.Buyer).WithMany().HasForeignKey(x => x.BuyerId);
+            });
+
+            modelBuilder.Entity<HopLine>(b =>
+            {
+                b.ToCollection(_linesCollection);
+                b.Property(x => x.OrderId).HasElementName("ord_id");
+                b.HasOne(x => x.Order).WithMany().HasForeignKey(x => x.OrderId);
+            });
+        }
+
+        sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime)
+                => Interlocked.Increment(ref _count);
+        }
+    }
+#endif
 
 #if !EF8 && !EF9
     class StaffMember


### PR DESCRIPTION
RebindInnerShaperToOuterQuery resolved a transitive $lookup's localField prefix by searching only the root entity type's navigations, which only finds the prior hop when it is one level deep. From the third hop onward the prior entity is reachable only through an intermediate, so the search returned null, no prefix was applied, and the emitted localField pointed at a nonexistent field, silently dropping rows.

Widen the search to every entity type already joined in the chain so the prefix resolves correctly regardless of depth.