### PR TITLE
EF-380: Fix ThenInclude whose key selector reaches through an owned navigation

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -700,29 +700,24 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
         // Employee.Manager.Manager): a pure ".Outer"* chain reaches the root, one ending in ".Inner"
         // reaches a prior hop. Checking this structurally (not by comparing entity types) is required for
         // self-referencing chains, where the target and through entity types are the same.
+        //
+        // A key selector can also reach the FK property through an owned/embedded navigation nested
+        // inside the root or the through-hop (e.g. Buyer.Address.RegionId, EF-380): PeelEmbeddedSegments
+        // strips those leading member accesses (closest to the FK property) before the Outer/Inner walk
+        // runs, so the walk still sees a pure Outer/Inner chain.
+        var (outerInnerTarget, embeddedSegments) = PeelEmbeddedSegments(
+            GetKeySelectorTargetObject(outerKeySelector.Body), outerKeySelector.Parameters[0]);
         var (isDirectFromRoot, throughLevel) = AnalyzeKeySelectorTarget(
-            GetKeySelectorTargetObject(outerKeySelector.Body), outerKeySelector.Parameters[0], priorJoinCount);
+            outerInnerTarget, outerKeySelector.Parameters[0], priorJoinCount);
 
         INavigation? navigation = null;
         JoinInfo? throughJoin = null;
+        string? embeddedPath = null;
 
+        IEntityType? anchorEntityType = null;
         if (isDirectFromRoot)
         {
-            if (fkPropertyName != null)
-            {
-                // IsOnDependent disambiguates a self-referencing relationship declared with both a
-                // reference nav (e.g. Manager) and its inverse collection nav (e.g. DirectReports):
-                // both share the same IForeignKey, so matching on ForeignKey.Properties alone matches
-                // either one, and picking the collection nav flips the $lookup's join direction
-                // (LookupExpression branches on Navigation.IsOnDependent).
-                navigation = outerEntityType.GetNavigations()
-                    .FirstOrDefault(n => n.TargetEntityType == innerEntityType
-                                         && n.IsOnDependent
-                                         && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
-            }
-
-            navigation ??= outerEntityType.GetNavigations()
-                .FirstOrDefault(n => n.TargetEntityType == innerEntityType);
+            anchorEntityType = outerEntityType;
         }
         else if (throughLevel is { } level && level >= 1 && level <= priorJoinCount)
         {
@@ -730,19 +725,53 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             // through (found by position, not by IEntityType — see above) and remember it so the
             // $lookup's localField can be prefixed with that intermediate's alias.
             throughJoin = outerQueryExpression.Joins[level - 1];
-            var throughEntityType = throughJoin.InnerEntityType;
+            anchorEntityType = throughJoin.InnerEntityType;
+        }
+
+        if (anchorEntityType != null)
+        {
+            // Walk any embedded segments via the navigation graph (not CLR type) so sibling owned
+            // navigations sharing a CLR type (e.g. ShippingAddress/BillingAddress) resolve to the right
+            // one, using each segment's mapped element name for the $lookup localField path.
+            var searchEntityType = anchorEntityType;
+            if (embeddedSegments.Count > 0)
+            {
+                var elementSegments = new List<string>();
+                foreach (var segment in embeddedSegments)
+                {
+                    if (searchEntityType.FindNavigation(segment) is not { } segmentNavigation)
+                    {
+                        // Can't resolve this embedded path — fall back to searching the anchor itself, as
+                        // if there were no embedded segments (matches pre-EF-380 behavior).
+                        searchEntityType = anchorEntityType;
+                        elementSegments = null;
+                        break;
+                    }
+
+                    searchEntityType = segmentNavigation.TargetEntityType;
+                    elementSegments.Add(searchEntityType.GetContainingElementName() ?? segment);
+                }
+
+                if (elementSegments is { Count: > 0 })
+                {
+                    embeddedPath = string.Join(".", elementSegments);
+                }
+            }
 
             if (fkPropertyName != null)
             {
-                // See the IsOnDependent comment in the isDirectFromRoot branch above — same ambiguity
-                // applies here.
-                navigation = throughEntityType.GetNavigations()
+                // IsOnDependent disambiguates a self-referencing relationship declared with both a
+                // reference nav (e.g. Manager) and its inverse collection nav (e.g. DirectReports):
+                // both share the same IForeignKey, so matching on ForeignKey.Properties alone matches
+                // either one, and picking the collection nav flips the $lookup's join direction
+                // (LookupExpression branches on Navigation.IsOnDependent).
+                navigation = searchEntityType.GetNavigations()
                     .FirstOrDefault(n => n.TargetEntityType == innerEntityType
                                          && n.IsOnDependent
                                          && n.ForeignKey.Properties.Any(p => p.Name == fkPropertyName));
             }
 
-            navigation ??= throughEntityType.GetNavigations()
+            navigation ??= searchEntityType.GetNavigations()
                 .FirstOrDefault(n => n.TargetEntityType == innerEntityType);
         }
 
@@ -775,8 +804,16 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             };
             if (throughJoin != null)
             {
-                // Transitive join: match against the already-unwound intermediate document.
-                lookup.LocalField = $"{throughJoin.Alias}.{lookup.LocalField}";
+                // Transitive join: match against the already-unwound intermediate document; an
+                // owned/embedded navigation (EF-380) inserts its path between the intermediate's alias
+                // and the field.
+                var throughAlias = embeddedPath != null ? $"{throughJoin.Alias}.{embeddedPath}" : throughJoin.Alias;
+                lookup.LocalField = $"{throughAlias}.{lookup.LocalField}";
+            }
+            else if (embeddedPath != null)
+            {
+                // Direct from root, but through an owned/embedded navigation (EF-380).
+                lookup.LocalField = $"{embeddedPath}.{lookup.LocalField}";
             }
 
             joinInfo.Lookup = lookup;
