### PR TITLE
EF-377: Fix chained Join whose first hop has no model navigation

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/LookupExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/LookupExpression.cs
@@ -56,6 +56,7 @@ internal sealed class LookupExpression
         }
 
         As = GetLookupAlias(navigation);
+        TargetEntityType = navigation.TargetEntityType;
 
         // TPH: sibling subtypes can share the same FK value space, so FK equality alone would also
         // match sibling-type documents; narrow by discriminator to just this type and its derived types.
@@ -72,19 +73,39 @@ internal sealed class LookupExpression
     }
 
     /// <summary>
-    /// The synthetic field name that a cross-collection <c>$lookup</c> writes its joined documents to
-    /// (the lookup's <see cref="As"/>) and that the shaper reads them back from. Centralized so every
-    /// write site (the lookup stage) and read site (projection binding) derive the identical alias from
-    /// the navigation, rather than re-spelling the <c>_lookup_</c> format independently and risking a
-    /// write/read mismatch.
+    /// Create a <see cref="LookupExpression"/> for a Join hop with no corresponding model navigation,
+    /// built directly from resolved join-key field paths instead of an <see cref="INavigation"/>.
+    /// </summary>
+    public LookupExpression(
+        IEntityType targetEntityType, string collectionName, string localField, string foreignField, string alias,
+        bool forceUnwind)
+    {
+        Navigation = null;
+        TargetEntityType = targetEntityType;
+        ForceUnwind = forceUnwind;
+        From = collectionName;
+        LocalField = localField;
+        ForeignField = foreignField;
+        As = alias;
+    }
+
+    /// <summary>
+    /// The field a <c>$lookup</c> writes its results to and the shaper reads back from. Centralized so
+    /// write and read sites can't drift on the <c>_lookup_</c> format.
     /// </summary>
     /// <param name="navigation">The navigation the lookup supports.</param>
     /// <returns>The <c>_lookup_&lt;NavigationName&gt;</c> field name.</returns>
     public static string GetLookupAlias(IReadOnlyNavigationBase navigation)
         => $"_lookup_{navigation.Name}";
 
-    /// <summary>The navigation this lookup supports.</summary>
-    public INavigation Navigation { get; }
+    /// <summary>The navigation this lookup supports, or <see langword="null"/> for a bare key-equality
+    /// Join hop with no corresponding model navigation (see EF-377).</summary>
+    public INavigation? Navigation { get; }
+
+    /// <summary>The entity type this lookup's <c>$lookup</c> stage produces documents for. Always
+    /// available, unlike <see cref="Navigation"/>, so consumers can match a lookup back to an entity
+    /// type without assuming a navigation exists.</summary>
+    public IEntityType TargetEntityType { get; }
 
     /// <summary>The target collection name to look up from.</summary>
     public string From { get; }
@@ -129,8 +150,9 @@ internal sealed class LookupExpression
     /// <summary>Whether this lookup uses a pipeline (filtered Include).</summary>
     public bool HasPipeline => PipelineStages.Count > 0;
 
-    /// <summary>Whether this lookup is for a single reference (not a collection).</summary>
-    public bool IsReference => !Navigation.IsCollection;
+    /// <summary>Whether this lookup is for a single reference (not a collection). A navigation-less
+    /// lookup (<see cref="Navigation"/> is <see langword="null"/>) is always treated as a reference.</summary>
+    public bool IsReference => Navigation is not { IsCollection: true };
 
     /// <summary>Whether $unwind should be applied after $lookup.</summary>
     public bool ShouldUnwind => IsReference || ForceUnwind;

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.Lookup.cs
@@ -39,6 +39,33 @@ internal sealed partial class MongoQueryExpression
     // hops into a single dictionary entry), this records one entry per join, letting a later hop find
     // the immediately-preceding hop even when it targets the same entity type.
     private readonly List<JoinRegistration> _joinRegistrations = [];
