### PR TITLE
EF-373: decline Skip/Take/Distinct interleaved between two cross-collection joins

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
@@ -31,6 +31,7 @@ internal sealed partial class MongoQueryExpression
     private readonly List<LookupExpression> _pendingLookups = [];
     private readonly Dictionary<IEntityType, MongoCollectionExpression> _innerCollections = new();
     private readonly Dictionary<IEntityType, bool> _innerCollectionIsLeftOuter = new();
+    private bool _hasInterleavingOperatorSinceLastJoin;
 
     /// <summary>
     /// Pending $lookup stages for cross-collection collection Include operations, ordered so that a
@@ -89,6 +90,26 @@ internal sealed partial class MongoQueryExpression
             _pendingLookups.Add(lookup);
         }
     }
+
+    /// <summary>
+    /// Records that a <c>Skip</c>/<c>Take</c>/<c>Distinct</c> was visited while at least one join was
+    /// already registered (see <see cref="Visitors.MongoQueryableMethodTranslatingExpressionVisitor"/>).
+    /// Operators visited before the first join don't count - they precede every join, not sit between two of
+    /// them.
+    /// </summary>
+    public void MarkPotentialJoinInterleavingOperator()
+    {
+        if (_innerCollections.Count > 0)
+        {
+            _hasInterleavingOperatorSinceLastJoin = true;
+        }
+    }
+
+    /// <summary>
+    /// Whether a <c>Skip</c>/<c>Take</c>/<c>Distinct</c> has been visited between two joins - see
+    /// <see cref="MarkPotentialJoinInterleavingOperator"/>.
+    /// </summary>
+    public bool HasInterleavingOperatorSinceLastJoin => _hasInterleavingOperatorSinceLastJoin;
 
     /// <summary>
     /// Inner collections involved in join operations.

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
@@ -32,6 +32,7 @@ internal sealed partial class MongoQueryExpression
     private readonly Dictionary<IEntityType, MongoCollectionExpression> _innerCollections = new();
     private readonly Dictionary<IEntityType, bool> _innerCollectionIsLeftOuter = new();
     private bool _hasInterleavingOperatorSinceLastJoin;
+    private int _joinRegistrationCount;
 
     /// <summary>
     /// Pending $lookup stages for cross-collection collection Include operations, ordered so that a
@@ -110,6 +111,15 @@ internal sealed partial class MongoQueryExpression
     /// <see cref="MarkPotentialJoinInterleavingOperator"/>.
     /// </summary>
     public bool HasInterleavingOperatorSinceLastJoin => _hasInterleavingOperatorSinceLastJoin;
+
+    /// <summary>
+    /// Register that a join was processed and report whether this is the second (or later) one.
+    /// Deliberately counts every join call, NOT distinct target entity types: <see cref="InnerCollections"/>
+    /// is keyed by <see cref="IEntityType"/> and dedups two navigations that target the same collection
+    /// (e.g. a self-join), so it under-counts joins for that shape - see EF-373.
+    /// </summary>
+    public bool RegisterJoinAndReportSecondOrLater()
+        => ++_joinRegistrationCount > 1;
 
     /// <summary>
     /// Inner collections involved in join operations.

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -624,6 +624,19 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
         outerQueryExpression.AddInnerCollection(innerQueryExpression.CollectionExpression.EntityType, isLeftOuter);
 
+        // EF-373: decide "is this the second-or-later join" from a dedicated counter, not from
+        // InnerCollections.Count - InnerCollections is keyed by IEntityType and dedups two navigations
+        // that join to the SAME target collection (e.g. a self-join), which would otherwise let this
+        // guard - and the interleaving flag it depends on - go unchecked for that shape.
+        if (outerQueryExpression.RegisterJoinAndReportSecondOrLater()
+            && outerQueryExpression.HasInterleavingOperatorSinceLastJoin)
+        {
+            throw new NotSupportedException(
+                "A 'Skip', 'Take', or 'Distinct' operator composed between two cross-collection "
+                + "joins (e.g. from 'Include'/'ThenInclude' or an explicit 'Join') is not supported. "
+                + "Move the operator so that it is not interleaved between the joins.");
+        }
+
         // Rebind the inner entity's projection to the outer MongoQueryExpression.
         // The inner shaper has a StructuralTypeShaperExpression bound to the inner MongoQueryExpression.
         // We need to migrate that projection to the outer query expression so the entity path
