### PR TITLE
EF-381: Decline a self-referencing two-hop join with no resolvable intermediate

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -664,14 +664,10 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         var fkPropertyName = outerKeySelector.Body.TryGetSimplePropertyName();
         INavigation? navigation = null;
 
-        // A root hop's key selector reads the FK directly off the join's outer parameter (e.g. "o.CustomerID").
-        // A transitive hop instead reads through a transparent identifier from a PRIOR join (e.g.
-        // "ti.Inner.CustomerID"). Only a root hop's FK conceptually belongs to the outer root entity type, so
-        // only a root hop may be resolved against the root's own navigations here — a transitive hop must be
-        // resolved via the prior-inner-collection scan below (or declined; see the check after it). Without
-        // this gate, a transitive hop whose FK property name happens to match one of the root's own
-        // navigations (e.g. a self-referencing Manager/DirectReports relationship reused two hops deep)
-        // resolves to the WRONG navigation instead of correctly finding no resolvable intermediate.
+        // Only a root hop's FK belongs to the outer root entity type, so only a root hop is resolved
+        // against the root's own navigations here. A transitive hop must go through the prior-inner-
+        // collection scan below (or be declined) — otherwise a self-referencing FK name (e.g. Manager/
+        // DirectReports reused two hops deep) can resolve to the wrong navigation.
         var isRootHop = IsRootHopKeySelector(outerKeySelector);
 
         if (isRootHop)
@@ -715,14 +711,10 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             }
         }
 
-        // A transitive hop with no resolvable intermediate has nothing to be scoped under: no $lookup
-        // will be registered for it, so a shaper built from here would read a field nothing wrote (e.g. a
-        // self-referencing two-hop chain, where the scan above deliberately skips a prior inner collection
-        // of the SAME entity type as this hop and so never finds a candidate). Decline the join outright
-        // rather than crash with a raw "missing element" exception during materialization. Scoped to the
-        // simple-FK-property shape (fkPropertyName != null) so unrelated already-undeclined gaps (e.g. a
-        // composite/complex key selector, which never resolves fkPropertyName here either) keep their
-        // existing — separately tracked — failure behavior instead of being pulled into this one.
+        // An unresolved transitive hop has no intermediate to scope a $lookup under (e.g. a self-
+        // referencing two-hop chain, where the scan above skips the same-entity-type prior collection).
+        // Decline rather than let the shaper read a field nothing wrote. Scoped to fkPropertyName != null
+        // so other already-declined gaps (e.g. composite keys) keep their existing failure behavior.
         if (!isRootHop && navigation == null && fkPropertyName != null)
         {
             return null;
@@ -793,13 +785,10 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
     }
 
     /// <summary>
