### PR TITLE
EF-433: Fix filtered-Include multi-key ordering and silent _id sort fallback

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
@@ -672,8 +672,11 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
         LookupExpression lookup,
         IEntityType targetEntityType)
     {
-        // Walk from the outermost call inward, collecting stages in reverse order.
+        // Walk from the outermost call inward, collecting stages in reverse order. Consecutive
+        // OrderBy/ThenBy keys are buffered in sortKeys and flushed as one $sort stage, since a
+        // later $sort would otherwise re-sort from scratch and discard earlier keys.
         var stages = new List<BsonDocument>();
+        var sortKeys = new List<(string Field, int Direction)>();
         var current = navigationExpression;
 
         while (current is MethodCallExpression methodCall)
@@ -682,16 +685,17 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
             switch (methodName)
             {
                 case "OrderBy" or "ThenBy":
-                    stages.Add(new BsonDocument("$sort", new BsonDocument(GetSortField(methodCall, targetEntityType), 1)));
+                    sortKeys.Add((GetSortField(methodCall, targetEntityType), 1));
                     current = methodCall.Arguments[0];
                     break;
 
                 case "OrderByDescending" or "ThenByDescending":
-                    stages.Add(new BsonDocument("$sort", new BsonDocument(GetSortField(methodCall, targetEntityType), -1)));
+                    sortKeys.Add((GetSortField(methodCall, targetEntityType), -1));
                     current = methodCall.Arguments[0];
                     break;
 
                 case "Skip":
+                    FlushSortKeys(sortKeys, stages);
                     if (methodCall.Arguments[1] is ConstantExpression skipConst)
                     {
                         stages.Add(new BsonDocument("$skip", (int)skipConst.Value!));
@@ -700,6 +704,7 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                     break;
 
                 case "Take":
+                    FlushSortKeys(sortKeys, stages);
                     if (methodCall.Arguments[1] is ConstantExpression takeConst)
                     {
                         stages.Add(new BsonDocument("$limit", (int)takeConst.Value!));
@@ -708,6 +713,8 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
                     break;
 
                 case "Where":
+                    FlushSortKeys(sortKeys, stages);
+
                     // A collection-Include subquery contains a Where for the synthetic FK-correlation
                     // predicate (the join condition), which the $lookup localField/foreignField already
                     // handles, so that one is dropped. But a user filtered-Include predicate
@@ -730,9 +737,32 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
             }
         }
 
+        FlushSortKeys(sortKeys, stages);
+
         // Stages were collected outermost-first; reverse so they execute in the right order.
         stages.Reverse();
         lookup.PipelineStages.AddRange(stages);
+    }
+
+    /// <summary>
+    /// Emits one $sort stage from the buffered sort keys, if any, and clears the buffer.
+    /// </summary>
+    /// <remarks>Keys are buffered last-first, so they're walked in reverse to restore key order.</remarks>
+    private static void FlushSortKeys(List<(string Field, int Direction)> sortKeys, List<BsonDocument> stages)
+    {
+        if (sortKeys.Count == 0)
+        {
+            return;
+        }
+
+        var sortDocument = new BsonDocument();
+        for (var i = sortKeys.Count - 1; i >= 0; i--)
+        {
+            sortDocument.Add(sortKeys[i].Field, sortKeys[i].Direction);
+        }
+
+        stages.Add(new BsonDocument("$sort", sortDocument));
+        sortKeys.Clear();
     }
 
     /// <summary>
@@ -807,7 +837,8 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
         var name = orderByCall.Arguments[1].UnwrapLambdaFromQuote().Body.TryGetSimplePropertyName();
         if (name == null)
         {
-            return "_id";
+            // Not a simple property access — fail loudly rather than silently sorting by "_id".
+            throw new InvalidOperationException(CoreStrings.TranslationFailed(orderByCall.Print()));
         }
 
         var property = entityType.FindProperty(name);

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -342,6 +342,41 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
 #endif
 
     [Fact]
+    public void Filtered_include_multi_key_order_by_then_by_applies_full_sort()
+    {
+        // EF-433: OrderBy(...).ThenBy(...) inside a filtered Include must produce a single $sort stage
+        // with both keys, not two sequential $sort stages (the second of which would silently discard
+        // the first key's ordering). Alice's orders share Priority for two of the three orders, so the
+        // secondary key (Amount) only takes effect within that group if both keys are honored together.
+        var (ordersCollection, customersCollection) = SetupOrdersAndCustomersForMultiKeySort();
+
+        using var db = new OrderCustomerDbContext(database, ordersCollection, customersCollection);
+
+        var customer = db.Customers
+            .Include(c => c.Orders.OrderBy(o => o.Priority).ThenBy(o => o.Amount))
+            .First(c => c.FullName == "Alice");
+
+        Assert.Equal([1, 1, 2], customer.Orders.Select(o => o.Priority));
+        Assert.Equal([10, 20, 5], customer.Orders.Select(o => o.Amount));
+    }
+
+    [Fact]
+    public void Filtered_include_order_by_unsupported_key_selector_is_not_silently_dropped()
+    {
+        // EF-433: a key selector that isn't a simple property access must fail loudly (translation
+        // failure) rather than silently fall back to sorting by "_id", which would return a plausible
+        // but wrong order with no error raised.
+        var (ordersCollection, customersCollection) = SetupOrdersAndCustomers();
+
+        using var db = new OrderCustomerDbContext(database, ordersCollection, customersCollection);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            db.Customers
+                .Include(c => c.Orders.OrderBy(o => o.OrderDescription.ToUpper()))
+                .First(c => c.FullName == "Alice"));
+    }
+
+    [Fact]
     public void Filtered_collection_include_predicate_is_not_silently_dropped()
     {
         // A user filtered-Include predicate (.Include(c => c.Orders.Where(...))) lowers to a Where inside
@@ -442,11 +477,36 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
         return (linesName, ordersName, buyersName, regionsName);
     }
 