@@ -862,6 +899,45 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             MethodCallExpression call when call.Method.IsEFPropertyMethod() && call.Arguments.Count == 2 => call.Arguments[0],
             _ => null
         };
+
+    /// <summary>
+    /// Strips leading member/<c>EF.Property</c> accesses off <paramref name="targetObject"/> that are
+    /// NOT part of the join chain's synthetic <c>Outer</c>/<c>Inner</c> transparent-identifier plumbing —
+    /// i.e. real navigation hops through an owned/embedded type nested inside the root or a prior join
+    /// (e.g. the "Address" in <c>x.Inner.Address.RegionId</c>, EF-380). Returns what's left (handed to
+    /// <see cref="AnalyzeKeySelectorTarget"/> to resolve against the root/prior-join chain) plus the
+    /// stripped segment names in root-to-leaf order.
+    /// </summary>
+    private static (Expression? RemainingTarget, List<string> EmbeddedSegments) PeelEmbeddedSegments(
+        Expression? targetObject, ParameterExpression parameter)
+    {
+        var embeddedSegments = new List<string>();
+        var current = targetObject;
+        while (current != null && !ReferenceEquals(current, parameter))
+        {
+            var (name, next) = current.RemoveConvert() switch
+            {
+                MemberExpression member when member.IsTransparentIdentifierOuterOrInnerAccess() => (null, null),
+                MemberExpression member => (member.Member.Name, member.Expression),
+                MethodCallExpression call when call.Method.IsEFPropertyMethod()
+                    && call.Arguments.Count == 2
+                    && call.Arguments[1] is ConstantExpression { Value: string propertyName } => (propertyName, call.Arguments[0]),
+                _ => (null, null)
+            };
+
+            if (name == null || next == null)
+            {
+                // Either we've reached the Outer/Inner chain plumbing, or an unrecognized shape — either
+                // way, hand off the rest to AnalyzeKeySelectorTarget as-is.
+                break;
+            }
+
+            embeddedSegments.Insert(0, name);
+            current = next;
+        }
+
+        return (current, embeddedSegments);
+    }
 
     /// <summary>
     /// Walks a chain of <c>.Outer</c>/<c>.Inner</c> member accesses from <paramref name="targetObject"/>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ThenIncludeThroughOwnedNavigationTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ThenIncludeThroughOwnedNavigationTests.cs
