### PR TITLE
EF-385: Reject filtered-Include sort keys that aren't mapped properties

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoProjectionBindingExpressionVisitor.Lookup.cs
@@ -842,7 +842,16 @@ internal sealed partial class MongoProjectionBindingExpressionVisitor : Expressi
         }
 
         var property = entityType.FindProperty(name);
-        return property != null ? Microsoft.EntityFrameworkCore.MongoPropertyExtensions.GetElementName(property) : name;
+        if (property == null)
+        {
+            // A member access that isn't a mapped property of the target entity (e.g. "o.Label.Length", or a
+            // member reached through an embedded document, where only the outermost member name survives).
+            // There is no element to sort on: using the raw member name would $sort on a field absent from the
+            // documents, which MongoDB treats as all-equal and returns in an arbitrary order. Fail loudly.
+            throw new InvalidOperationException(CoreStrings.TranslationFailed(orderByCall.Print()));
+        }
+
+        return Microsoft.EntityFrameworkCore.MongoPropertyExtensions.GetElementName(property);
     }
 
     /// <summary>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/CrossCollectionIncludeTests.cs
@@ -377,6 +377,23 @@ public class CrossCollectionIncludeTests(TemporaryDatabaseFixture database)
     }
 
     [Fact]
+    public void Filtered_include_order_by_unmapped_member_key_selector_is_not_silently_dropped()
+    {
+        // A key selector that IS a member access, but names something that is not a mapped property of the
+        // target entity (here string.Length), has no BSON element to sort on. Emitting the member name as an
+        // element name would $sort on a field absent from every document, returning a plausible but arbitrary
+        // order with no error raised, so this must fail loudly too.
+        var (ordersCollection, customersCollection) = SetupOrdersAndCustomers();
+
+        using var db = new OrderCustomerDbContext(database, ordersCollection, customersCollection);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            db.Customers
+                .Include(c => c.Orders.OrderBy(o => o.OrderDescription.Length))
+                .First(c => c.FullName == "Alice"));
+    }
+
+    [Fact]
     public void Filtered_collection_include_predicate_is_not_silently_dropped()
     {
         // A user filtered-Include predicate (.Include(c => c.Orders.Where(...))) lowers to a Where inside


### PR DESCRIPTION
Was previously allowing unmapped properties to be specified (and ignored) as sort keys