-    /// Whether a join's outer key selector reads the FK property directly off the join's own root entity,
-    /// as opposed to reading through a PRIOR join's inner (dependent) side. A sibling Include chain (e.g.
-    /// <c>.Include(r => r.A).Include(r => r.B)</c>) lowers its second join's key selector to
-    /// "ti.Outer.BId" — "Outer" always re-exposes the SAME root entity a prior join started from, so any
-    /// number of ".Outer" hops still counts as a root hop. Only an ".Inner" hop (e.g. "ti.Inner.CustomerID",
-    /// from a chained Join/ThenInclude) reads through a previously-joined DEPENDENT and makes this a
-    /// transitive hop.
+    /// Whether a join's outer key selector reads the FK directly off the join's own root entity, rather
+    /// than through a prior join's inner (dependent) side. Any depth of ".Outer" (sibling Include chains
+    /// re-exposing the same root) still counts as a root hop; an ".Inner" hop (chained Join/ThenInclude)
+    /// does not.
     /// </summary>
     private static bool IsRootHopKeySelector(LambdaExpression outerKeySelector)
     {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -619,6 +619,11 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         var reboundInnerShaper = RebindInnerShaperToOuterQuery(
             inner.ShaperExpression, innerQueryExpression, outerQueryExpression, outerKeySelector);
 
+        if (reboundInnerShaper == null)
+        {
+            return null;
+        }
+
         var newResultSelector = ReplacingExpressionVisitor.Replace(
             resultSelector.Parameters[0], outer.ShaperExpression,
             ReplacingExpressionVisitor.Replace(
@@ -628,7 +633,7 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         return outer.UpdateShaperExpression(newResultSelector);
     }
 
-    private static Expression RebindInnerShaperToOuterQuery(
+    private static Expression? RebindInnerShaperToOuterQuery(
         Expression innerShaper,
         MongoQueryExpression innerQueryExpression,
         MongoQueryExpression outerQueryExpression,
@@ -659,15 +664,28 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         var fkPropertyName = outerKeySelector.Body.TryGetSimplePropertyName();
         INavigation? navigation = null;
 
-        if (fkPropertyName != null)
-        {
-            navigation = outerEntityType.GetNavigations()
-                .FirstOrDefault(n => n.TargetEntityType == innerEntityType
-                                     && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
-        }
+        // A root hop's key selector reads the FK directly off the join's outer parameter (e.g. "o.CustomerID").
+        // A transitive hop instead reads through a transparent identifier from a PRIOR join (e.g.
+        // "ti.Inner.CustomerID"). Only a root hop's FK conceptually belongs to the outer root entity type, so
+        // only a root hop may be resolved against the root's own navigations here — a transitive hop must be
+        // resolved via the prior-inner-collection scan below (or declined; see the check after it). Without
+        // this gate, a transitive hop whose FK property name happens to match one of the root's own
+        // navigations (e.g. a self-referencing Manager/DirectReports relationship reused two hops deep)
+        // resolves to the WRONG navigation instead of correctly finding no resolvable intermediate.
+        var isRootHop = IsRootHopKeySelector(outerKeySelector);
 
-        navigation ??= outerEntityType.GetNavigations()
-            .FirstOrDefault(n => n.TargetEntityType == innerEntityType);
+        if (isRootHop)
+        {
+            if (fkPropertyName != null)
+            {
+                navigation = outerEntityType.GetNavigations()
+                    .FirstOrDefault(n => n.TargetEntityType == innerEntityType
+                                         && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
+            }
+
+            navigation ??= outerEntityType.GetNavigations()
+                .FirstOrDefault(n => n.TargetEntityType == innerEntityType);
+        }
 
         // Transitive join: the inner entity is reached not directly from the root but THROUGH a
         // previously-joined intermediate (e.g. OrderDetail.Order.Customer — the join's outer key
@@ -695,6 +713,19 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
                     break;
                 }
             }
+        }
+
+        // A transitive hop with no resolvable intermediate has nothing to be scoped under: no $lookup
+        // will be registered for it, so a shaper built from here would read a field nothing wrote (e.g. a
+        // self-referencing two-hop chain, where the scan above deliberately skips a prior inner collection
+        // of the SAME entity type as this hop and so never finds a candidate). Decline the join outright
+        // rather than crash with a raw "missing element" exception during materialization. Scoped to the
+        // simple-FK-property shape (fkPropertyName != null) so unrelated already-undeclined gaps (e.g. a
+        // composite/complex key selector, which never resolves fkPropertyName here either) keep their
+        // existing — separately tracked — failure behavior instead of being pulled into this one.
+        if (!isRootHop && navigation == null && fkPropertyName != null)
+        {
+            return null;
         }
 
         // Document-shape decision (single source of truth): the driver's native LeftJoin
@@ -759,6 +790,35 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
         return structuralShaper.Update(
             new ProjectionBindingExpression(outerQueryExpression, projectionIndex, typeof(ValueBuffer)));
+    }
+
+    /// <summary>
+    /// Whether a join's outer key selector reads the FK property directly off the join's own root entity,
+    /// as opposed to reading through a PRIOR join's inner (dependent) side. A sibling Include chain (e.g.
+    /// <c>.Include(r => r.A).Include(r => r.B)</c>) lowers its second join's key selector to
+    /// "ti.Outer.BId" — "Outer" always re-exposes the SAME root entity a prior join started from, so any
+    /// number of ".Outer" hops still counts as a root hop. Only an ".Inner" hop (e.g. "ti.Inner.CustomerID",
+    /// from a chained Join/ThenInclude) reads through a previously-joined DEPENDENT and makes this a
+    /// transitive hop.
+    /// </summary>
+    private static bool IsRootHopKeySelector(LambdaExpression outerKeySelector)
+    {
+        var body = outerKeySelector.Body.RemoveConvert();
+        var receiver = (body switch
+        {
+            ParameterExpression => body,
+            MemberExpression member => member.Expression,
+            MethodCallExpression { Arguments.Count: 2 } methodCall when methodCall.Method.IsEFPropertyMethod()
+                => methodCall.Arguments[0],
+            _ => null
+        })?.RemoveConvert();
+
+        while (receiver is MemberExpression { Member.Name: "Outer" } outerAccess)
+        {
+            receiver = outerAccess.Expression.RemoveConvert();
+        }
+
+        return receiver == outerKeySelector.Parameters[0];
     }
 
     protected override ShapedQueryExpression? TranslateLastOrDefault(ShapedQueryExpression source, LambdaExpression? predicate,

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -693,7 +693,7 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         // on a prior inner collection and remember the intermediate so the $lookup's localField can be
         // prefixed with that intermediate's "_lookup_<Intermediate>" path.
         INavigation? throughNavigation = null;
-        if (navigation == null && fkPropertyName != null)
+        if (!isRootHop && navigation == null && fkPropertyName != null)
         {
             foreach (var priorInnerEntityType in outerQueryExpression.InnerCollections.Keys)
             {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -287,14 +287,10 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     [Fact]
     public void Include_self_referencing_two_hop_chain_declines_cleanly()
     {
-        // EF-381: Staff.Manager is a self-referencing navigation (StaffMember -> StaffMember). Chaining
-        // ThenInclude(m => m.Manager) produces a SECOND join hop whose outer key selector reads through
-        // the transparent identifier from the first join, targeting the SAME entity type the first hop
-        // already joined. RebindInnerShaperToOuterQuery's transitive scan explicitly skips a prior inner
-        // collection whose entity type matches the current hop's (guarding against self-matching), so no
-        // intermediate is resolved and no $lookup is ever registered for this hop -- yet, pre-fix, the
-        // code still built a shaper reading a "_lookup_StaffMember" field nothing wrote, crashing
-        // materialization with a raw InvalidOperationException instead of a clean translation failure.
+        // EF-381: ThenInclude(m => m.Manager) is a second join hop on the same self-referencing entity
+        // type, so no intermediate resolves for it and no $lookup gets registered. Pre-fix, the shaper
+        // still read a "_lookup_StaffMember" field nothing wrote, crashing with a raw exception instead
+        // of a clean translation failure.
         var staffName = TemporaryDatabaseFixtureBase.CreateCollectionName("Staff") + Guid.NewGuid().ToString("N")[..8];
         var grandManagerId = ObjectId.GenerateNewId();
         var managerId = ObjectId.GenerateNewId();

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -283,6 +283,40 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     }
 #endif
 
+#if !EF8 && !EF9
+    [Fact]
+    public void Include_self_referencing_two_hop_chain_declines_cleanly()
+    {
+        // EF-381: Staff.Manager is a self-referencing navigation (StaffMember -> StaffMember). Chaining
+        // ThenInclude(m => m.Manager) produces a SECOND join hop whose outer key selector reads through
+        // the transparent identifier from the first join, targeting the SAME entity type the first hop
+        // already joined. RebindInnerShaperToOuterQuery's transitive scan explicitly skips a prior inner
+        // collection whose entity type matches the current hop's (guarding against self-matching), so no
+        // intermediate is resolved and no $lookup is ever registered for this hop -- yet, pre-fix, the
+        // code still built a shaper reading a "_lookup_StaffMember" field nothing wrote, crashing
+        // materialization with a raw InvalidOperationException instead of a clean translation failure.
+        var staffName = TemporaryDatabaseFixtureBase.CreateCollectionName("Staff") + Guid.NewGuid().ToString("N")[..8];
+        var grandManagerId = ObjectId.GenerateNewId();
+        var managerId = ObjectId.GenerateNewId();
+        var employeeId = ObjectId.GenerateNewId();
+
+        var staff = database.MongoDatabase.GetCollection<BsonDocument>(staffName);
+        staff.InsertMany([
+            new BsonDocument { { "_id", grandManagerId }, { "emp_name", "GrandBoss" } },
+            new BsonDocument { { "_id", managerId }, { "emp_name", "Boss" }, { "mgr_id", grandManagerId } },
+            new BsonDocument { { "_id", employeeId }, { "emp_name", "Worker" }, { "mgr_id", managerId } }
+        ]);
+
+        using var db = new StaffDbContext(database, staffName);
+
+        // Must be a clean "could not be translated" failure, not a raw BSON exception from a shaper
+        // reading a field that no $lookup ever populated.
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            db.Staff.Include(s => s.Manager).ThenInclude(m => m.Manager).ToList());
+        Assert.Contains("could not be translated", ex.Message);
+    }
+#endif
+
     [Fact]
     public void Filtered_collection_include_predicate_is_not_silently_dropped()
     {


### PR DESCRIPTION
RebindInnerShaperToOuterQuery resolved a join hop's navigation by matching FK-property-name and target-entity-type against the query ROOT's navigations, even for a transitive hop (one whose outer key selector reads through a prior join's transparent-identifier ".Inner", e.g. a chained Join/ThenInclude). For a self-referencing relationship (e.g. StaffMember.Manager/DirectReports), this matched the wrong -- or no -- navigation, and the resulting shaper read a "_lookup_<Type>" field that no $lookup had ever populated, crashing materialization with a raw InvalidOperationException instead of failing translation cleanly.

Classify each hop as "root" (FK read directly off the outer parameter, or through any depth of transparent-identifier ".Outer" re-exposure) vs "transitive" (".Inner") via a new IsRootHopKeySelector helper, only consult the root's own navigations for root hops, and decline the join outright when a transitive hop's intermediate can't be resolved via the existing prior-inner-collection scan.