### PR TITLE
EF-229: Fix Contains-on-projected-scalar-collection returning wrong results

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -37,7 +37,7 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-222](https://jira.mongodb.org/browse/EF-222) | `translation of Like issue EF-222` | `EF.Functions.Like(...)` is not translated. | 9 |
 | [EF-227](https://jira.mongodb.org/browse/EF-227) | `Max over empty nullables issue EF-227` | `Min` / `Max` over an empty nullable sequence does not produce the EF-expected `null`. | 4 |
 | [EF-228](https://jira.mongodb.org/browse/EF-228) | `Truncation data loss issue EF-228` | `Sum`/`Average` over `float` columns suffers precision/truncation loss when accumulated server-side. | 2 |
-| [EF-229](https://jira.mongodb.org/browse/EF-229) | `Incorrect results issue EF-229` | `Contains` at the top of the query tree returns wrong results in at least one shape. | 1 |
+| [EF-232](https://jira.mongodb.org/browse/EF-232) | `Sum of empty set cast to nullable issue EF-232` | `Sum_with_no_data_cast_to_nullable` does not produce the EF-expected `null`. (The `Compiled_query_when_does_not_end_in_query_operator` failure that previously also cited EF-232 has been re-tagged as `EF-X011`.) | 1 |
 | [EF-234](https://jira.mongodb.org/browse/EF-234) | `translation of Random issue EF-234` | `EF.Functions.Random()` is not translated. | 2 |
 | [EF-235](https://jira.mongodb.org/browse/EF-235) | `Translate Convert methods issue EF-235` | `Convert.ToBoolean/Byte/Int*/Decimal/Double/String/...` calls are not translated. | 8 |
 | [EF-237](https://jira.mongodb.org/browse/EF-237) | `MathF mapping issue EF-237` | `MathF.*` overloads (the `float` Math API) are not translated. | 25 |

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -802,8 +802,44 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             return null;
         }
 
-        var rewrite = TryRewriteEntityContains(collectionExpr, itemExpr);
+        var rewrite = TryRewriteEntityContains(collectionExpr, itemExpr)
+                      ?? TryRewriteScalarProjectedContains(collectionExpr, itemExpr);
         return rewrite != null ? Visit(rewrite)! : null;
+    }
+
+    /// <summary>
+    /// Rewrites <c>source.Select(selector).Contains(item)</c> (scalar, not entity, projection) into
+    /// <c>source.Any(x => selector(x) == item)</c>. The two are equivalent regardless of what precedes the
+    /// <c>Select</c>, and routing through <c>Any</c> avoids handing the driver's LINQ provider a
+    /// <c>Contains</c>-of-a-projection shape it mistranslates (CSHARP-5678 / EF-229).
+    /// </summary>
+    private Expression? TryRewriteScalarProjectedContains(Expression collection, Expression item)
+    {
+        if (collection is not MethodCallExpression { Method.Name: nameof(Queryable.Select) } selectCall
+            || selectCall.Arguments.Count != 2)
+            return null;
+
+        var selectMethodDefinition = selectCall.Method.GetGenericMethodDefinition();
+        var isQueryable = selectMethodDefinition == QueryableMethods.Select;
+        if (!isQueryable && selectMethodDefinition != EnumerableMethods.Select)
+            return null;
+
+        var selector = selectCall.Arguments[1].UnwrapLambdaFromQuote();
+        if (selector.Parameters.Count != 1)
+            return null;
+
+        var elementType = selector.Parameters[0].Type;
+        var predicate = Expression.Lambda(
+            Expression.Equal(selector.Body, item, liftToNull: false, method: null),
+            selector.Parameters[0]);
+
+        var anySource = isQueryable ? typeof(Queryable) : typeof(Enumerable);
+        var anyMethod = anySource.GetMethods()
+            .First(m => m.Name == nameof(Enumerable.Any) && m.GetParameters().Length == 2)
+            .MakeGenericMethod(elementType);
+
+        return Expression.Call(null, anyMethod, selectCall.Arguments[0],
+            isQueryable ? Expression.Quote(predicate) : predicate);
     }
 
     protected override Expression VisitBinary(BinaryExpression node)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/ProjectionTests.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Diagnostics;
 using MongoDB.EntityFrameworkCore.FunctionalTests.Entities.Guides;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
@@ -1277,6 +1278,26 @@ public class ProjectionTests(ReadOnlySampleGuidesFixture database)
 
         Assert.NotNull(result);
         Assert.Equal("Mercury", result);
+    }
+
+    [Fact]
+    public void Select_scalar_projection_contains_matching_value()
+        => Assert.True(_db.Planets.Select(p => p.name).Contains("Saturn"));
+
+    [Fact]
+    public void Select_scalar_projection_contains_non_matching_value()
+        => Assert.False(_db.Planets.Select(p => p.name).Contains("Vulcan"));
+
+    [Fact]
+    public void Select_scalar_projection_contains_translates_to_any_equal()
+    {
+        var (loggerFactory, spyLogger) = SpyLoggerProvider.Create();
+        using var db = GuidesDbContext.Create(database.MongoDatabase, loggerFactory: loggerFactory);
+
+        Assert.True(db.Planets.Select(p => p.name).Contains("Saturn"));
+
+        var message = spyLogger.GetLogMessageByEventId(MongoEventId.ExecutedMqlQuery);
+        Assert.Contains("\"$match\" : { \"name\" : \"Saturn\" }", message);
     }
 
     public void Dispose()

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -1630,14 +1630,11 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Contains_top_level(bool async)
     {
-        // Fails: Incorrect results issue EF-229
-        Assert.Contains(
-            "Expected: True",
-            (await Assert.ThrowsAsync<EqualException>(() => base.Contains_top_level(async))).Message);
+        await base.Contains_top_level(async);
 
         AssertMql(
             """
-            Customers.{ "$project" : { "_v" : "$_id", "_id" : 0 } }, { "$match" : { "_v" : { "_v" : "ALFKI" } } }, { "$limit" : 1 }, { "$project" : { "_id" : 0, "_v" : null } }
+            Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$limit" : 1 }, { "$project" : { "_id" : 0, "_v" : null } }
             """);
     }
 


### PR DESCRIPTION
Queryable.Contains over a Select(x => scalar) projection was handed verbatim to the driver's LINQ v3 provider, which mistranslates this shape (CSHARP-5678). Rewrite source.Select(selector).Contains(item) to source.Any(x => selector(x) == item) before it reaches the driver -- the two are equivalent and Any already translates correctly.