+    private readonly Dictionary<IEntityType, NavigationlessJoinKey> _navigationlessJoinKeys = new();
+
+    /// <summary>
+    /// The resolved <c>$lookup</c> key info for a Join hop with no corresponding model navigation —
+    /// captured so a later dependent hop can scope its <see cref="LookupExpression.LocalField"/>, and
+    /// so this hop's own <c>$lookup</c> can be emitted retroactively if flat mode is forced.
+    /// </summary>
+    /// <param name="CollectionName">The target collection to look up from.</param>
+    /// <param name="LocalField">The local (outer) field path used for the equality match.</param>
+    /// <param name="ForeignField">The foreign (inner) field path used for the equality match.</param>
+    /// <param name="Alias">The stable <c>_lookup_&lt;ShortName&gt;</c> alias this hop's projection was
+    /// registered under.</param>
+    internal readonly record struct NavigationlessJoinKey(
+        string CollectionName, string LocalField, string ForeignField, string Alias);
+
+    /// <summary>
+    /// Register the raw join-key info for a Join hop that has no corresponding model navigation.
+    /// </summary>
+    public void RegisterNavigationlessJoinKey(IEntityType entityType, NavigationlessJoinKey key)
+        => _navigationlessJoinKeys[entityType] = key;
+
+    /// <summary>
+    /// Attempt to retrieve the raw join-key info previously registered for a navigation-less Join hop
+    /// whose inner entity is <paramref name="entityType"/>.
+    /// </summary>
+    public bool TryGetNavigationlessJoinKey(IEntityType entityType, out NavigationlessJoinKey key)
+        => _navigationlessJoinKeys.TryGetValue(entityType, out key);
 
     /// <summary>
     /// Pending $lookup stages for cross-collection collection Include operations, ordered so that a

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -741,13 +741,15 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
         // GuardAgainstMultiBranchNavigationCount, so here we only need the matching lookup to exist.
         var targetEntityType = rootExpression.EntityType;
         var lookup = _pendingLookups.FirstOrDefault(
-            l => l.InjectAfterRoot && l.Navigation.TargetEntityType == targetEntityType);
+            l => l.InjectAfterRoot && l.TargetEntityType == targetEntityType);
         if (lookup == null)
         {
             return false;
         }
 
-        var navigation = lookup.Navigation;
+        // InjectAfterRoot is only ever set for navigation-derived lookups (collection-count
+        // projections), so a matched lookup here always carries a real navigation.
+        var navigation = lookup.Navigation!;
 
         // Extract the outer document reference from the FK predicate: the parameter that is NOT the inner
         // Where lambda's parameter (e.g. the `c` in `o0 => c.CustomerID == o0.CustomerID`).

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.cs
@@ -265,7 +265,7 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                             var intermediateMatches = _queryExpression.GetPendingLookups().Where(
                                 l => l.IsReference
                                      && l.ForceUnwind
-                                     && l.Navigation.TargetEntityType == declaringType).ToList();
+                                     && l.TargetEntityType == declaringType).ToList();
 
                             // The intermediate is matched by its target entity type, not by its alias. When
                             // more than one reference lookup targets the same entity type — e.g. two reference

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -676,7 +676,7 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
                 }
 
                 var joinField = _queryExpression.GetPendingLookups()
