### PR TITLE
EF-228: Fix Average/Sum over float throwing on precision loss

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -46,7 +46,7 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-221](https://jira.mongodb.org/browse/EF-221) | `Equals with different types issue EF-221` | `==` / `Equals` with operands of mismatched CLR types (e.g. `int == long`) is not translated correctly. | 4 |
 | [EF-222](https://jira.mongodb.org/browse/EF-222) | `translation of Like issue EF-222` | `EF.Functions.Like(...)` is not translated. | 9 |
 | [EF-227](https://jira.mongodb.org/browse/EF-227) | `Max over empty nullables issue EF-227` | `Min` / `Max` over an empty nullable sequence does not produce the EF-expected `null`. | 4 |
-| [EF-228](https://jira.mongodb.org/browse/EF-228) | `Truncation data loss issue EF-228` | `Sum`/`Average` over `float` columns suffers precision/truncation loss when accumulated server-side. | 2 |
+| [EF-228](https://jira.mongodb.org/browse/EF-228) | _(no remaining `// Fails:` tags)_ | Fixed: `Sum`/`Average` over a `float` selector now widens the captured aggregate to `double` before handing it to the driver (avoiding the driver's strict `SingleSerializer` truncation check) and narrows back to `float` client-side. The `Type_casting_inside_sum` test formerly cross-referenced here was re-investigated and re-tagged **EF-X023**: it fails via an unrelated mechanism (an explicit `(decimal)` cast in the selector, not a `float` Average/Sum result). | 0 |
 | [EF-232](https://jira.mongodb.org/browse/EF-232) | `Sum of empty set cast to nullable issue EF-232` | `Sum_with_no_data_cast_to_nullable` does not produce the EF-expected `null`. (The `Compiled_query_when_does_not_end_in_query_operator` failure that previously also cited EF-232 has been re-tagged as `EF-X011`.) | 1 |
 | [EF-234](https://jira.mongodb.org/browse/EF-234) | `translation of Random issue EF-234` | `EF.Functions.Random()` is not translated. | 2 |
 | [EF-235](https://jira.mongodb.org/browse/EF-235) | `Translate Convert methods issue EF-235` | `Convert.ToBoolean/Byte/Int*/Decimal/Double/String/...` calls are not translated. | 8 |
@@ -93,7 +93,7 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 | EF-X001 | Sub-query selection across DbSets is not translated | 144 |
 | EF-X002 | Provider throws a different exception than the EF translation-failure message | 46 |
 | EF-X003 | Driver-level feature gaps surfaced as test failures | 19 |
-| EF-X004 | Float `Sum`/`Average` truncation (likely duplicate of EF-228) | 1 |
+| EF-X004 | Int-division precision loss in a projected field | 1 |
 | EF-X005 | BSON document missing nested required reference (AdHoc JSON) | 2 |
 | EF-X006 | MongoDB `DateTimeKind` round-trip handling | 1 |
 | EF-X007 | Views / `HasDefiningQuery` semantics for MongoDB collections | 2 |
@@ -114,6 +114,7 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 | EF-X022 | Join/GroupJoin whose inner source is a filtered or ordered sub-query is rejected | 18 |
 | EF-X024 | `Where`/entity materialization over a flattened multi-join chain onto ambiguous same-navigation or navigation-less siblings is not translated | 2 |
 | EF-X016 | Bulk `ExecuteUpdate`/`ExecuteDelete` source restricted to a single collection scoped by `Where` | 47 |
+| EF-X023 | Explicit `(decimal)` cast inside `Sum`/`Average` loses precision server-side | 1 |
 
 ### EF-X001 — Sub-query selection across DbSets is not translated
 Comment patterns: `// Fails: Subquery selection EF-X001`, `// Fails: Subqueries not supported EF-X001`, `// Fails: No subquery support EF-X001`.
@@ -128,9 +129,9 @@ Affected: ~36 tests. EF's base tests expect `InvalidOperationException` with EF'
 Comment patterns: `// Fails: Unsupported by driver EF-X003`, `// Fails: Reverse not supported by driver EF-X003`, `// Fails: Limited support on client evaluation EF-X003`.
 Affected: ~17 tests. These are MongoDB C# Driver gaps (the driver does not implement a particular LINQ-to-MQL translation). Many likely fold into existing `CSHARP-*` tickets; a single umbrella issue would let the provider track its dependency on driver work.
 
-### EF-X004 — Float `Sum`/`Average` truncation (likely duplicate of EF-228)
+### EF-X004 — Int-division precision loss in a projected field
 Comment pattern: `// Fails: Truncation resulted in data loss EF-X004`.
-Affected: 1 test (`NorthwindAggregateOperatorsQueryMongoTest.cs`). Almost certainly the same failure mode as [EF-228](https://jira.mongodb.org/browse/EF-228); recommend re-tagging with `EF-228` and dropping this ticket once confirmed.
+Affected: 1 test (`NorthwindSelectQueryMongoTest.Projection_when_arithmetic_expression_precedence`). Confirmed **not** a duplicate of [EF-228](https://jira.mongodb.org/browse/EF-228) (now fixed) — this test still fails the same way afterward. An integer-division result (`$_id / $_id`) fails to deserialize back into an `int`-typed projected field (`FormatException: "An error occurred while deserializing the B property"`), unrelated to `Average`/`Sum`.
 
 ### EF-X005 — BSON document missing nested required reference (AdHoc JSON)
 Comment patterns: `// Fails: NestedRequiredReference is null in BsonDocument for entity id=6 EF-X005`, `// Fails: Entity id=5 has no RequiredReference field EF-X005`.
@@ -351,6 +352,15 @@ condition and is not yet translated into the `$lookup` sub-pipeline `$match`. Pr
 this ticket tracks. Functional coverage:
 `CrossCollectionIncludeTests.Filtered_collection_include_predicate_is_not_silently_dropped` and
 `CrossCollectionIncludeTests.Query_filter_on_collection_include_target_is_not_silently_dropped`.
+
+### EF-X023 — Explicit `(decimal)` cast inside `Sum`/`Average` loses precision server-side
+Comment pattern: `// Fails: Explicit float-to-decimal cast inside Sum loses precision EF-X023`.
+Affected: 1 test (`NorthwindAggregateOperatorsQueryMongoTest.Type_casting_inside_sum`, `.Sum(od => (decimal)od.Discount)`).
+Distinct from [EF-228](https://jira.mongodb.org/browse/EF-228) (fixed): here the selector already casts to `decimal`
+before the sum, translating to `{ "$sum": { "$toDecimal": "$Discount" } }`; the server-side `$toDecimal` conversion
+of the underlying `float` values itself introduces binary-floating-point noise (returns `121.04000180587159838`
+instead of `121.040`), so widening the aggregate (EF-228's fix) does not apply — the precision loss happens before
+the `$sum`, not in deserializing its result.
 
 ### EF-X024 — `Where`/entity materialization over a flattened multi-join chain onto ambiguous same-navigation or navigation-less siblings is not translated
 Comment pattern: `// Fails: Where over a flattened multi-join chain is not translated EF-X024`, or

--- a/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Expressions/MongoQueryExpression.cs
@@ -51,6 +51,12 @@ internal sealed partial class MongoQueryExpression : Expression
     /// </summary>
     public Expression? CapturedExpression { get; set; }
 
+    /// <summary>
+    /// Set when <see cref="CapturedExpression"/> was widened to a wider numeric overload to dodge the
+    /// driver's strict narrowing check (EF-228). Holds the original public result type to narrow back to.
+    /// </summary>
+    public Type? AggregateNarrowingResultType { get; set; }
+
     /// <inheritdoc />
     public override Type Type
         => typeof(object);

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -160,12 +160,86 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
             if (newCardinality != shapedQueryExpression.ResultCardinality)
                 shapedQueryExpression = shapedQueryExpression.UpdateResultCardinality(newCardinality);
 
-            ((MongoQueryExpression)shapedQueryExpression.QueryExpression).CapturedExpression = _finalExpression;
+            var mongoQueryExpression = (MongoQueryExpression)shapedQueryExpression.QueryExpression;
+            var widened = WidenFloatAverageOrSum(_finalExpression);
+            mongoQueryExpression.CapturedExpression = widened;
+            mongoQueryExpression.AggregateNarrowingResultType = widened != _finalExpression ? _finalExpression?.Type : null;
             return shapedQueryExpression;
         }
 
         return QueryCompilationContext.NotTranslatedExpression;
     }
+
+    /// <summary>
+    /// MongoDB computes <c>$avg</c>/<c>$sum</c> in double precision; the driver's <c>float</c> serializer
+    /// throws <see cref="MongoDB.Bson.TruncationException"/> rather than narrow a lossy result (EF-228).
+    /// Rewrite to the <c>double</c> overload here; narrowing back happens client-side in
+    /// <see cref="MongoShapedQueryCompilingExpressionVisitor"/>.
+    /// </summary>
+    private static Expression? WidenFloatAverageOrSum(Expression? expression)
+    {
+        if (expression is not MethodCallExpression { Method.DeclaringType: var declaringType } call
+            || declaringType != typeof(Queryable)
+            || call.Method.Name is not (nameof(Queryable.Average) or nameof(Queryable.Sum)))
+        {
+            return expression;
+        }
+
+        var isAverage = call.Method.Name == nameof(Queryable.Average);
+
+        if (call.Arguments.Count == 2
+            && (isAverage ? QueryableMethods.IsAverageWithSelector(call.Method) : QueryableMethods.IsSumWithSelector(call.Method)))
+        {
+            var selector = call.Arguments[1] is UnaryExpression { NodeType: ExpressionType.Quote } quote
+                ? (LambdaExpression)quote.Operand
+                : (LambdaExpression)call.Arguments[1];
+
+            var widenedType = WidenedFloatResultType(selector.ReturnType);
+            if (widenedType == null)
+            {
+                return expression;
+            }
+
+            var sourceType = call.Method.GetGenericArguments()[0];
+            var newSelector = Expression.Lambda(Expression.Convert(selector.Body, widenedType), selector.Parameters);
+            var openMethod = isAverage
+                ? QueryableMethods.GetAverageWithSelector(widenedType)
+                : QueryableMethods.GetSumWithSelector(widenedType);
+
+            return Expression.Call(openMethod.MakeGenericMethod(sourceType), call.Arguments[0], newSelector);
+        }
+
+        if (call.Arguments.Count == 1
+            && (isAverage ? QueryableMethods.IsAverageWithoutSelector(call.Method) : QueryableMethods.IsSumWithoutSelector(call.Method)))
+        {
+            var elementType = call.Arguments[0].Type.GetGenericArguments()[0];
+            var widenedType = WidenedFloatResultType(elementType);
+            if (widenedType == null)
+            {
+                return expression;
+            }
+
+            var parameter = Expression.Parameter(elementType, "x");
+            var selectCall = Expression.Call(
+                null,
+                QueryableMethods.Select.MakeGenericMethod(elementType, widenedType),
+                call.Arguments[0],
+                Expression.Lambda(Expression.Convert(parameter, widenedType), parameter));
+
+            var openMethod = isAverage
+                ? QueryableMethods.GetAverageWithoutSelector(widenedType)
+                : QueryableMethods.GetSumWithoutSelector(widenedType);
+
+            return Expression.Call(openMethod, selectCall);
+        }
+
+        return expression;
+    }
+
+    private static Type? WidenedFloatResultType(Type type)
+        => type == typeof(float) ? typeof(double)
+            : type == typeof(float?) ? typeof(double?)
+            : null;
 
     protected override ShapedQueryExpression TranslateSelect(ShapedQueryExpression source, LambdaExpression selector)
     {

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoShapedQueryCompilingExpressionVisitor.cs
@@ -161,10 +161,34 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
 
         if (ProjectionAnalyzer.CanPushDown(shapedQueryExpression.ShaperExpression))
         {
+            var publicResultType = shapedQueryExpression.ShaperExpression.Type;
+
+            if (mongoQueryExpression.AggregateNarrowingResultType == publicResultType
+                && mongoQueryExpression.CapturedExpression is { Type: var driverResultType }
+                && driverResultType != publicResultType)
+            {
+                // EF-228: the captured expression was widened (e.g. float Average/Sum -> double) so the
+                // driver deserializes leniently; narrow the driver's result back to the public type here,
+                // client-side, via a plain numeric conversion rather than a strict BSON round-trip.
+                var narrowParameter = Expression.Parameter(driverResultType, "v");
+                var narrowLambda = Expression.Lambda(Expression.Convert(narrowParameter, publicResultType), narrowParameter);
+
+                return Expression.Call(null,
+                    ExecuteNarrowedProjectedQueryMethodInfo.MakeGenericMethod(
+                        rootEntityType.ClrType, driverResultType, publicResultType),
+                    QueryCompilationContext.QueryContextParameter,
+                    Expression.Constant(rootEntityType),
+                    Expression.Constant(_bsonSerializerFactory),
+                    Expression.Constant(mongoQueryExpression),
+                    Expression.Constant(_contextType),
+                    Expression.Constant(_threadSafetyChecksEnabled),
+                    Expression.Constant(shapedQueryExpression.ResultCardinality),
+                    Expression.Constant(narrowLambda.Compile(), narrowLambda.Type));
+            }
+
             // Push-down path: scalar/anonymous projections handled entirely by LINQ V3
             return Expression.Call(null,
-                ExecuteProjectedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType,
-                    shapedQueryExpression.ShaperExpression.Type),
+                ExecuteProjectedQueryMethodInfo.MakeGenericMethod(rootEntityType.ClrType, publicResultType),
                 QueryCompilationContext.QueryContextParameter,
                 Expression.Constant(rootEntityType),
                 Expression.Constant(_bsonSerializerFactory),
@@ -350,6 +374,34 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             mongoQueryContext,
             executableQuery,
             (_, e) => e,
+            contextType,
+            standAloneStateManager: false,
+            threadSafetyChecksEnabled,
+            GetOnZeroResultsAction(queryExpression));
+    }
+
+    // EF-228: sibling of ExecuteProjectedQuery for the case where MongoQueryableMethodTranslatingExpressionVisitor
+    // widened the captured expression (e.g. float Average/Sum -> double) so the driver deserializes the
+    // aggregate result leniently. TDriverResult is what the driver actually returns; narrow converts it
+    // to the TResult the public LINQ signature promised.
+    private static QueryingEnumerable<TDriverResult, TResult> ExecuteNarrowedProjectedQuery<TSource, TDriverResult, TResult>(
+        QueryContext queryContext,
+        IReadOnlyEntityType entityType,
+        BsonSerializerFactory bsonSerializerFactory,
+        MongoQueryExpression queryExpression,
+        Type contextType,
+        bool threadSafetyChecksEnabled,
+        ResultCardinality resultCardinality,
+        Func<TDriverResult, TResult> narrow)
+    {
+        var (mongoQueryContext, executableQuery) = TranslateQuery<TSource>(
+            queryContext, entityType, bsonSerializerFactory, queryExpression, resultCardinality,
+            (translator, expression) => translator.TranslateProjected(expression));
+
+        return new QueryingEnumerable<TDriverResult, TResult>(
+            mongoQueryContext,
+            executableQuery,
+            (_, e) => narrow(e),
             contextType,
             standAloneStateManager: false,
             threadSafetyChecksEnabled,
@@ -688,6 +740,12 @@ internal sealed class MongoShapedQueryCompilingExpressionVisitor : ShapedQueryCo
             .GetTypeInfo()
             .DeclaredMethods
             .Single(m => m.Name == nameof(ExecuteProjectedQuery));
+
+    private static readonly MethodInfo ExecuteNarrowedProjectedQueryMethodInfo =
+        typeof(MongoShapedQueryCompilingExpressionVisitor)
+            .GetTypeInfo()
+            .DeclaredMethods
+            .Single(m => m.Name == nameof(ExecuteNarrowedProjectedQuery));
 
     private static readonly MethodInfo CreateInnerSourceMethodInfo =
         typeof(MongoShapedQueryCompilingExpressionVisitor)

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/AggregateFloatPrecisionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/AggregateFloatPrecisionTests.cs
@@ -1,0 +1,109 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+
+namespace MongoDB.EntityFrameworkCore.FunctionalTests.Query;
+
+/// <summary>
+/// Regression tests for EF-228: <c>Average</c>/<c>Sum</c> over a <c>float</c>-typed selector threw
+/// <see cref="MongoDB.Bson.TruncationException"/> because MongoDB always computes <c>$avg</c>/<c>$sum</c>
+/// in double precision, and the driver's default <c>SingleSerializer</c> refuses to narrow a double
+/// result back to <c>float</c> if any precision would be lost.
+/// </summary>
+[XUnitCollection("QueryTests")]
+public class AggregateFloatPrecisionTests(TemporaryDatabaseFixture database)
+    : IClassFixture<TemporaryDatabaseFixture>
+{
+    private record Order
+    {
+        public ObjectId _id { get; set; }
+        public float Discount { get; set; }
+    }
+
+    [Fact]
+    public void Average_over_float_selector_does_not_throw_on_precision_loss()
+    {
+        var collection = database.CreateCollection<Order>();
+        using var db = SingleEntityDbContext.Create(collection);
+        db.Entities.AddRange(new Order { Discount = 1.1f }, new Order { Discount = 2.2f });
+        db.SaveChanges();
+
+        var average = db.Entities.Average(e => e.Discount);
+
+        Assert.Equal(1.65f, average, 3);
+    }
+
+    [Fact]
+    public void Sum_over_float_selector_does_not_throw_on_precision_loss()
+    {
+        var collection = database.CreateCollection<Order>();
+        using var db = SingleEntityDbContext.Create(collection);
+        db.Entities.AddRange(new Order { Discount = 1.1f }, new Order { Discount = 2.2f });
+        db.SaveChanges();
+
+        var sum = db.Entities.Sum(e => e.Discount);
+
+        Assert.Equal(3.3f, sum, 3);
+    }
+
+    [Fact]
+    public void Average_over_float_without_selector_does_not_throw_on_precision_loss()
+    {
+        var collection = database.CreateCollection<Order>();
+        using var db = SingleEntityDbContext.Create(collection);
+        db.Entities.AddRange(new Order { Discount = 1.1f }, new Order { Discount = 2.2f });
+        db.SaveChanges();
+
+        var average = db.Entities.Select(e => e.Discount).Average();
+
+        Assert.Equal(1.65f, average, 3);
+    }
+
+    [Fact]
+    public void Sum_over_float_without_selector_does_not_throw_on_precision_loss()
+    {
+        var collection = database.CreateCollection<Order>();
+        using var db = SingleEntityDbContext.Create(collection);
+        db.Entities.AddRange(new Order { Discount = 1.1f }, new Order { Discount = 2.2f });
+        db.SaveChanges();
+
+        var sum = db.Entities.Select(e => e.Discount).Sum();
+
+        Assert.Equal(3.3f, sum, 3);
+    }
+
+    private record NullableOrder
+    {
+        public ObjectId _id { get; set; }
+        public float? Discount { get; set; }
+    }
+
+    [Fact]
+    public void Average_over_nullable_float_selector_does_not_throw_on_precision_loss()
+    {
+        var collection = database.CreateCollection<NullableOrder>();
+        using var db = SingleEntityDbContext.Create(collection);
+        db.Entities.AddRange(
+            new NullableOrder { Discount = 1.1f }, new NullableOrder { Discount = 2.2f }, new NullableOrder { Discount = null });
+        db.SaveChanges();
+
+        var average = db.Entities.Average(e => e.Discount);
+
+        Assert.NotNull(average);
+        Assert.Equal(1.65f, average.Value, 3);
+    }
+}

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -722,14 +722,11 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Sum_on_float_column(bool async)
     {
-        // Fails: Truncation data loss issue EF-228
-        Assert.Contains(
-            "Truncation resulted in data loss.",
-            (await Assert.ThrowsAsync<TruncationException>(() => base.Sum_on_float_column(async))).Message);
+        await base.Sum_on_float_column(async);
 
         AssertMql(
             """
-            OrderDetails.{ "$match" : { "_id.ProductID" : 1 } }, { "$group" : { "_id" : null, "_v" : { "$sum" : "$Discount" } } }, { "$project" : { "_id" : 0 } }
+            OrderDetails.{ "$match" : { "_id.ProductID" : 1 } }, { "$group" : { "_id" : null, "_v" : { "$sum" : { "$toDouble" : "$Discount" } } } }, { "$project" : { "_id" : 0 } }
             """);
     }
 
@@ -849,14 +846,11 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Average_on_float_column(bool async)
     {
-        // Fails: Truncation data loss issue EF-228
-        Assert.Contains(
-            "Truncation resulted in data loss.",
-            (await Assert.ThrowsAsync<TruncationException>(() => base.Average_on_float_column(async))).Message);
+        await base.Average_on_float_column(async);
 
         AssertMql(
             """
-            OrderDetails.{ "$match" : { "_id.ProductID" : 1 } }, { "$group" : { "_id" : null, "_v" : { "$avg" : "$Discount" } } }, { "$project" : { "_id" : 0 } }
+            OrderDetails.{ "$match" : { "_id.ProductID" : 1 } }, { "$group" : { "_id" : null, "_v" : { "$avg" : { "$toDouble" : "$Discount" } } } }, { "$project" : { "_id" : 0 } }
             """);
     }
 
@@ -2291,8 +2285,10 @@ Orders.{ "$match" : { "$or" : [{ "_id" : 10248 }, { "_id" : 10249 }] } }
 
     public override async Task Type_casting_inside_sum(bool async)
     {
-        // Fails: Truncation data loss issue EF-228
+        // Fails: Explicit float-to-decimal cast inside Sum loses precision EF-X023
         // Returns 121.04000180587159838 instead of 121.040 because of conversion errors.
+        // Distinct from EF-228 (fixed): this is an explicit (decimal) cast in the selector, not a
+        // float Average/Sum result, and the server-side $toDecimal conversion itself is lossy here.
         Assert.Contains(
             "Actual:   121.04000180587159838",
             (await Assert.ThrowsAsync<EqualException>(() =>


### PR DESCRIPTION
MongoDB always computes $avg/$sum in double precision. When the LINQ selector is float-typed, the driver deserializes the result with the strict SingleSerializer, which throws TruncationException rather than narrow a double that isn't exactly representable as a float.

Rewrite the captured Average/Sum call to the widening double overload before handing it to the driver, and narrow the result back to float client-side (a plain numeric conversion, not a BSON round-trip) once execution completes.