### PR TITLE
EF-371: Fix self-referencing two-hop navigation returning wrong data

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -277,29 +277,24 @@ Lifting this ticket requires translating the inner sub-query into the `$lookup` 
 `Select_Where_Navigation_Null_Deep`. They were believed to share one root cause — "compound multi-hop
 navigation lowering". They did not.
 
-**Four of the five are fixed** (EF-369 / EF-370, see
+**All five are now fixed.** Four via EF-369 / EF-370 (see
 `docs/superpowers/specs/2026-08-03-required-nav-unwind-semantics-design.md`): the composed predicate /
 `Contains` filter was being *discarded* when a multi-join Include chain was flattened to root-level
 `_lookup_<Nav>` fields, so the query returned every row (2155 against 112 / 112 / 352 / 40 expected).
-Those four are now un-skipped, run on EF10 with real `AssertMql` baselines, and take the standard
+Those four are un-skipped, run on EF10 with real `AssertMql` baselines, and take the standard
 `#if EF8 || EF9` **EF-X020** arm (their navigations are optional, so EF lowers them to `Queryable.LeftJoin`,
-whose dispatch case does not exist before EF10).
+whose dispatch case does not exist before EF10):
 
-**The fifth is a different defect**, tracked as EF-371. It is **baselined green, not skipped** — a skip
-stops the shape being exercised at all, so neither a regression nor an accidental fix would be noticed.
-The `#else` (EF10) arm asserts the wrong data with the loose form the repo uses for a wrong-*data* failure
-(as opposed to the exact-type form reserved for a wrong exception *type*), plus the real `AssertMql`
-baseline, which pins the defective pipeline including the bare hop-2 `$unwind` diagnosed below:
+- `Include_with_multiple_optional_navigations`
+- `Multiple_include_with_multiple_optional_navigations`
+- `Navigation_from_join_clause_inside_contains`
+- `Navigation_inside_contains_nested`
 
-```csharp
-// Fails: returns wrong data (0 rows instead of 6) EF-371
-await Assert.ThrowsAnyAsync<Xunit.Sdk.XunitException>(() => base.Select_Where_Navigation_Null_Deep(async));
-```
-
-On EF8/EF9 the same shape fails at *translation* instead, so that arm is the standard **EF-X020**
-`AssertTranslationFailed` + empty `AssertMql()`. `Select_Where_Navigation_Null_Deep`
-filters on `e.Manager.Manager == null` over the self-referencing `Employee.Manager` navigation and returns
-**0 rows where 6 are correct**. Two causes, both independent of the discarded-operator bug:
+The fifth, `Select_Where_Navigation_Null_Deep` (a self-referencing two-hop navigation,
+`e.Manager.Manager == null`), was a **different defect**, tracked and fixed as EF-371. It filters on
+`e.Manager.Manager == null` over the self-referencing `Employee.Manager` navigation and was returning
+**0 rows where 6 are correct**. Two causes, both independent of the discarded-operator bug fixed by
+EF-369/EF-370:
 
 1. `MongoQueryExpression._innerCollections` is keyed by `IEntityType`, so a self-referencing two-hop
    navigation registers only **one** inner collection. `InnerCollections.Count > 1` stays false, no