@@ -725,20 +738,6 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         var isSecondOrLaterJoin = outerQueryExpression.InnerCollections.Count > 1;
         if (isSecondOrLaterJoin)
         {
-            // EF-373: a Skip/Take/Distinct sitting between two joins has no single correct position in a
-            // scheme that emits all forced-unwind $lookup stages as one contiguous group (see
-            // MongoQueryExpression.GetPendingLookups): the group must stay together and in dependency order,
-            // but a paging/dedup operator interleaved between the joins would then run on the wrong side of
-            // one of them, producing correct-looking but wrong rows. Decline the flatten for this shape
-            // rather than silently mis-position it - that's strictly better than reordered wrong data.
-            if (outerQueryExpression.HasInterleavingOperatorSinceLastJoin)
-            {
-                throw new NotSupportedException(
-                    "A 'Skip', 'Take', or 'Distinct' operator composed between two cross-collection "
-                    + "joins (e.g. from 'Include'/'ThenInclude' or an explicit 'Join') is not supported. "
-                    + "Move the operator so that it is not interleaved between the joins.");
-            }
-
             // Flatten: register a forced-unwind $lookup for THIS join...
             if (navigation != null)
             {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -94,6 +94,15 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         var source = Visit(methodCallExpression.Arguments[0]);
         if (source is ShapedQueryExpression shapedQueryExpression)
         {
+            // EF-373: Skip/Take/Distinct composed BETWEEN two cross-collection joins has no single correct
+            // position once a second join forces the $lookup-flattening fallback (see TranslateJoinCore) -
+            // record that one of these occurred while at least one join is already registered so the next
+            // join registration can decline rather than silently mis-position the $lookup stages.
+            if (method.Name is nameof(Queryable.Skip) or nameof(Queryable.Take) or nameof(Queryable.Distinct))
+            {
+                ((MongoQueryExpression)shapedQueryExpression.QueryExpression).MarkPotentialJoinInterleavingOperator();
+            }
+
             var methodDefinition = method.IsGenericMethod ? method.GetGenericMethodDefinition() : method;
             switch (method.Name)
             {
@@ -716,6 +725,20 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         var isSecondOrLaterJoin = outerQueryExpression.InnerCollections.Count > 1;
         if (isSecondOrLaterJoin)
         {
+            // EF-373: a Skip/Take/Distinct sitting between two joins has no single correct position in a
+            // scheme that emits all forced-unwind $lookup stages as one contiguous group (see
+            // MongoQueryExpression.GetPendingLookups): the group must stay together and in dependency order,
+            // but a paging/dedup operator interleaved between the joins would then run on the wrong side of
+            // one of them, producing correct-looking but wrong rows. Decline the flatten for this shape
+            // rather than silently mis-position it - that's strictly better than reordered wrong data.
+            if (outerQueryExpression.HasInterleavingOperatorSinceLastJoin)
+            {
+                throw new NotSupportedException(
+                    "A 'Skip', 'Take', or 'Distinct' operator composed between two cross-collection "
+                    + "joins (e.g. from 'Include'/'ThenInclude' or an explicit 'Join') is not supported. "
+                    + "Move the operator so that it is not interleaved between the joins.");
+            }
+
             // Flatten: register a forced-unwind $lookup for THIS join...
             if (navigation != null)
             {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionRelationshipTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionRelationshipTests.cs
@@ -556,6 +556,25 @@ public class CrossCollectionRelationshipTests(TemporaryDatabaseFixture database)
                 .Include(l => l.Product)
                 .ToList());
     }
+
+    // EF-373 (review follow-up): InnerCollections is keyed by IEntityType, so two navigations that join
+    // to the SAME target entity type (e.g. a self-join) collapse to one entry there - the guard above
+    // must not rely on that count, or it would stay silent for this shape too.
+    [Fact]
+    public void Take_between_two_joins_to_same_target_entity_type_declines_rather_than_returning_wrong_rows()
+    {
+        var (linesName, ordersName) = SetupSameTypeJoinLinesAndOrders();
+
+        using var db = new SameTypeJoinDbContext(database, linesName, ordersName);
+
+        Assert.Throws<NotSupportedException>(() =>
+            db.Lines
+                .OrderBy(l => l.LineName)
+                .Where(l => l.PrimaryOrder.OrderName != "O2")
+                .Take(3)
+                .Include(l => l.SecondaryOrder)
+                .ToList());
+    }
 #endif
 
     // ---------------------------------------------------------------------------------------------
@@ -594,6 +613,28 @@ public class CrossCollectionRelationshipTests(TemporaryDatabaseFixture database)
         ]);
 
         return (linesName, ordersName, productsName);
+    }
+
+    private (string linesName, string ordersName) SetupSameTypeJoinLinesAndOrders()
+    {
+        var linesName = TemporaryDatabaseFixtureBase.CreateCollectionName("SameTypeJoinLines") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("SameTypeJoinOrders") + Guid.NewGuid().ToString("N")[..8];
+
+        var order1Id = ObjectId.GenerateNewId();
+        var order2Id = ObjectId.GenerateNewId();
+
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertMany([
+            new BsonDocument { { "_id", order1Id }, { "name", "O1" } },
+            new BsonDocument { { "_id", order2Id }, { "name", "O2" } }
+        ]);
+        database.MongoDatabase.GetCollection<BsonDocument>(linesName).InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L1" }, { "primary_ord_id", order1Id }, { "secondary_ord_id", order1Id } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L2" }, { "primary_ord_id", order2Id }, { "secondary_ord_id", order1Id } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L3" }, { "primary_ord_id", order1Id }, { "secondary_ord_id", order1Id } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L4" }, { "primary_ord_id", order1Id }, { "secondary_ord_id", order1Id } }
+        ]);
+
+        return (linesName, ordersName);
     }
 
     private (string ordersName, string customersName) SetupThreeOrdersTwoCustomers()