-                    .FirstOrDefault(l => l.Navigation.TargetEntityType == shaperEntityType)?.As;
+                    .FirstOrDefault(l => l.TargetEntityType == shaperEntityType)?.As;
                 if (joinField != null)
                 {
                     var lookupDocument = CreateGetValueExpression(DocParameter, joinField, false, typeof(BsonDocument));

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -25,6 +25,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
+using MongoDB.EntityFrameworkCore.Extensions;
 using MongoDB.EntityFrameworkCore.Query.Expressions;
 
 namespace MongoDB.EntityFrameworkCore.Query.Visitors;
@@ -593,14 +594,14 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
     protected override ShapedQueryExpression? TranslateGroupJoin(ShapedQueryExpression outer, ShapedQueryExpression inner,
         LambdaExpression outerKeySelector, LambdaExpression innerKeySelector, LambdaExpression resultSelector)
-        => TranslateJoinCore(outer, inner, outerKeySelector, resultSelector, isLeftOuter: true);
+        => TranslateJoinCore(outer, inner, outerKeySelector, innerKeySelector, resultSelector, isLeftOuter: true);
 
     protected override ShapedQueryExpression? TranslateIntersect(ShapedQueryExpression source1, ShapedQueryExpression source2)
         => null;
 
     protected override ShapedQueryExpression? TranslateLeftJoin(ShapedQueryExpression outer, ShapedQueryExpression inner,
         LambdaExpression outerKeySelector, LambdaExpression innerKeySelector, LambdaExpression resultSelector)
-        => TranslateJoinCore(outer, inner, outerKeySelector, resultSelector, isLeftOuter: true);
+        => TranslateJoinCore(outer, inner, outerKeySelector, innerKeySelector, resultSelector, isLeftOuter: true);
 
 #if !EF8 && !EF9
     protected override ShapedQueryExpression? TranslateRightJoin(ShapedQueryExpression outer, ShapedQueryExpression inner,
@@ -610,14 +611,14 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
     protected override ShapedQueryExpression? TranslateJoin(ShapedQueryExpression outer, ShapedQueryExpression inner,
         LambdaExpression outerKeySelector, LambdaExpression innerKeySelector, LambdaExpression resultSelector)
-        => TranslateJoinCore(outer, inner, outerKeySelector, resultSelector, isLeftOuter: false);
+        => TranslateJoinCore(outer, inner, outerKeySelector, innerKeySelector, resultSelector, isLeftOuter: false);
 
     // isLeftOuter carries the LINQ operator's join semantics to the emitted $lookup/$unwind: Join is inner,
     // LeftJoin/GroupJoin are left-outer. EF lowers a REQUIRED reference navigation to Queryable.Join, which
     // is what makes it drop principals with a dangling foreign key, matching relational EF Core.
     private static ShapedQueryExpression? TranslateJoinCore(
         ShapedQueryExpression outer, ShapedQueryExpression inner,
-        LambdaExpression outerKeySelector, LambdaExpression resultSelector, bool isLeftOuter)
+        LambdaExpression outerKeySelector, LambdaExpression innerKeySelector, LambdaExpression resultSelector, bool isLeftOuter)
     {
         var outerQueryExpression = (MongoQueryExpression)outer.QueryExpression;
         var innerQueryExpression = (MongoQueryExpression)inner.QueryExpression;
@@ -642,7 +643,7 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         // We need to migrate that projection to the outer query expression so the entity path
         // shaper can read inner entity properties from the $lookup result field.
         var reboundInnerShaper = RebindInnerShaperToOuterQuery(
-            inner.ShaperExpression, innerQueryExpression, outerQueryExpression, outerKeySelector, isLeftOuter);
+            inner.ShaperExpression, innerQueryExpression, outerQueryExpression, outerKeySelector, innerKeySelector, isLeftOuter);
 
         var newResultSelector = ReplacingExpressionVisitor.Replace(
             resultSelector.Parameters[0], outer.ShaperExpression,
@@ -658,6 +659,7 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         MongoQueryExpression innerQueryExpression,
         MongoQueryExpression outerQueryExpression,
         LambdaExpression outerKeySelector,
+        LambdaExpression innerKeySelector,
         bool isLeftOuter)
     {
         if (innerShaper is not StructuralTypeShaperExpression structuralShaper
@@ -760,7 +762,9 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         // navigation for more than one hop (e.g. "Manager" used twice), so the plain alias would collide
         // between hops; disambiguate by prefixing with the through-hop's alias. Collision is detected by
         // the ALIAS a plain lookup would produce, not navigation identity, since two distinct navigations
-        // that happen to share a name would also collide.
+        // that happen to share a name would also collide. A bare key-equality hop with no model navigation
+        // (EF-377) falls back to "_lookup_<ShortName>", same as a navigation-bearing hop with no alias
+        // collision to worry about.
         var plainAlias = navigation != null
             ? Expressions.LookupExpression.GetLookupAlias(navigation)
             : $"_lookup_{innerEntityType.ShortName()}";
@@ -768,6 +772,31 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         var lookupAlias = navigation != null && aliasAlreadyUsed && throughRegistration != null
             ? $"{throughRegistration.Value.Alias}_{navigation.Name}"
             : plainAlias;
+
+        // Bare key-equality Join hop with nothing in the model to key on (EF-377): remember the raw
+        // join-key field paths so a later dependent hop can scope its $lookup, and so this hop's own
+        // $lookup can be synthesized below if flat mode is forced. The owning entity type and through
+        // alias are the same ones already resolved above — the root when isDirectFromRoot, or the
+        // through-hop's target/alias otherwise.
+        MongoQueryExpression.NavigationlessJoinKey? navigationlessKey = null;
+        if (navigation == null && fkPropertyName != null)
+        {
+            var fkOwnerEntityType = throughRegistration?.TargetEntityType ?? outerEntityType;
+            var throughAlias = throughRegistration?.Alias;
+            var innerKeyPropertyName = innerKeySelector.Body.TryGetSimplePropertyName();
+            var outerProperty = fkOwnerEntityType.FindProperty(fkPropertyName);
+            var innerProperty = innerKeyPropertyName != null ? innerEntityType.FindProperty(innerKeyPropertyName) : null;
+            if (outerProperty != null && innerProperty != null)
+            {
+                var localField = throughAlias != null
+                    ? $"{throughAlias}.{outerProperty.GetElementName()}"
+                    : outerProperty.GetElementName();
+
+                navigationlessKey = new MongoQueryExpression.NavigationlessJoinKey(
+                    innerEntityType.GetCollectionName(), localField, innerProperty.GetElementName(), lookupAlias);
+                outerQueryExpression.RegisterNavigationlessJoinKey(innerEntityType, navigationlessKey.Value);
+            }
+        }
 
         if (isSecondOrLaterJoin)
         {
@@ -787,6 +816,16 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
                 outerQueryExpression.AddLookup(lookup);
             }
+            else if (navigationlessKey is { } key)
+            {
+                // This hop is itself a bare key-equality Join with no model navigation (EF-377); the
+                // localField captured in navigationlessKey is already scoped by the through-hop's alias.
+                outerQueryExpression.AddLookup(new Expressions.LookupExpression(
+                    innerEntityType, key.CollectionName, key.LocalField, key.ForeignField, key.Alias, forceUnwind: true)
+                {
+                    PreserveNullAndEmptyArrays = isLeftOuter
+                });
+            }
 
             // ...and retroactively for every PRIOR join so the whole document is flat (a no-op for any
             // prior join already registered directly, since AddLookup dedupes by alias). Use the
@@ -795,11 +834,6 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             // is unconditional, so a miss is an internal error.
             foreach (var priorRegistration in outerQueryExpression.JoinRegistrations)
             {
-                if (priorRegistration.Navigation == null)
-                {
-                    continue;
-                }
-
                 if (!outerQueryExpression.TryGetJoinIsLeftOuter(priorRegistration.TargetEntityType, out var priorIsLeftOuter))
                 {
                     throw new InvalidOperationException(
@@ -808,12 +842,26 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                         + "please report it with the query that produced it.");
                 }
 
-                outerQueryExpression.AddLookup(
-                    new Expressions.LookupExpression(priorRegistration.Navigation, forceUnwind: true)
+                if (priorRegistration.Navigation != null)
+                {
+                    outerQueryExpression.AddLookup(
+                        new Expressions.LookupExpression(priorRegistration.Navigation, forceUnwind: true)
+                        {
+                            As = priorRegistration.Alias,
+                            PreserveNullAndEmptyArrays = priorIsLeftOuter
+                        });
+                }
+                else if (outerQueryExpression.TryGetNavigationlessJoinKey(priorRegistration.TargetEntityType, out var priorKey))
+                {
+                    // Bare key-equality Join hop with no model navigation (EF-377): synthesize its
+                    // $lookup from the raw key info captured when that hop was translated.
+                    outerQueryExpression.AddLookup(new Expressions.LookupExpression(
+                        priorRegistration.TargetEntityType, priorKey.CollectionName, priorKey.LocalField,
+                        priorKey.ForeignField, priorKey.Alias, forceUnwind: true)
                     {
-                        As = priorRegistration.Alias,
                         PreserveNullAndEmptyArrays = priorIsLeftOuter
                     });
+                }
             }
         }
 

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NavigationlessJoinChainTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/NavigationlessJoinChainTests.cs
@@ -1,0 +1,233 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Extensions;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-377: a chained Join with a bare key-equality hop (no model navigation) previously left a
+/// dependent hop's <c>$lookup</c> localField unscoped, or dropped the hop's own <c>$lookup</c>
+/// entirely, once a later join forced flat mode — silently dropping every row. Covers the bare hop
+/// in first, second, and both positions, plus the shared <c>GroupJoin</c> translator path.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class NavigationlessJoinChainTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    [Fact]
+    public void Bare_first_hop_then_navigation_backed_second_hop_returns_correct_rows_and_scopes_lookup()
+    {
+        var (rootsName, midsName, leavesName) = Seed();
+        var logs = new List<string>();
+
+        using var db = new NavigationlessJoinDbContext(database, rootsName, midsName, leavesName, logs.Add);
+
+        var results =
+            db.NRoots
+                .Join(db.NMids, r => r.MidKey, m => m.Id, (r, m) => new { r, m })
+                .Join(db.NLeaves, x => x.m.LeafId, l => l.Id, (x, l) => new { x.r, l })
+                .ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("R1", result.r.Name);
+        Assert.Equal("A", result.l.Label);
+
+        // NMid has no navigation from NRoot, so its $lookup uses the "_lookup_NMid" fallback alias;
+        // the second hop's $lookup must be scoped under that alias, not the root document.
+        Assert.Contains(logs, l => l.Contains("\"as\" : \"_lookup_NMid\""));
+        Assert.Contains(logs, l => l.Contains("\"localField\" : \"_lookup_NMid.LeafId\""));
+    }
+
+    [Fact]
+    public void Navigation_backed_first_hop_then_bare_second_hop_returns_correct_rows_and_scopes_lookup()
+    {
+        var (rootsName, midsName, leavesName) = Seed();
+        var logs = new List<string>();
+
+        using var db = new NavigationlessJoinDbContext(
+            database, rootsName, midsName, leavesName, logs.Add, firstHopHasNavigation: true, secondHopHasNavigation: false);
+
+        var results =
+            db.NRoots
+                .Join(db.NMids, r => r.MidKey, m => m.Id, (r, m) => new { r, m })
+                .Join(db.NLeaves, x => x.m.LeafId, l => l.Id, (x, l) => new { x.r, l })
+                .ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("R1", result.r.Name);
+        Assert.Equal("A", result.l.Label);
+
+        // This time NMid.Leaf is the bare hop; its $lookup must still scope under the first
+        // hop's real navigation alias ("_lookup_Mid").
+        Assert.Contains(logs, l => l.Contains("\"as\" : \"_lookup_Mid\""));
+        Assert.Contains(logs, l => l.Contains("\"localField\" : \"_lookup_Mid.LeafId\""));
+    }
+
+    [Fact]
+    public void Both_hops_bare_key_equality_joins_return_correct_rows_and_scope_lookup()
+    {
+        var (rootsName, midsName, leavesName) = Seed();
+        var logs = new List<string>();
+
+        using var db = new NavigationlessJoinDbContext(
+            database, rootsName, midsName, leavesName, logs.Add, secondHopHasNavigation: false);
+
+        var results =
+            db.NRoots
+                .Join(db.NMids, r => r.MidKey, m => m.Id, (r, m) => new { r, m })
+                .Join(db.NLeaves, x => x.m.LeafId, l => l.Id, (x, l) => new { x.r, l })
+                .ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("R1", result.r.Name);
+        Assert.Equal("A", result.l.Label);
+
+        Assert.Contains(logs, l => l.Contains("\"as\" : \"_lookup_NMid\""));
+        Assert.Contains(logs, l => l.Contains("\"localField\" : \"_lookup_NMid.LeafId\""));
+    }
+
+#if !EF8 && !EF9
+    // EF8's and EF9's left-join pattern detection doesn't recognize this idiom when the outer
+    // sequence comes from a prior bare Join, so it fails to translate on EF8/EF9 (fixed in EF10).
+    [Fact]
+    public void Bare_first_hop_then_GroupJoin_left_join_pattern_returns_correct_rows()
+    {
+        var (rootsName, midsName, leavesName) = Seed();
+
+        using var db = new NavigationlessJoinDbContext(database, rootsName, midsName, leavesName);
+
+        var results =
+            db.NRoots
+                .Join(db.NMids, r => r.MidKey, m => m.Id, (r, m) => new { r, m })
+                .GroupJoin(db.NLeaves, x => x.m.LeafId, l => l.Id, (x, leaves) => new { x.r, leaves })
+                .SelectMany(x => x.leaves.DefaultIfEmpty(), (x, l) => new { x.r, l })
+                .ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("R1", result.r.Name);
+        Assert.NotNull(result.l);
+        Assert.Equal("A", result.l!.Label);
+    }
+#endif
+
+    private (string rootsName, string midsName, string leavesName) Seed()
+    {
+        var rootsName = TemporaryDatabaseFixtureBase.CreateCollectionName("NRoots") + Guid.NewGuid().ToString("N")[..8];
+        var midsName = TemporaryDatabaseFixtureBase.CreateCollectionName("NMids") + Guid.NewGuid().ToString("N")[..8];
+        var leavesName = TemporaryDatabaseFixtureBase.CreateCollectionName("NLeaves") + Guid.NewGuid().ToString("N")[..8];
+
+        database.MongoDatabase.GetCollection<BsonDocument>(rootsName).InsertMany([
+            new BsonDocument { { "_id", 1 }, { "Name", "R1" }, { "MidKey", 100 } }
+        ]);
+        database.MongoDatabase.GetCollection<BsonDocument>(midsName).InsertMany([
+            new BsonDocument { { "_id", 100 }, { "LeafId", 1000 } }
+        ]);
+        database.MongoDatabase.GetCollection<BsonDocument>(leavesName).InsertMany([
+            new BsonDocument { { "_id", 1000 }, { "Label", "A" } }
+        ]);
+
+        return (rootsName, midsName, leavesName);
+    }
+
+    class NRoot
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public int MidKey { get; set; }
+        public NMid Mid { get; set; }
+    }
+
+    class NMid
+    {
+        public int Id { get; set; }
+        public int LeafId { get; set; }
+        public NLeaf Leaf { get; set; }
+    }
+
+    class NLeaf
+    {
+        public int Id { get; set; }
+        public string Label { get; set; }
+    }
+
+    class NavigationlessJoinDbContext(
+        TemporaryDatabaseFixture database, string rootsCollection, string midsCollection, string leavesCollection,
+        Action<string>? logAction = null, bool firstHopHasNavigation = false, bool secondHopHasNavigation = true)
+        : DbContext(new DbContextOptionsBuilder<NavigationlessJoinDbContext>()
+            .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+            .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .LogTo(l => logAction?.Invoke(l))
+            .EnableSensitiveDataLogging()
+            .Options)
+    {
+        public DbSet<NRoot> NRoots { get; set; }
+        public DbSet<NMid> NMids { get; set; }
+        public DbSet<NLeaf> NLeaves { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<NRoot>(b =>
+            {
+                b.ToCollection(rootsCollection);
+                b.HasKey(r => r.Id);
+                if (firstHopHasNavigation)
+                {
+                    b.HasOne(r => r.Mid).WithMany().HasForeignKey(r => r.MidKey);
+                }
+                else
+                {
+                    // Otherwise EF's convention-based discovery would still turn the CLR navigation
+                    // property into an (unwanted) relationship, adding a shadow FK not present in
+                    // the seed data.
+                    b.Ignore(r => r.Mid);
+                }
+            });
+
+            modelBuilder.Entity<NMid>(b =>
+            {
+                b.ToCollection(midsCollection);
+                b.HasKey(m => m.Id);
+                if (secondHopHasNavigation)
+                {
+                    b.HasOne(m => m.Leaf).WithMany().HasForeignKey(m => m.LeafId);
+                }
+                else
+                {
+                    b.Ignore(m => m.Leaf);
+                }
+            });
+
+            modelBuilder.Entity<NLeaf>(b =>
+            {
+                b.ToCollection(leavesCollection);
+                b.HasKey(l => l.Id);
+            });
+        }
+
+        private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime) => Interlocked.Increment(ref _count);
+        }
+    }
+}


### PR DESCRIPTION
A transitive $lookup hop that depends on a prior Join could only scope its localField, and the prior hop could only register its own $lookup once flattened, by finding an INavigation for that prior hop. A bare key-equality Join with no corresponding model navigation had none, so the second hop was left unscoped or the intermediate's $lookup was silently skipped, producing wrong results.

LookupExpression now carries a navigation-independent TargetEntityType and gained a constructor that builds a $lookup directly from raw join-key field paths. MongoQueryExpression records this raw key info per navigation-less hop so later hops and the retroactive flattening pass can still resolve and emit it correctly.