@@ -310,10 +305,16 @@ filters on `e.Manager.Manager == null` over the self-referencing `Employee.Manag
    `LeftJoinResult`, so it falls through to `Queryable.Join` and the driver emits a bare `$unwind` — an
    **inner** join. Rows whose grandparent is absent are dropped, so `== null` can never match.
 
-With this one test baselined, the full spec suite is **green on all three EF versions** (0 failures) and
-carries **no skips for this work**. It is the only known-incorrect query shape remaining; when
-self-referencing multi-hop reference navigation is fixed, the EF10 arm flips red at the `ThrowsAnyAsync`
-and is replaced by a plain `await base.…` plus a refreshed baseline.
+The fix: `_innerCollections` now registers per-navigation (not just per-`IEntityType`), lookup-alias
+collisions are detected by the alias string a plain lookup would produce rather than by `INavigation`
+identity (so two distinct navigations sharing a name are disambiguated too), and the residual `Where`
+left over from stripping a join chain for `$lookup` is rewritten against the flattened
+`_lookup_<Navigation>` fields instead of being discarded (the sibling `Select` is still discarded — its
+projection is reconstructed independently by the compiled client-side shaper). It is un-skipped and
+asserts real data + MQL on EF10; EF8/EF9 still assert translation failure per EF-X020.
+
+With all five un-skipped, the full spec suite is **green on all three EF versions** (EF8/EF9/EF10:
+0 failures) and carries **no skips for this work**.
 
 ---
 

--- a/src/MongoDB.EntityFrameworkCore/ExpressionExtensionMethods.cs
+++ b/src/MongoDB.EntityFrameworkCore/ExpressionExtensionMethods.cs
@@ -129,4 +129,16 @@ internal static class ExpressionExtensionMethods
                      && methodCall.Arguments[1] is ConstantExpression { Value: string name } => name,
             _ => null
         };
+
+    /// <summary>
+    /// Whether <paramref name="member"/> is an access to the <c>Outer</c>/<c>Inner</c> field of an EF-
+    /// generated <c>TransparentIdentifier&lt;TOuter,TInner&gt;</c> — the wrapper nav-expansion introduces
+    /// for each join in a chain. Checked by declaring type (not just member name) so a joined entity that
+    /// happens to declare its own real <c>Outer</c>/<c>Inner</c> property isn't mistaken for join-chain
+    /// plumbing.
+    /// </summary>
+    internal static bool IsTransparentIdentifierOuterOrInnerAccess(this MemberExpression member)
+        => member.Member.Name is "Outer" or "Inner"
+           && member.Member.DeclaringType is { IsGenericType: true } declaringType
+           && declaringType.Name.StartsWith("TransparentIdentifier", StringComparison.Ordinal);
 }

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
@@ -31,9 +31,14 @@ internal sealed partial class MongoQueryExpression
     private readonly List<LookupExpression> _pendingLookups = [];
     private readonly Dictionary<IEntityType, MongoCollectionExpression> _innerCollections = new();
     private readonly Dictionary<IEntityType, bool> _innerCollectionIsLeftOuter = new();
-    private readonly Dictionary<IEntityType, INavigation> _innerCollectionNavigations = new();
     private bool _hasInterleavingOperatorSinceLastJoin;
     private int _joinRegistrationCount;
+
+    // Every join registered so far, in registration order. Unlike _innerCollections (keyed by
+    // IEntityType, so a self-referencing navigation chain like Employee.Manager.Manager collapses both
+    // hops into a single dictionary entry), this records one entry per join, letting a later hop find
+    // the immediately-preceding hop even when it targets the same entity type.
+    private readonly List<JoinRegistration> _joinRegistrations = [];
 
     /// <summary>
     /// Pending $lookup stages for cross-collection collection Include operations, ordered so that a
@@ -150,6 +155,20 @@ internal sealed partial class MongoQueryExpression
         => _innerCollections.Count > 0 && !_pendingLookups.Any(l => l.ForceUnwind);
 
     /// <summary>
+    /// Every join registered so far, in registration order. See <see cref="RegisterJoin"/>.
+    /// </summary>
+    public IReadOnlyList<JoinRegistration> JoinRegistrations => _joinRegistrations;
+
+    /// <summary>
+    /// Records that a join against <paramref name="targetEntityType"/> was resolved to
+    /// <paramref name="navigation"/> and surfaced under <paramref name="alias"/>, so a subsequent chained
+    /// hop can find the immediately-preceding hop by position rather than by <see cref="IEntityType"/>,
+    /// which can't distinguish repeat hops against the same entity type.
+    /// </summary>
+    public void RegisterJoin(IEntityType targetEntityType, string alias, INavigation? navigation)
+        => _joinRegistrations.Add(new JoinRegistration(targetEntityType, alias, navigation));
+
+    /// <summary>
     /// Register an inner collection for a join, recording the LINQ operator's own left-outer/inner
     /// semantics the first time this entity type is joined (see <see cref="TryGetJoinIsLeftOuter"/>) so a
     /// later retroactive flattening never has to re-derive it from model metadata, which can disagree
@@ -177,19 +196,10 @@ internal sealed partial class MongoQueryExpression
     /// </summary>
     public bool TryGetJoinIsLeftOuter(IEntityType entityType, out bool isLeftOuter)
         => _innerCollectionIsLeftOuter.TryGetValue(entityType, out isLeftOuter);
-
-    /// <summary>
-    /// Records which navigation actually introduced an inner collection's $lookup, so its
-    /// "_lookup_&lt;Navigation&gt;" alias can be recovered later. Re-deriving this from metadata is unsafe
-    /// when more than one navigation targets the same entity type.
-    /// </summary>
-    public void RegisterInnerCollectionNavigation(IEntityType entityType, INavigation navigation)
-        => _innerCollectionNavigations[entityType] = navigation;
-
-    /// <summary>
-    /// Get the navigation that was registered (via <see cref="RegisterInnerCollectionNavigation"/>) as
-    /// having introduced the given inner collection, or <see langword="null"/> if none was recorded.
-    /// </summary>
-    public INavigation? GetInnerCollectionNavigation(IEntityType entityType)
-        => _innerCollectionNavigations.GetValueOrDefault(entityType);
 }
+
+/// <summary>
+/// One entry in <see cref="MongoQueryExpression.JoinRegistrations"/> — see
+/// <see cref="MongoQueryExpression.RegisterJoin"/>.
+/// </summary>
+internal readonly record struct JoinRegistration(IEntityType TargetEntityType, string Alias, INavigation? Navigation);

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.LeftJoin.cs
@@ -879,7 +879,7 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         /// Resolves the <c>$lookup</c> that supplies the <c>Inner</c> of the TransparentIdentifier at
         /// <paramref name="depth"/> (0 = innermost join). Matched on the join's inner entity CLR type
         /// AND the join's outer key (the FK property), so two navigations to the same entity type stay
-        /// distinguishable. Returns <see langword="null"/> when the match is missing or ambiguous.
+        /// distinguishable. Returns <see langword="null"/> when the match is missing.
         /// </summary>
         private LookupExpression? ResolveLookup(int depth, Type innerType)
         {
@@ -898,7 +898,34 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
                                 || l.Navigation.ForeignKey.PrincipalKey.Properties.Any(p => p.Name == keyName)))
                 .ToList();
 
-            return candidates.Count == 1 ? candidates[0] : null;
+            if (candidates.Count == 1)
+            {
+                return candidates[0];
+            }
+
+            if (candidates.Count == 0)
+            {
+                return null;
+            }
+
+            // Ambiguous by type/key alone: a self-referencing chain (e.g. Employee.Manager.Manager)
+            // registers more than one hop for the same navigation against the same target entity type.
+            // Disambiguate structurally instead, mirroring the dependency relation OrderLookupsByDependency
+            // already relies on: the innermost (depth 0) hop's lookup reads straight off the root
+            // document, so its LocalField isn't prefixed by any sibling candidate's alias; every deeper
+            // hop's lookup is chained onto the alias of the hop immediately before it.
+            if (depth == 0)
+            {
+                return candidates.FirstOrDefault(candidate => candidates.All(other =>
+                    ReferenceEquals(other, candidate)
+                    || !candidate.LocalField.StartsWith(other.As + ".", StringComparison.Ordinal)));
+            }
+
+            var previous = ResolveLookup(depth - 1, innerType);
+            return previous == null
+                ? null
+                : candidates.FirstOrDefault(candidate =>
+                    candidate.LocalField.StartsWith(previous.As + ".", StringComparison.Ordinal));
         }
 
         private sealed class Rewriter(TransparentIdentifierToLookupFieldRewriter owner, ParameterExpression oldParam)

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -679,55 +679,51 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         }
 
         // Find the navigation for this join using the FK property from the outer key selector.
-        // This correctly handles self-joins where multiple navigations target the same entity type.
         var innerEntityType = innerEntityProjection.EntityType;
         var outerEntityType = outerQueryExpression.CollectionExpression.EntityType;
         var fkPropertyName = outerKeySelector.Body.TryGetSimplePropertyName();
+
+        // The outer key selector's FK-access target tells us whether this join reads directly off the
+        // root entity or off a previously-joined intermediate (e.g. the second ".Manager" in
+        // Employee.Manager.Manager): a pure ".Outer"* chain reaches the root, one ending in ".Inner"
+        // reaches a prior hop. Checking this structurally (not by comparing entity types) is required for
+        // self-referencing chains, where the target and through entity types are the same.
+        var (isDirectFromRoot, throughLevel) = AnalyzeKeySelectorTarget(
+            GetKeySelectorTargetObject(outerKeySelector.Body), outerKeySelector.Parameters[0],
+            outerQueryExpression.JoinRegistrations.Count);
+
         INavigation? navigation = null;
+        JoinRegistration? throughRegistration = null;
 
-        if (fkPropertyName != null)
+        if (isDirectFromRoot)
         {
-            navigation = outerEntityType.GetNavigations()
-                .FirstOrDefault(n => n.TargetEntityType == innerEntityType
-                                     && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
-        }
-
-        navigation ??= outerEntityType.GetNavigations()
-            .FirstOrDefault(n => n.TargetEntityType == innerEntityType);
-
-        // Transitive join: the inner entity is reached not directly from the root but THROUGH a
-        // previously-joined intermediate (e.g. OrderDetail.Order.Customer — the join's outer key
-        // selector is "o.Inner.CustomerID"). When no direct navigation exists, resolve the navigation
-        // on a prior inner collection and remember the intermediate so the $lookup's localField can be
-        // prefixed with that intermediate's "_lookup_<Intermediate>" path (the intermediate may itself be
-        // reached transitively, so the prefix must come from the navigation actually joined through —
-        // recorded via RegisterInnerCollectionNavigation, not re-derived from metadata, which could
-        // resolve to an unrelated navigation never emitted as a $lookup).
-        INavigation? throughNavigation = null;
-        if (navigation == null && fkPropertyName != null)
-        {
-            foreach (var priorInnerEntityType in outerQueryExpression.InnerCollections.Keys)
+            if (fkPropertyName != null)
             {
-                if (priorInnerEntityType == innerEntityType)
-                {
-                    continue;
-                }
-
-                var candidate = priorInnerEntityType.GetNavigations()
+                navigation = outerEntityType.GetNavigations()
                     .FirstOrDefault(n => n.TargetEntityType == innerEntityType
                                          && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
-                if (candidate != null)
-                {
-                    navigation = candidate;
-                    throughNavigation = outerQueryExpression.GetInnerCollectionNavigation(priorInnerEntityType);
-                    break;
-                }
             }
-        }
 
-        if (navigation != null)
+            navigation ??= outerEntityType.GetNavigations()
+                .FirstOrDefault(n => n.TargetEntityType == innerEntityType);
+        }
+        else if (throughLevel is { } level && level >= 1 && level <= outerQueryExpression.JoinRegistrations.Count)
         {
-            outerQueryExpression.RegisterInnerCollectionNavigation(innerEntityType, navigation);
+            // Transitive join: resolve the navigation on the join hop the key selector actually reaches
+            // through (found by position, not by IEntityType — see above) and remember it so the
+            // $lookup's localField can be prefixed with that intermediate's alias.
+            throughRegistration = outerQueryExpression.JoinRegistrations[level - 1];
+            var throughEntityType = throughRegistration.Value.TargetEntityType;
+
+            if (fkPropertyName != null)
+            {
+                navigation = throughEntityType.GetNavigations()
+                    .FirstOrDefault(n => n.TargetEntityType == innerEntityType
+                                         && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
+            }
+
+            navigation ??= throughEntityType.GetNavigations()
+                .FirstOrDefault(n => n.TargetEntityType == innerEntityType);
         }
 
         // Document-shape decision (single source of truth): the driver's native LeftJoin
@@ -742,7 +738,28 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         // "_lookup_<Navigation>" alias. The shaper derives the field it reads from that navigation
         // plus the computed UsesDriverJoinFields flag (driver-native => "_inner"; flat => the
         // "_lookup_<Navigation>" alias), so the projection is never retroactively rewritten.
-        var isSecondOrLaterJoin = outerQueryExpression.InnerCollections.Count > 1;
+        //
+        // InnerCollections dedupes by IEntityType, which is harmless for independent direct joins that
+        // happen to target the same entity type (see NorthwindJoinQueryMongoTest.Join_GroupJoin_DefaultIfEmpty_Where)
+        // — they don't need separate fields. A CHAINED hop (!isDirectFromRoot) always forces the flatten
+        // decision regardless, because a self-referencing chain (e.g. Employee.Manager.Manager) reaches
+        // the same entity type through a prior hop and genuinely needs its own field.
+        var isSecondOrLaterJoin = outerQueryExpression.InnerCollections.Count > 1 || !isDirectFromRoot;
+
+        // Stable, navigation-derived alias (shaper maps it to "_inner" for the lone driver-native
+        // reference, or reads it directly in flat mode). A self-referencing chain re-resolves the SAME
+        // navigation for more than one hop (e.g. "Manager" used twice), so the plain alias would collide
+        // between hops; disambiguate by prefixing with the through-hop's alias. Collision is detected by
+        // the ALIAS a plain lookup would produce, not navigation identity, since two distinct navigations
+        // that happen to share a name would also collide.
+        var plainAlias = navigation != null
+            ? Expressions.LookupExpression.GetLookupAlias(navigation)
+            : $"_lookup_{innerEntityType.ShortName()}";
+        var aliasAlreadyUsed = outerQueryExpression.JoinRegistrations.Any(r => r.Alias == plainAlias);
+        var lookupAlias = navigation != null && aliasAlreadyUsed && throughRegistration != null
+            ? $"{throughRegistration.Value.Alias}_{navigation.Name}"
+            : plainAlias;
+
         if (isSecondOrLaterJoin)
         {
             // Flatten: register a forced-unwind $lookup for THIS join...
@@ -750,55 +767,48 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             {
                 var lookup = new Expressions.LookupExpression(navigation, forceUnwind: true)
                 {
+                    As = lookupAlias,
                     PreserveNullAndEmptyArrays = isLeftOuter
                 };
-                if (throughNavigation != null)
+                if (throughRegistration != null)
                 {
                     // Transitive join: match against the already-unwound intermediate document.
-                    lookup.LocalField = $"{Expressions.LookupExpression.GetLookupAlias(throughNavigation)}.{lookup.LocalField}";
+                    lookup.LocalField = $"{throughRegistration.Value.Alias}.{lookup.LocalField}";
                 }
 
                 outerQueryExpression.AddLookup(lookup);
             }
 
-            // ...and retroactively for every PRIOR inner collection so the whole document is flat. Use
-            // the navigation actually registered for each prior collection (not a metadata re-derivation)
-            // for the same reason as above: the wrong navigation would emit under the wrong alias.
-            foreach (var priorInnerEntityType in outerQueryExpression.InnerCollections.Keys)
+            // ...and retroactively for every PRIOR join so the whole document is flat (a no-op for any
+            // prior join already registered directly, since AddLookup dedupes by alias). Use the
+            // left-outer/inner-ness recorded when THAT join was translated (AddInnerCollection), not
+            // ForeignKey.IsRequired, which can disagree with the LINQ operator actually used. Recording
+            // is unconditional, so a miss is an internal error.
+            foreach (var priorRegistration in outerQueryExpression.JoinRegistrations)
             {
-                if (priorInnerEntityType == innerEntityType)
+                if (priorRegistration.Navigation == null)
                 {
                     continue;
                 }
 
-                var priorNavigation = outerQueryExpression.GetInnerCollectionNavigation(priorInnerEntityType);
-                if (priorNavigation != null)
+                if (!outerQueryExpression.TryGetJoinIsLeftOuter(priorRegistration.TargetEntityType, out var priorIsLeftOuter))
                 {
-                    // Use the left-outer/inner-ness recorded when THAT join was translated
-                    // (AddInnerCollection), not ForeignKey.IsRequired, which can disagree with the LINQ
-                    // operator actually used. Recording is unconditional, so a miss is an internal error.
-                    if (!outerQueryExpression.TryGetJoinIsLeftOuter(priorInnerEntityType, out var priorIsLeftOuter))
-                    {
-                        throw new InvalidOperationException(
-                            "No recorded join kind for a previously joined entity type during $lookup "
-                            + "flattening. This is an internal error in the MongoDB EF Core provider; "
-                            + "please report it with the query that produced it.");
-                    }
-
-                    outerQueryExpression.AddLookup(
-                        new Expressions.LookupExpression(priorNavigation, forceUnwind: true)
-                        {
-                            PreserveNullAndEmptyArrays = priorIsLeftOuter
-                        });
+                    throw new InvalidOperationException(
+                        "No recorded join kind for a previously joined entity type during $lookup "
+                        + "flattening. This is an internal error in the MongoDB EF Core provider; "
+                        + "please report it with the query that produced it.");
                 }
+
+                outerQueryExpression.AddLookup(
+                    new Expressions.LookupExpression(priorRegistration.Navigation, forceUnwind: true)
+                    {
+                        As = priorRegistration.Alias,
+                        PreserveNullAndEmptyArrays = priorIsLeftOuter
+                    });
             }
         }
 
-        // Stable, navigation-derived alias. For the lone driver-native reference the shaper maps this
-        // to "_inner"; in flat mode it reads this "_lookup_<Navigation>" field directly.
-        var lookupAlias = navigation != null
-            ? Expressions.LookupExpression.GetLookupAlias(navigation)
-            : $"_lookup_{innerEntityType.ShortName()}";
+        outerQueryExpression.RegisterJoin(innerEntityType, lookupAlias, navigation);
 
         Expression parentAccess = new RootReferenceExpression(outerEntityType);
         ObjectAccessExpression lookupAccessExpression = navigation != null
@@ -811,6 +821,67 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
         return structuralShaper.Update(
             new ProjectionBindingExpression(outerQueryExpression, projectionIndex, typeof(ValueBuffer)));
+    }
+
+    /// <summary>
+    /// Extracts the object an outer key selector's body reads a property FROM — the "x" in
+    /// <c>x.Foo</c> or <c>EF.Property(x, "Foo")</c> — used to determine whether the selector reaches the
+    /// root entity or a prior join's result. See <see cref="AnalyzeKeySelectorTarget"/>.
+    /// </summary>
+    private static Expression? GetKeySelectorTargetObject(Expression body)
+        => body.RemoveConvert() switch
+        {
+            MemberExpression member => member.Expression,
+            MethodCallExpression call when call.Method.IsEFPropertyMethod() && call.Arguments.Count == 2 => call.Arguments[0],
+            _ => null
+        };
+
+    /// <summary>
+    /// Walks a chain of <c>.Outer</c>/<c>.Inner</c> member accesses from <paramref name="targetObject"/>
+    /// down to <paramref name="parameter"/> to determine whether the selector reads the root entity's own
+    /// property (a pure <c>.Outer</c>* chain, or the bare parameter) or a prior hop's result (a chain
+    /// ending in <c>.Inner</c>). Each <c>.Outer</c> step walks one hop back toward the root, and a
+    /// terminal <c>.Inner</c> at some step resolves to that
+    /// step's join (1-based, oldest first).
+    /// </summary>
+    private static (bool IsDirectFromRoot, int? ThroughLevel) AnalyzeKeySelectorTarget(
+        Expression? targetObject, ParameterExpression parameter, int priorJoinCount)
+    {
+        if (targetObject == null)
+        {
+            return (false, null);
+        }
+
+        var steps = new List<string>();
+        var cur = targetObject;
+        while (cur is MemberExpression step && step.IsTransparentIdentifierOuterOrInnerAccess())
+        {
+            steps.Add(step.Member.Name);
+            cur = step.Expression!;
+        }
+
+        if (!ReferenceEquals(cur, parameter))
+        {
+            // Not a recognizable Outer/Inner chain rooted at our parameter — only treat as direct when
+            // the target object IS the parameter itself (no chain at all).
+            return (ReferenceEquals(targetObject, parameter), null);
+        }
+
+        steps.Reverse();
+        var level = priorJoinCount;
+        foreach (var step in steps)
+        {
+            if (step == "Outer")
+            {
+                level--;
+            }
+            else
+            {
+                return (false, level);
+            }
+        }
+
+        return (true, null);
     }
 
     protected override ShapedQueryExpression? TranslateLastOrDefault(ShapedQueryExpression source, LambdaExpression? predicate,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -699,8 +699,14 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         {
             if (fkPropertyName != null)
             {
+                // IsOnDependent disambiguates a self-referencing relationship declared with both a
+                // reference nav (e.g. Manager) and its inverse collection nav (e.g. DirectReports):
+                // both share the same IForeignKey, so matching on ForeignKey.Properties alone matches
+                // either one, and picking the collection nav flips the $lookup's join direction
+                // (LookupExpression branches on Navigation.IsOnDependent).
                 navigation = outerEntityType.GetNavigations()
                     .FirstOrDefault(n => n.TargetEntityType == innerEntityType
+                                         && n.IsOnDependent
                                          && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
             }
 
@@ -717,8 +723,11 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
             if (fkPropertyName != null)
             {
+                // See the IsOnDependent comment in the isDirectFromRoot branch above — same ambiguity
+                // applies here.
                 navigation = throughEntityType.GetNavigations()
                     .FirstOrDefault(n => n.TargetEntityType == innerEntityType
+                                         && n.IsOnDependent
                                          && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
             }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -308,6 +308,37 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
         Assert.Equal("Boss", employee.Manager.EmployeeName);
         Assert.Null(allStaff.First(s => s.EmployeeName == "Boss").Manager);
     }
+
+    [Fact]
+    public void Chained_self_referencing_navigation_filter_resolves_reference_not_inverse_collection()
+    {
+        // StaffMember declares BOTH directions of the self-reference: Manager (reference, dependent
+        // side) and DirectReports (inverse collection, principal side) - they share the same
+        // IForeignKey. A chained filter through the reference nav must resolve Manager, not
+        // DirectReports, for each hop: picking the inverse collection nav flips the $lookup's join
+        // direction (LookupExpression branches on Navigation.IsOnDependent), silently walking the
+        // relationship backwards instead of throwing.
+        var staffName = TemporaryDatabaseFixtureBase.CreateCollectionName("Staff") + Guid.NewGuid().ToString("N")[..8];
+        var ceoId = ObjectId.GenerateNewId();
+        var vpId = ObjectId.GenerateNewId();
+        var managerId = ObjectId.GenerateNewId();
+
+        var staff = database.MongoDatabase.GetCollection<BsonDocument>(staffName);
+        staff.InsertMany([
+            new BsonDocument { { "_id", ceoId }, { "emp_name", "CEO" } },
+            new BsonDocument { { "_id", vpId }, { "emp_name", "VP" }, { "mgr_id", ceoId } },
+            new BsonDocument { { "_id", managerId }, { "emp_name", "Manager" }, { "mgr_id", vpId } }
+        ]);
+
+        using var db = new StaffDbContext(database, staffName);
+        var namesWhoseGreatGrandManagerIsNull = db.Staff
+            .Where(s => s.Manager.Manager.Manager == null)
+            .Select(s => s.EmployeeName)
+            .OrderBy(n => n)
+            .ToList();
+
+        Assert.Equal(["CEO", "Manager", "VP"], namesWhoseGreatGrandManagerIsNull);
+    }
 #endif
 
     [Fact]

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindNavigationsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindNavigationsQueryMongoTest.cs
@@ -318,11 +318,10 @@ Employees.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "
         await AssertTranslationFailed(() => base.Select_Where_Navigation_Null_Deep(async));
         AssertMql();
 #else
-        // Fails: returns wrong data (0 rows instead of 6) EF-371
-        await Assert.ThrowsAnyAsync<Xunit.Sdk.XunitException>(() => base.Select_Where_Navigation_Null_Deep(async));
+        await base.Select_Where_Navigation_Null_Deep(async);
         AssertMql(
             """
-Employees.{ "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Employees", "localField" : "_outer.ReportsTo", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : { "path" : "$_inner", "preserveNullAndEmptyArrays" : true } }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$project" : { "_outer" : "$$ROOT", "_id" : 0 } }, { "$lookup" : { "from" : "Employees", "localField" : "_outer._inner.ReportsTo", "foreignField" : "_id", "as" : "_inner" } }, { "$unwind" : "$_inner" }, { "$project" : { "_outer" : "$_outer", "_inner" : "$_inner", "_id" : 0 } }, { "$match" : { "_inner" : null } }
+Employees.{ "$lookup" : { "from" : "Employees", "localField" : "ReportsTo", "foreignField" : "_id", "as" : "_lookup_Manager" } }, { "$unwind" : { "path" : "$_lookup_Manager", "preserveNullAndEmptyArrays" : true } }, { "$lookup" : { "from" : "Employees", "localField" : "_lookup_Manager.ReportsTo", "foreignField" : "_id", "as" : "_lookup_Manager_Manager" } }, { "$unwind" : { "path" : "$_lookup_Manager_Manager", "preserveNullAndEmptyArrays" : true } }, { "$match" : { "_lookup_Manager_Manager" : null } }
 """);
 #endif
     }


### PR DESCRIPTION
Employee.Manager.Manager-style chains collapsed both hops into a single registered join (InnerCollections was keyed by IEntityType) and, once correctly split, collided on the same $lookup alias since both hops resolve the same navigation. The residual Where filtering on the joined result was also being discarded instead of rewritten against the flattened _lookup_<Navigation> fields once the join chain was stripped.

Un-skips Select_Where_Navigation_Null_Deep (formerly grouped under EF-216).