@@ -1208,6 +1249,52 @@ public class CrossCollectionRelationshipTests(TemporaryDatabaseFixture database)
             {
                 b.ToCollection(productsCollection);
                 b.Property(p => p.ProductName).HasElementName("name");
+            });
+        }
+    }
+
+    // Two navigations from the same root that join to the SAME target entity type (self-join shape) -
+    // as opposed to TwoJoinLine's two navigations to two DIFFERENT target types.
+    class SameTypeJoinLine
+    {
+        public ObjectId _id { get; set; }
+        public string LineName { get; set; }
+        public ObjectId? PrimaryOrderId { get; set; }
+        public SameTypeJoinOrder PrimaryOrder { get; set; }
+        public ObjectId? SecondaryOrderId { get; set; }
+        public SameTypeJoinOrder SecondaryOrder { get; set; }
+    }
+
+    class SameTypeJoinOrder
+    {
+        public ObjectId _id { get; set; }
+        public string OrderName { get; set; }
+    }
+
+    class SameTypeJoinDbContext(TemporaryDatabaseFixture database, string linesCollection, string ordersCollection)
+        : CrossCollectionDbContextBase<SameTypeJoinDbContext>(database)
+    {
+        public DbSet<SameTypeJoinLine> Lines { get; set; }
+        public DbSet<SameTypeJoinOrder> Orders { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<SameTypeJoinLine>(b =>
+            {
+                b.ToCollection(linesCollection);
+                b.Property(l => l.LineName).HasElementName("name");
+                b.Property(l => l.PrimaryOrderId).HasElementName("primary_ord_id");
+                b.Property(l => l.SecondaryOrderId).HasElementName("secondary_ord_id");
+                b.HasOne(l => l.PrimaryOrder).WithMany().HasForeignKey(l => l.PrimaryOrderId);
+                b.HasOne(l => l.SecondaryOrder).WithMany().HasForeignKey(l => l.SecondaryOrderId);
+            });
+
+            modelBuilder.Entity<SameTypeJoinOrder>(b =>
+            {
+                b.ToCollection(ordersCollection);
+                b.Property(o => o.OrderName).HasElementName("name");
             });
         }
     }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionRelationshipTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionRelationshipTests.cs