+    // Alice's orders: two share Priority 1 (Amounts 20 then 10, inserted out of Amount order) and one has
+    // Priority 2. Sorting by Priority then Amount must yield Amount order [10, 20, 5]; sorting by Amount
+    // alone (the ThenBy-collapse bug) would yield [5, 10, 20] instead.
+    private (string ordersCollection, string customersCollection) SetupOrdersAndCustomersForMultiKeySort()
+    {
+        var customersName = TemporaryDatabaseFixtureBase.CreateCollectionName("IncludeCustomers") + Guid.NewGuid().ToString("N")[..8];
+        var ordersName = TemporaryDatabaseFixtureBase.CreateCollectionName("IncludeOrders") + Guid.NewGuid().ToString("N")[..8];
+
+        var customerId = ObjectId.GenerateNewId();
+
+        var customers = database.MongoDatabase.GetCollection<BsonDocument>(customersName);
+        customers.InsertOne(new BsonDocument { { "_id", customerId }, { "name", "Alice" } });
+
+        var orders = database.MongoDatabase.GetCollection<BsonDocument>(ordersName);
+        orders.InsertMany([
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order A" }, { "cust_id", customerId }, { "priority", 1 }, { "amount", 20 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order B" }, { "cust_id", customerId }, { "priority", 2 }, { "amount", 5 } },
+            new BsonDocument { { "_id", ObjectId.GenerateNewId() }, { "desc", "Order C" }, { "cust_id", customerId }, { "priority", 1 }, { "amount", 10 } }
+        ]);
+
+        return (ordersName, customersName);
+    }
+
     class Order
     {
         public ObjectId _id { get; set; }
         public string OrderDescription { get; set; }
         public ObjectId? CustomerId { get; set; }
+        public int? Priority { get; set; }
+        public int? Amount { get; set; }
         public Customer Customer { get; set; }
     }
 
@@ -499,6 +559,8 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
                 b.ToCollection(_ordersCollection);
                 b.Property(o => o.OrderDescription).HasElementName("desc");
                 b.Property(o => o.CustomerId).HasElementName("cust_id");
+                b.Property(o => o.Priority).HasElementName("priority");
+                b.Property(o => o.Amount).HasElementName("amount");
             });
         }
 


### PR DESCRIPTION
Merge consecutive OrderBy/ThenBy calls in a filtered Include's $lookup sub-pipeline into a single $sort stage instead of one per key, since a later $sort stage fully re-sorts the set and silently discards earlier keys. Also make an unsupported (non-property) sort-key selector throw a translation failure instead of silently falling back to sorting by _id.