@@ -1,0 +1,292 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if !EF8 && !EF9
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MongoDB.Bson;
+using MongoDB.EntityFrameworkCore.Extensions;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// EF-380: a second-join key selector reaching through an owned/embedded navigation on an
+/// already-joined intermediate (e.g. <c>Order.Buyer.Address.RegionId</c>) used to emit an unscoped
+/// <c>$lookup</c> localField ("RegionId" instead of "_lookup_Buyer.Address.RegionId"), silently
+/// matching nothing and leaving <c>Region</c> null despite matching data existing.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class ThenIncludeThroughOwnedNavigationTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    [Fact]
+    public void ThenInclude_reaching_through_an_owned_navigation_after_a_prior_join_resolves_the_nested_reference()
+    {
+        var (ordersName, buyersName, regionsName) = Seed();
+        var logs = new List<string>();
+
+        using var db = new OwnedNavigationJoinDbContext(database, ordersName, buyersName, regionsName, logs.Add);
+
+        var order = db.JOrders
+            .Include(o => o.Buyer)
+            .ThenInclude(b => b.Address)
+            .ThenInclude(a => a.Region)
+            .Single();
+
+        Assert.NotNull(order.Buyer);
+        Assert.NotNull(order.Buyer.Address);
+        Assert.Equal("London", order.Buyer.Address.City);
+        Assert.NotNull(order.Buyer.Address.Region);
+        Assert.Equal("Europe", order.Buyer.Address.Region.Name);
+
+        // Scoped under the Buyer lookup alias AND the embedded Address path, not a bare "RegionId".
+        Assert.Contains(logs, l => l.Contains("\"localField\" : \"_lookup_Buyer.Address.RegionId\""));
+    }
+
+    /// <summary>
+    /// Sibling owned navigations sharing a CLR type (<c>ShippingAddress</c> / <c>BillingAddress</c>, both
+    /// <c>J2Address</c>) must resolve via the real navigation graph, not a CLR-type guess — otherwise
+    /// owner resolution could pick the sibling with no <c>Region</c> relationship, dropping the $lookup.
+    /// </summary>
+    [Fact]
+    public void ThenInclude_through_one_of_two_sibling_owned_navigations_sharing_a_clr_type_resolves_the_correct_one()
+    {
+        var (ordersName, buyersName, regionsName) = Seed2();
+        var logs = new List<string>();
+
+        using var db = new SiblingOwnedNavigationJoinDbContext(database, ordersName, buyersName, regionsName, logs.Add);
+
+        var order = db.J2Orders
+            .Include(o => o.Buyer)
+            .ThenInclude(b => b.ShippingAddress)
+            .ThenInclude(a => a.Region)
+            .Single();
+
+        Assert.NotNull(order.Buyer);
+        Assert.NotNull(order.Buyer.ShippingAddress);
+        Assert.Equal("London", order.Buyer.ShippingAddress.City);
+        Assert.NotNull(order.Buyer.ShippingAddress.Region);
+        Assert.Equal("Europe", order.Buyer.ShippingAddress.Region.Name);
+
+        Assert.Contains(logs, l => l.Contains("\"localField\" : \"_lookup_Buyer.ShippingAddress.RegionId\""));
+    }
+
+    private (string ordersName, string buyersName, string regionsName) Seed2()
+    {
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("J2Orders") + Guid.NewGuid().ToString("N")[..8];
+        var buyersName = TemporaryDatabaseFixtureBase.CreateCollectionName("J2Buyers") + Guid.NewGuid().ToString("N")[..8];
+        var regionsName = TemporaryDatabaseFixtureBase.CreateCollectionName("J2Regions") + Guid.NewGuid().ToString("N")[..8];
+
+        var buyerId = ObjectId.GenerateNewId();
+        var regionId = ObjectId.GenerateNewId();
+
+        database.MongoDatabase.GetCollection<BsonDocument>(regionsName).InsertOne(
+            new BsonDocument { { "_id", regionId }, { "Name", "Europe" } });
+        database.MongoDatabase.GetCollection<BsonDocument>(buyersName).InsertOne(
+            new BsonDocument
+            {
+                { "_id", buyerId },
+                { "Name", "Alice" },
+                { "ShippingAddress", new BsonDocument { { "City", "London" }, { "RegionId", regionId } } },
+                { "BillingAddress", new BsonDocument { { "City", "Paris" } } }
+            });
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertOne(
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Desc", "Order 1" }, { "BuyerId", buyerId } });
+
+        return (ordersName, buyersName, regionsName);
+    }
+
+    class J2Order
+    {
+        public ObjectId _id { get; set; }
+        public string Desc { get; set; }
+        public ObjectId? BuyerId { get; set; }
+        public J2Buyer Buyer { get; set; }
+    }
+
+    class J2Buyer
+    {
+        public ObjectId _id { get; set; }
+        public string Name { get; set; }
+        public J2Address ShippingAddress { get; set; }
+        public J2Address BillingAddress { get; set; }
+    }
+
+    class J2Address
+    {
+        public string City { get; set; }
+        public ObjectId? RegionId { get; set; }
+        public J2Region Region { get; set; }
+    }
+
+    class J2Region
+    {
+        public ObjectId _id { get; set; }
+        public string Name { get; set; }
+    }
+
+    class SiblingOwnedNavigationJoinDbContext(
+        TemporaryDatabaseFixture database, string ordersCollection, string buyersCollection, string regionsCollection,
+        Action<string>? logAction = null)
+        : DbContext(new DbContextOptionsBuilder<SiblingOwnedNavigationJoinDbContext>()
+            .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+            .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .LogTo(l => logAction?.Invoke(l))
+            .EnableSensitiveDataLogging()
+            .Options)
+    {
+        public DbSet<J2Order> J2Orders { get; set; }
+        public DbSet<J2Buyer> J2Buyers { get; set; }
+        public DbSet<J2Region> J2Regions { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<J2Order>(b =>
+            {
+                b.ToCollection(ordersCollection);
+                b.HasOne(o => o.Buyer).WithMany().HasForeignKey(o => o.BuyerId);
+            });
+
+            modelBuilder.Entity<J2Buyer>(b =>
+            {
+                b.ToCollection(buyersCollection);
+                b.OwnsOne(c => c.ShippingAddress, a =>
+                {
+                    a.HasOne(x => x.Region).WithMany().HasForeignKey(x => x.RegionId);
+                });
+                // Sibling owned navigation, same CLR type (J2Address), but WITHOUT the Region relationship.
+                b.OwnsOne(c => c.BillingAddress, a =>
+                {
+                    a.Ignore(x => x.Region);
+                });
+            });
+
+            modelBuilder.Entity<J2Region>(b =>
+            {
+                b.ToCollection(regionsCollection);
+            });
+        }
+
+        private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime) => Interlocked.Increment(ref _count);
+        }
+    }
+
+    private (string ordersName, string buyersName, string regionsName) Seed()
+    {
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("JOrders") + Guid.NewGuid().ToString("N")[..8];
+        var buyersName = TemporaryDatabaseFixtureBase.CreateCollectionName("JBuyers") + Guid.NewGuid().ToString("N")[..8];
+        var regionsName = TemporaryDatabaseFixtureBase.CreateCollectionName("JRegions") + Guid.NewGuid().ToString("N")[..8];
+
+        var buyerId = ObjectId.GenerateNewId();
+        var regionId = ObjectId.GenerateNewId();
+
+        database.MongoDatabase.GetCollection<BsonDocument>(regionsName).InsertOne(
+            new BsonDocument { { "_id", regionId }, { "Name", "Europe" } });
+        database.MongoDatabase.GetCollection<BsonDocument>(buyersName).InsertOne(
+            new BsonDocument
+            {
+                { "_id", buyerId },
+                { "Name", "Alice" },
+                { "Address", new BsonDocument { { "City", "London" }, { "RegionId", regionId } } }
+            });
+        database.MongoDatabase.GetCollection<BsonDocument>(ordersName).InsertOne(
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "Desc", "Order 1" }, { "BuyerId", buyerId } });
+
+        return (ordersName, buyersName, regionsName);
+    }
+
+    class JOrder
+    {
+        public ObjectId _id { get; set; }
+        public string Desc { get; set; }
+        public ObjectId? BuyerId { get; set; }
+        public JBuyer Buyer { get; set; }
+    }
+
+    class JBuyer
+    {
+        public ObjectId _id { get; set; }
+        public string Name { get; set; }
+        public JAddress Address { get; set; }
+    }
+
+    class JAddress
+    {
+        public string City { get; set; }
+        public ObjectId? RegionId { get; set; }
+        public JRegion Region { get; set; }
+    }
+
+    class JRegion
+    {
+        public ObjectId _id { get; set; }
+        public string Name { get; set; }
+    }
+
+    class OwnedNavigationJoinDbContext(
+        TemporaryDatabaseFixture database, string ordersCollection, string buyersCollection, string regionsCollection,
+        Action<string>? logAction = null)
+        : DbContext(new DbContextOptionsBuilder<OwnedNavigationJoinDbContext>()
+            .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+            .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+            .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .LogTo(l => logAction?.Invoke(l))
+            .EnableSensitiveDataLogging()
+            .Options)
+    {
+        public DbSet<JOrder> JOrders { get; set; }
+        public DbSet<JBuyer> JBuyers { get; set; }
+        public DbSet<JRegion> JRegions { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<JOrder>(b =>
+            {
+                b.ToCollection(ordersCollection);
+                b.HasOne(o => o.Buyer).WithMany().HasForeignKey(o => o.BuyerId);
+            });
+
+            modelBuilder.Entity<JBuyer>(b =>
+            {
+                b.ToCollection(buyersCollection);
+                b.OwnsOne(c => c.Address, a =>
+                {
+                    a.HasOne(x => x.Region).WithMany().HasForeignKey(x => x.RegionId);
+                });
+            });
+
+            modelBuilder.Entity<JRegion>(b =>
+            {
+                b.ToCollection(regionsCollection);
+            });
+        }
+
+        private sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime) => Interlocked.Increment(ref _count);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
A transitive Join hop resolves its navigation by searching the prior joined intermediate's own navigations. When the navigation is instead declared on an owned/embedded type nested inside that intermediate (e.g. "x.Buyer.Address.RegionId" — Region is a navigation on the embedded Address, not on Buyer), the search failed to find it, and the hop silently fell back to unscoped root-tier resolution — producing a wrong, unscoped $lookup localField and a silently null navigation despite matching data existing.

Resolve the key selector's actual owner (walking back through owned navigations to the nearest joinable ancestor) so the navigation search looks in the right place, and fold the embedded path into the $lookup's localField prefix.