@@ -504,6 +504,58 @@ public class CrossCollectionRelationshipTests(TemporaryDatabaseFixture database)
         Assert.Single(order.PriorityItems);
         Assert.All(order.PriorityItems, i => Assert.IsType<PriorityChainItem>(i));
     }
+
+    // EF-373: a Skip/Take/Distinct composed BETWEEN two sibling cross-collection joins (one join
+    // triggered by a filter on a navigation, the other by an Include) has no single correct position
+    // once the second join forces the $lookup-flattening fallback - the whole group of forced-unwind
+    // $lookup stages must stay together, so the interleaved operator would end up running on the wrong
+    // side of one of them and silently return the wrong rows. Decline with a clear exception instead.
+    [Fact]
+    public void Take_between_two_joins_declines_rather_than_returning_wrong_rows()
+    {
+        var (linesName, ordersName, productsName) = SetupLinesOrdersProducts();
+
+        using var db = new TwoJoinDbContext(database, linesName, ordersName, productsName);
+
+        Assert.Throws<NotSupportedException>(() =>
+            db.Lines
+                .OrderBy(l => l.LineName)
+                .Where(l => l.Order.OrderName != "O2")
+                .Take(3)
+                .Include(l => l.Product)
+                .ToList());
+    }
+
+    [Fact]
+    public void Skip_between_two_joins_declines_rather_than_returning_wrong_rows()
+    {
+        var (linesName, ordersName, productsName) = SetupLinesOrdersProducts();
+
+        using var db = new TwoJoinDbContext(database, linesName, ordersName, productsName);
+
+        Assert.Throws<NotSupportedException>(() =>
+            db.Lines
+                .OrderBy(l => l.LineName)
+                .Where(l => l.Order.OrderName != "O2")
+                .Skip(1)
+                .Include(l => l.Product)
+                .ToList());
+    }
+
+    [Fact]
+    public void Distinct_between_two_joins_declines_rather_than_returning_wrong_rows()
+    {
+        var (linesName, ordersName, productsName) = SetupLinesOrdersProducts();
+
+        using var db = new TwoJoinDbContext(database, linesName, ordersName, productsName);
+
+        Assert.Throws<NotSupportedException>(() =>
+            db.Lines
+                .Where(l => l.Order.OrderName != "O2")
+                .Distinct()
+                .Include(l => l.Product)
+                .ToList());
+    }
 #endif
 
     // ---------------------------------------------------------------------------------------------
@@ -516,6 +568,32 @@ public class CrossCollectionRelationshipTests(TemporaryDatabaseFixture database)
         var customersName = TemporaryDatabaseFixtureBase.CreateCollectionName("RelCustomers") + Guid.NewGuid().ToString("N")[..8];
         var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("RelOrders") + Guid.NewGuid().ToString("N")[..8];
         return (ordersName, customersName);
+    }
+
+    private (string linesName, string ordersName, string productsName) SetupLinesOrdersProducts()
+    {
+        var linesName = TemporaryDatabaseFixtureBase.CreateCollectionName("TwoJoinLines") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("TwoJoinOrders") + Guid.NewGuid().ToString("N")[..8];
+        var productsName = TemporaryDatabaseFixtureBase.CreateCollectionName("TwoJoinProducts") + Guid.NewGuid().ToString("N")[..8];
+
+        var order1Id = ObjectId.GenerateNewId();
+        var order2Id = ObjectId.GenerateNewId();
+        var productId = ObjectId.GenerateNewId();
+
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertMany([
+            new BsonDocument { { "_id", order1Id }, { "name", "O1" } },
+            new BsonDocument { { "_id", order2Id }, { "name", "O2" } }
+        ]);
+        database.MongoDatabase.GetCollection<BsonDocument>(productsName).InsertOne(
+            new BsonDocument { { "_id", productId }, { "name", "Widget" } });
+        database.MongoDatabase.GetCollection<BsonDocument>(linesName).InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L1" }, { "ord_id", order1Id }, { "prod_id", productId } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L2" }, { "ord_id", order2Id }, { "prod_id", productId } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L3" }, { "ord_id", order1Id }, { "prod_id", productId } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "name", "L4" }, { "ord_id", order1Id }, { "prod_id", productId } }
+        ]);
+
+        return (linesName, ordersName, productsName);
     }
 
     private (string ordersName, string customersName) SetupThreeOrdersTwoCustomers()
