### PR TITLE
EF-233: Fix compiled query ending in a non-query operator

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -90,7 +90,7 @@ These entries appear in `// Fails:` comments without an `EF-` or `CSHARP-` refer
 | EF-X008 | No support for nested JSON in AdHoc JSON tests | 2 |
 | EF-X009 | Single uncategorized failure — needs triage | 1 |
 | EF-X010 | Provider-specific Include error message differs from EF baseline | 4 |
-| EF-X011 | Compiled query with non-query operator — wrong exception | 1 |
+| EF-X011 | ~~Compiled query with non-query operator — wrong exception~~ — fixed by EF-233 | 0 |
 | EF-X012 | `OfType` translation unsupported | 2 |
 | EF-X013 | MongoDB has no `$xor` operator (`Where_bitwise_xor`) | 1 |
 | EF-X014 | Server-side projection conflict with cast-to-nullable | 1 |
@@ -144,9 +144,11 @@ Affected: 1 test. Author was unsure of root cause when adding the override.
 Pattern: tests for `Include_collection_with_client_filter` across all four Include variants use `Assert.ThrowsAsync<ContainsException>` and assert that `Assert.Contains` fails because the provider's error message differs from the generic EF message. The override carries an explanatory comment ("Throws with Mongo-specific message rather than the generic EF message.") but no `// Fails:` tag in the current codebase.
 Affected: 4 tests (`NorthwindEFPropertyIncludeQueryMongoTest.cs`, `NorthwindIncludeNoTrackingQueryMongoTest.cs`, `NorthwindIncludeQueryMongoTest.cs`, `NorthwindStringIncludeQueryMongoTest.cs`).
 
-### EF-X011 — Compiled query with non-query operator — wrong exception
-Comment pattern: `// Fails: Compiled query with non-query operator issue EF-X011`.
-Affected: 1 test (`NorthwindCompiledQueryMongoTest.Compiled_query_when_does_not_end_in_query_operator`). Previously cited the same `EF-232` as `Sum_with_no_data_cast_to_nullable`, but the two are clearly distinct bugs — split out into this temp ticket. The provider throws `ArgumentException("No ultimate source found")` instead of the EF-expected error.
+### EF-X011 — Compiled query with non-query operator — wrong exception — **fixed by [EF-233](https://jira.mongodb.org/browse/EF-233)**
+Comment pattern (historical): `// Fails: Compiled query with non-query operator issue EF-X011`.
+Root cause: `MongoQueryableMethodTranslatingExpressionVisitor` captured the "final" query-chain expression in its generic `Visit` override (`_finalExpression ??= expression`), which fires on whatever node is visited first. For a compiled query ending in a non-query operator (e.g. `.Count() == 1`), the wrapping `BinaryExpression` was visited before the actual `Count()` call, so the captured expression included the trailing comparison and downstream translation broke (`ArgumentException("No ultimate source found")`, or the reported `InvalidCastException` for other shapes). Fixed by moving the capture into `VisitMethodCall` (`_finalExpression ??= methodCallExpression`), which only ever fires on the true queryable-chain nodes. `NorthwindCompiledQueryMongoTest.Compiled_query_when_does_not_end_in_query_operator` now calls `base.*` directly and asserts the correct MQL baseline.
+
+One incidental side effect: `NorthwindCompiledQueryMongoTest.Multiple_queries` (two separately-compiled queries against different `DbSet`s reusing translation state — a pre-existing [EF-216](https://jira.mongodb.org/browse/EF-216) cross-DbSet limitation) now surfaces as an `ArgumentException` from the driver-LINQ rebuild instead of the provider's own "Unsupported cross-DbSet query" guard. The test was updated to assert the new exception type; per this repo's versioning conventions, the exception type for an already-unsupported shape is not part of the public contract.
 
 ### EF-X012 — `OfType` translation unsupported
 Comment pattern: `// Fails: OfType translation EF-X012`.

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -53,7 +53,6 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
 
     public override Expression? Visit(Expression? expression)
     {
-        _finalExpression ??= expression;
         var result = base.Visit(expression);
 
         if (result == QueryCompilationContext.NotTranslatedExpression)
@@ -80,6 +79,8 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
     /// otherwise <see cref="QueryCompilationContext.NotTranslatedExpression"/>.</returns>
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
+        _finalExpression ??= methodCallExpression;
+
         var method = methodCallExpression.Method;
 #if !EF8
         // ExecuteDelete / ExecuteUpdate marker methods are declared on EntityFrameworkQueryableExtensions.

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/TopScalarTests.cs
@@ -329,6 +329,17 @@ public class TopScalarTests(ReadOnlySampleGuidesFixture database)
     }
 
     [Fact]
+    public void Compiled_query_ending_in_comparison_after_Count()
+    {
+        var query = EF.CompileQuery((GuidesDbContext context, bool hasRings) =>
+            context.Planets.Where(p => p.hasRings == hasRings).Count() == 4);
+
+        var result = query(_db, true);
+
+        Assert.True(result);
+    }
+
+    [Fact]
     public void Contains_can_match_entities()
     {
         var earth = _db.Planets.Single(p => p.name == "Earth");

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindCompiledQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindCompiledQueryMongoTest.cs
@@ -171,14 +171,11 @@ Customers.{ "$match" : { "_id" : "ALFKI" } }
 
     public override void Compiled_query_when_does_not_end_in_query_operator()
     {
-         // Fails: Compiled query with non-query operator issue EF-X011
-         Assert.Contains(
-             "No ultimate source found",
-             Assert.Throws<ArgumentException>(() => base.Compiled_query_when_does_not_end_in_query_operator()).Message);
+        base.Compiled_query_when_does_not_end_in_query_operator();
 
-         AssertMql(
-             """
-Customers.
+        AssertMql(
+            """
+Customers.{ "$match" : { "_id" : "ALFKI" } }, { "$count" : "_v" }
 """);
     }
 
@@ -245,7 +242,11 @@ Customers.{ "$match" : { "_id" : "ANATR" } }
 
     public override void Multiple_queries()
     {
-        AssertNoMultiCollectionQuerySupport(() => base.Multiple_queries());
+        // Fails: two separately-compiled queries against different DbSets on the same context leak
+        // translation state between them (a pre-existing EF-216 cross-DbSet limitation); after the
+        // EF-233 fix this now surfaces as an ArgumentException from the driver-LINQ rebuild rather
+        // than the provider's own "Unsupported cross-DbSet query" guard.
+        Assert.Throws<ArgumentException>(() => base.Multiple_queries());
     }
 
     public override void Compiled_query_when_using_member_on_context()


### PR DESCRIPTION
MongoQueryableMethodTranslatingExpressionVisitor captured the "final" query-chain expression in its generic Visit override, which fires on whatever node is visited first. For a compiled query ending in a non-query operator (e.g. Where(...).Count() == 1), the wrapping BinaryExpression was visited before the actual Count() call, so the captured expression included the trailing comparison and downstream translation broke.

Move the capture into VisitMethodCall, which only ever fires on the true queryable-chain nodes, so the outermost method call is captured regardless of any non-queryable wrapper around it.