### PR TITLE
EF-390: Fix dotted owned-hop scalar leaf projecting as null

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingRemovingExpressionVisitor.cs
@@ -700,7 +700,51 @@ internal class MongoProjectionBindingRemovingExpressionVisitor : ExpressionVisit
             return (ownerInfo.EntityType, ownerInfo.BsonDocExpression);
         }
 
+        // Owned navigations aren't joins, so a dotted hop like `b.Home.City` has no ObjectAccessExpression
+        // wrapping "Home" — just a plain MemberExpression or an EF.Property call. Recurse to resolve it,
+        // so multi-level hops (`b.Home.Inner.City`) don't fall back to a leaf lookup on the wrong document.
+        if (expression is MemberExpression navMemberExpression)
+        {
+            var navSource = TryResolveFieldAccessSource(navMemberExpression.Expression);
+            var embeddedNavDocument = TryResolveEmbeddedNavigationDocument(navSource, navSource.EntityType?.FindNavigation(navMemberExpression.Member));
+            if (embeddedNavDocument != null)
+            {
+                return embeddedNavDocument.Value;
+            }
+        }
+
+        if (expression is MethodCallExpression navPropertyCall
+            && navPropertyCall.Method.IsEFPropertyMethod()
+            && navPropertyCall.Arguments[1] is ConstantExpression { Value: string navPropertyName })
+        {
+            var navSource = TryResolveFieldAccessSource(navPropertyCall.Arguments[0]);
+            var embeddedNavDocument = TryResolveEmbeddedNavigationDocument(navSource, navSource.EntityType?.FindNavigation(navPropertyName));
+            if (embeddedNavDocument != null)
+            {
+                return embeddedNavDocument.Value;
+            }
+        }
+
         return (null, null);
+    }
+
+    /// <summary>
+    /// Builds the nested-document read for an embedded (owned) *reference* navigation hop, or
+    /// <see langword="null"/> to let callers fall through to other resolution paths. Collection
+    /// navigations are excluded: their container is a BSON array, not a <see cref="BsonDocument"/>.
+    /// </summary>
+    private (IEntityType EntityType, Expression DocumentExpression)? TryResolveEmbeddedNavigationDocument(
+        (IEntityType? EntityType, Expression? DocumentExpression) navSource, INavigation? navigation)
+    {
+        if (navigation == null || navigation.IsCollection || !navigation.IsEmbedded() || navSource.DocumentExpression == null)
+        {
+            return null;
+        }
+
+        var elementName = navigation.TargetEntityType.GetContainingElementName() ?? navigation.Name;
+        var navDocumentExpression =
+            CreateGetValueExpression(navSource.DocumentExpression, elementName, false, typeof(BsonDocument));
+        return (navigation.TargetEntityType, navDocumentExpression);
     }
 
     private static readonly MethodInfo MqlFieldMethodInfo =

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/OwnedEntityTests.cs
@@ -459,6 +459,117 @@ public class OwnedEntityTests(TemporaryDatabaseFixture database)
     }
 
     [Fact]
+    public void OwnedEntity_dotted_scalar_leaf_projects_alongside_array_leaf()
+    {
+        var collection = database.CreateCollection<BlogWithHome>();
+
+        var id = ObjectId.GenerateNewId();
+
+        var modelBuilder = (ModelBuilder mb) =>
+        {
+            mb.Entity<BlogWithHome>().OwnsOne(b => b.Home, h => h.OwnsMany(x => x.Notes, n => n.HasKey(x => x.NoteId)));
+        };
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            dbContext.Entities.Add(new BlogWithHome
+            {
+                _id = id,
+                Home = new Home { City = "Springfield", Notes = [new Note { NoteId = 1, Text = "a" }, new Note { NoteId = 2, Text = "b" }] }
+            });
+            dbContext.SaveChanges();
+        }
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            var found = dbContext.Entities.AsNoTracking()
+                .Where(e => e._id == id)
+                .Select(e => new { e.Home.City, e.Home.Notes })
+                .Single();
+
+            Assert.Equal(["a", "b"], found.Notes.Select(n => n.Text));
+            Assert.Equal("Springfield", found.City);
+        }
+    }
+
+    private record BlogWithHome
+    {
+        public ObjectId _id { get; set; }
+        public Home Home { get; set; }
+    }
+
+    private record Home
+    {
+        public string City { get; set; }
+        public List<Note> Notes { get; set; }
+    }
+
+    private record Note
+    {
+        public int NoteId { get; set; }
+        public string Text { get; set; }
+    }
+
+    [Fact]
+    public void OwnedEntity_two_level_dotted_scalar_leaf_projects_alongside_array_leaf()
+    {
+        var collection = database.CreateCollection<BlogWithNestedHome>();
+
+        var id = ObjectId.GenerateNewId();
+
+        var modelBuilder = (ModelBuilder mb) =>
+        {
+            mb.Entity<BlogWithNestedHome>().OwnsOne(b => b.Home, h =>
+            {
+                h.OwnsMany(x => x.Notes, n => n.HasKey(x => x.NoteId));
+                h.OwnsOne(x => x.Inner);
+            });
+        };
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            dbContext.Entities.Add(new BlogWithNestedHome
+            {
+                _id = id,
+                Home = new NestedHome
+                {
+                    Inner = new InnerHome { City = "Springfield" },
+                    Notes = [new Note { NoteId = 1, Text = "a" }, new Note { NoteId = 2, Text = "b" }]
+                }
+            });
+            dbContext.SaveChanges();
+        }
+
+        {
+            using var dbContext = SingleEntityDbContext.Create(collection, modelBuilder);
+            var found = dbContext.Entities.AsNoTracking()
+                .Where(e => e._id == id)
+                .Select(e => new { e.Home.Inner.City, e.Home.Notes })
+                .Single();
+
+            Assert.Equal(["a", "b"], found.Notes.Select(n => n.Text));
+            Assert.Equal("Springfield", found.City);
+        }
+    }
+
+    private record BlogWithNestedHome
+    {
+        public ObjectId _id { get; set; }
+        public NestedHome Home { get; set; }
+    }
+
+    private record NestedHome
+    {
+        public InnerHome Inner { get; set; }
+        public List<Note> Notes { get; set; }
+    }
+
+    private record InnerHome
+    {
+        public string City { get; set; }
+    }
+
+    [Fact]
     public void OwnedEntity_collection_projection_alias_with_bson_representation_uses_owned_property_serializer()
     {
         var collection = database.CreateCollection<PersonWithMultipleLocations>();


### PR DESCRIPTION
A scalar reached through an embedded (OwnsOne) navigation, e.g. `b.Home.City`, projected as null when the surrounding Select couldn't fully push down to the driver's LINQ v3 provider (e.g. because a sibling owned collection leaf, `b.Home.Notes`, forces the mixed BsonDocument fallback). TryResolveFieldAccessSource had no case for a navigation hop reached via a MemberExpression or EF.Property(...) on the root shaper, so the property lookup failed and fell back to a bare leaf-name ("City") read at the document root instead of the nested "Home" sub-document where the value actually lives.