### PR TITLE
EF-232: Fix Sum() over an empty set returning null for nullable projections

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -38,7 +38,6 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-227](https://jira.mongodb.org/browse/EF-227) | `Max over empty nullables issue EF-227` | `Min` / `Max` over an empty nullable sequence does not produce the EF-expected `null`. | 4 |
 | [EF-228](https://jira.mongodb.org/browse/EF-228) | `Truncation data loss issue EF-228` | `Sum`/`Average` over `float` columns suffers precision/truncation loss when accumulated server-side. | 2 |
 | [EF-229](https://jira.mongodb.org/browse/EF-229) | `Incorrect results issue EF-229` | `Contains` at the top of the query tree returns wrong results in at least one shape. | 1 |
-| [EF-232](https://jira.mongodb.org/browse/EF-232) | `Sum of empty set cast to nullable issue EF-232` | `Sum_with_no_data_cast_to_nullable` does not produce the EF-expected `null`. (The `Compiled_query_when_does_not_end_in_query_operator` failure that previously also cited EF-232 has been re-tagged as `EF-X011`.) | 1 |
 | [EF-234](https://jira.mongodb.org/browse/EF-234) | `translation of Random issue EF-234` | `EF.Functions.Random()` is not translated. | 2 |
 | [EF-235](https://jira.mongodb.org/browse/EF-235) | `Translate Convert methods issue EF-235` | `Convert.ToBoolean/Byte/Int*/Decimal/Double/String/...` calls are not translated. | 8 |
 | [EF-237](https://jira.mongodb.org/browse/EF-237) | `MathF mapping issue EF-237` | `MathF.*` overloads (the `float` Math API) are not translated. | 25 |

--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -250,7 +250,7 @@ The following inconsistencies were observed while building this inventory and ha
 
 ### 1. `EF-232` was reused for two distinct failure modes — **fixed**
 
-`Sum_with_no_data_cast_to_nullable` keeps `EF-232`; `Compiled_query_when_does_not_end_in_query_operator` was re-tagged with the new temp ticket `EF-X011`.
+`Sum_with_no_data_cast_to_nullable` kept `EF-232` (since fixed and removed from the table above); `Compiled_query_when_does_not_end_in_query_operator` was re-tagged with the new temp ticket `EF-X011`.
 
 ### 2. Sibling `#if` branches missing the `// Fails:` tag — **fixed**
 

--- a/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
+++ b/src/MongoDB.EntityFrameworkCore/Storage/MongoClientWrapper.cs
@@ -15,6 +15,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -121,8 +123,26 @@ public class MongoClientWrapper : IMongoClientWrapper
         }
 
         _commandLogger.ExecutedMqlQuery(executableQuery);
+
+        if (result is null)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(typeof(T));
+            if (underlyingType != null && IsSumQuery(executableQuery.Query))
+            {
+                // The driver's $group over zero input documents yields zero output documents, so a
+                // nullable Sum() comes back as default(T) (null). LINQ defines Sum() over an empty set
+                // as 0 even for nullable projections (unlike Average(), which stays undefined), so
+                // that empty-cursor result is coerced to the numeric zero here.
+                result = (T)Convert.ChangeType(0, underlyingType);
+            }
+        }
+
         return [result];
     }
+
+    private static bool IsSumQuery(Expression query)
+        => query is MethodCallExpression { Method.Name: "Sum", Method.DeclaringType: var declaringType }
+           && declaringType == typeof(Queryable);
 
     private IMongoClient GetOrCreateMongoClient(MongoOptionsExtension? options, IServiceProvider serviceProvider)
     {

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
@@ -265,6 +265,22 @@ public class TopScalarTests(ReadOnlySampleGuidesFixture database)
     }
 
     [Fact]
+    public void Sum_with_nullable_selector_over_empty_set_is_zero()
+    {
+        var sum = _db.Planets.Where(p => p.orderFromSun > 100).Select(p => (int?)p.orderFromSun).Sum();
+
+        Assert.Equal(0, sum);
+    }
+
+    [Fact]
+    public async Task SumAsync_with_nullable_selector_over_empty_set_is_zero()
+    {
+        var sum = await _db.Planets.Where(p => p.orderFromSun > 100).Select(p => (int?)p.orderFromSun).SumAsync();
+
+        Assert.Equal(0, sum);
+    }
+
+    [Fact]
     public void Max_with_selector()
     {
         var sum = _db.Planets.Max(p => p.orderFromSun);

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindAggregateOperatorsQueryMongoTest.cs
@@ -191,11 +191,7 @@ public class NorthwindAggregateOperatorsQueryMongoTest
 
     public override async Task Sum_with_no_data_cast_to_nullable(bool async)
     {
-        // Fails: Sum of empty set cast to nullable issue EF-232
-        Assert.Contains(
-            "Expected: 0",
-            (await Assert.ThrowsAsync<EqualException>(() =>
-                base.Sum_with_no_data_cast_to_nullable(async))).Message);
+        await base.Sum_with_no_data_cast_to_nullable(async);
 
         AssertMql(
             """


### PR DESCRIPTION
Sum() of an empty set is defined as 0 (unlike Average(), which is undefined), and this should hold even when the projection is a nullable numeric type. The MongoDB driver's $group produces zero output documents for zero input rows, so SingleOrDefault() on the driver side returns default(T) - 0 for plain numeric types, but null for their nullable counterparts.

Coerce that empty-cursor result to the numeric zero in MongoClientWrapper.ExecuteScalar when the underlying query is a Queryable.Sum call, matching LINQ-to-Objects semantics without any driver change.