@@ -1071,6 +1149,66 @@ public class CrossCollectionRelationshipTests(TemporaryDatabaseFixture database)
                     .HasValue<PriorityChainItem>("Priority");
             });
             modelBuilder.Entity<PriorityChainItem>().Property(i => i.PriorityLevel).HasElementName("priority");
+        }
+    }
+
+    // Two SIBLING cross-collection joins off a common root (as opposed to ChainCustomer/Order/Item's
+    // transitive chain): a Line references both an Order (used in a Where filter) and a Product (via
+    // Include) - the shape EF-373 covers.
+    class TwoJoinLine
+    {
+        public ObjectId _id { get; set; }
+        public string LineName { get; set; }
+        public ObjectId? OrderId { get; set; }
+        public TwoJoinOrder Order { get; set; }
+        public ObjectId? ProductId { get; set; }
+        public TwoJoinProduct Product { get; set; }
+    }
+
+    class TwoJoinOrder
+    {
+        public ObjectId _id { get; set; }
+        public string OrderName { get; set; }
+    }
+
+    class TwoJoinProduct
+    {
+        public ObjectId _id { get; set; }
+        public string ProductName { get; set; }
+    }
+
+    class TwoJoinDbContext(TemporaryDatabaseFixture database, string linesCollection, string ordersCollection, string productsCollection)
+        : CrossCollectionDbContextBase<TwoJoinDbContext>(database)
+    {
+        public DbSet<TwoJoinLine> Lines { get; set; }
+        public DbSet<TwoJoinOrder> Orders { get; set; }
+        public DbSet<TwoJoinProduct> Products { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<TwoJoinLine>(b =>
+            {
+                b.ToCollection(linesCollection);
+                b.Property(l => l.LineName).HasElementName("name");
+                b.Property(l => l.OrderId).HasElementName("ord_id");
+                b.Property(l => l.ProductId).HasElementName("prod_id");
+                b.HasOne(l => l.Order).WithMany().HasForeignKey(l => l.OrderId);
+                b.HasOne(l => l.Product).WithMany().HasForeignKey(l => l.ProductId);
+            });
+
+            modelBuilder.Entity<TwoJoinOrder>(b =>
+            {
+                b.ToCollection(ordersCollection);
+                b.Property(o => o.OrderName).HasElementName("name");
+            });
+
+            modelBuilder.Entity<TwoJoinProduct>(b =>
+            {
+                b.ToCollection(productsCollection);
+                b.Property(p => p.ProductName).HasElementName("name");
+            });
         }
     }
 #endif

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionRelationshipTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionRelationshipTests.cs
@@ -505,11 +505,8 @@ public class CrossCollectionRelationshipTests(TemporaryDatabaseFixture database)
         Assert.All(order.PriorityItems, i => Assert.IsType<PriorityChainItem>(i));
     }
 
-    // EF-373: a Skip/Take/Distinct composed BETWEEN two sibling cross-collection joins (one join
-    // triggered by a filter on a navigation, the other by an Include) has no single correct position
-    // once the second join forces the $lookup-flattening fallback - the whole group of forced-unwind
-    // $lookup stages must stay together, so the interleaved operator would end up running on the wrong
-    // side of one of them and silently return the wrong rows. Decline with a clear exception instead.
+    // EF-373: once a second join forces the $lookup-flattening fallback, an interleaved Skip/Take/Distinct
+    // has no correct position and would silently return wrong rows - decline instead.
     [Fact]
     public void Take_between_two_joins_declines_rather_than_returning_wrong_rows()
     {


### PR DESCRIPTION
A Skip/Take/Distinct composed between two cross-collection joins (e.g. one join triggered by a navigation filter, the other by an Include) has no single correct position once the second join forces the $lookup-flattening fallback: the forced-unwind $lookup stages must stay together as one group, so the interleaved operator ends up on the wrong side of one of them, producing wrong or malformed results.

Decline the shape with a clear NotSupportedException instead - the conservative first step recommended by the ticket - rather than silently mis-positioning the $lookup stages.