### PR TITLE
EF-253: Drop redundant re-ordering by the same property in an OrderBy/ThenBy chain

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -63,7 +63,6 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-248](https://jira.mongodb.org/browse/EF-248) | `Translate String.FirstOrDefault and String.LastOrDefault issue EF-248` | `String.FirstOrDefault()` / `LastOrDefault()` (LINQ-on-string) is not translated. | 2 |
 | [EF-249](https://jira.mongodb.org/browse/EF-249) | `checked issue EF-249` | `checked { ... }` arithmetic is not honored — the `Checked_context_with_arithmetic_does_not_fail` test sees a different exception than EF expects. | 1 |
 | [EF-252](https://jira.mongodb.org/browse/EF-252) | `Concurrency detector tests broken EF-252` | `Throws_on_concurrent_query_first/list` — the concurrency detector does not fire as the EF base test expects. | 2 |
-| [EF-253](https://jira.mongodb.org/browse/EF-253) | `Multiple ordering issue EF-253` | `OrderBy(x).ThenBy(x)` on the same column with different directions does not emit the expected MQL. | 1 |
 | [EF-254](https://jira.mongodb.org/browse/EF-254) | `Take zero EF-254` | `.Skip(0).Take(0)` with a parameter does not produce the expected empty result. | 1 |
 | [EF-371](https://jira.mongodb.org/browse/EF-371) | `returns wrong data (0 rows instead of 6) EF-371` | A self-referencing two-hop reference navigation (`e.Manager.Manager`) collapses to a single join and hop 2 degrades to an inner `$unwind`, so the query returns 0 rows instead of 6. Baselined green on EF10 by asserting the wrong-data failure; the EF8/EF9 arm is a translation failure tagged EF-X020. | 1 |
 

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitor.cs
@@ -71,6 +71,124 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
     private static readonly Type[] AllowedQueryableExtensions =
         [typeof(Queryable), typeof(MongoQueryableExtensions), typeof(Driver.Linq.MongoQueryable)];
 
+    private static readonly HashSet<string> OrderingMethodNames =
+    [
+        nameof(Queryable.OrderBy), nameof(Queryable.OrderByDescending),
+        nameof(Queryable.ThenBy), nameof(Queryable.ThenByDescending)
+    ];
+
+    /// <summary>
+    /// Elides a <c>ThenBy</c>/<c>ThenByDescending</c> ordering whose key selector matches an earlier ordering
+    /// already established in the same <c>OrderBy</c>/<c>ThenBy</c> chain (see <see cref="KeySelectorsMatch"/>
+    /// for what "matches" means here). Once a key fully determines the sort order, re-ordering by it again -
+    /// in either direction - is a no-op; left untouched, the driver's LINQ provider renders both orderings
+    /// into a single <c>$sort</c> stage and MongoDB rejects the resulting document for its duplicate field
+    /// name (EF-253 / CSHARP-5690). Relational EF providers already drop this kind of redundant ordering from
+    /// the generated SQL, so this mirrors their behavior rather than merely working around the driver
+    /// limitation. Orderings that supply an explicit <see cref="IComparer{T}"/> are left untouched (in either
+    /// role - as a candidate for elision, or as prior state a later ordering could match) since a custom
+    /// comparer can make an otherwise-identical key selector not actually redundant.
+    /// </summary>
+    internal static Expression ElideRedundantOrderings(Expression expression)
+    {
+        if (expression is not MethodCallExpression { Arguments.Count: > 0 } methodCall
+            || !AllowedQueryableExtensions.Contains(methodCall.Method.DeclaringType))
+        {
+            return expression;
+        }
+
+        if (!OrderingMethodNames.Contains(methodCall.Method.Name))
+        {
+            var visitedSource = ElideRedundantOrderings(methodCall.Arguments[0]);
+            if (ReferenceEquals(visitedSource, methodCall.Arguments[0]))
+            {
+                return methodCall;
+            }
+
+            var updatedArgs = methodCall.Arguments.ToArray();
+            updatedArgs[0] = visitedSource;
+            return methodCall.Update(methodCall.Object, updatedArgs);
+        }
+
+        // Collect the contiguous ordering chain, outer (last-applied) to inner (first-applied), then
+        // reverse it so it can be replayed in chronological order.
+        var chain = new List<MethodCallExpression>();
+        var node = methodCall;
+        while (AllowedQueryableExtensions.Contains(node.Method.DeclaringType) && OrderingMethodNames.Contains(node.Method.Name))
+        {
+            chain.Add(node);
+            if (node.Arguments[0] is not MethodCallExpression next)
+            {
+                break;
+            }
+
+            node = next;
+        }
+
+        chain.Reverse();
+
+        Expression current = ElideRedundantOrderings(chain[0].Arguments[0]);
+        var seenKeys = new List<LambdaExpression>();
+        foreach (var call in chain)
+        {
+            // OrderBy/OrderByDescending establish a brand new ordering - even mid-chain (e.g.
+            // .OrderBy(k).OrderByDescending(k)) - superseding whatever came before, so only ThenBy/
+            // ThenByDescending calls continue an existing chain for duplicate-detection purposes.
+            if (call.Method.Name is nameof(Queryable.OrderBy) or nameof(Queryable.OrderByDescending))
+            {
+                seenKeys.Clear();
+            }
+
+            var keySelector = call.Arguments.Count == 2 ? call.Arguments[1].UnwrapLambdaFromQuote() : null;
+            var isDuplicate = keySelector is not null && seenKeys.Any(seen => KeySelectorsMatch(seen, keySelector));
+
+            if (keySelector is not null)
+            {
+                seenKeys.Add(keySelector);
+            }
+
+            if (isDuplicate)
+            {
+                continue;
+            }
+
+            if (ReferenceEquals(current, call.Arguments[0]))
+            {
+                current = call;
+                continue;
+            }
+
+            var newArgs = call.Arguments.ToArray();
+            newArgs[0] = current;
+            current = call.Update(call.Object, newArgs);
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Whether two ordering key selectors are both a *direct*, single-hop access to the same member of the
+    /// lambda parameter (e.g. <c>x =&gt; x.CustomerId</c>), modulo the identity of their (distinct) lambda
+    /// parameters. Deliberately narrow to a single hop: the driver's LINQ provider renders a direct property
+    /// access as-is against its raw field path, so two orderings on the *same* directly-accessed member are
+    /// what collide into a single <c>$sort</c> document with a duplicate field name (EF-253 / CSHARP-5690).
+    /// Anything requiring computation - a further member hop off that property (<c>x.Name.Length</c>), a
+    /// method call (<c>Math.Truncate(x.Amount)</c>), etc. - instead gets materialized by EF into its own
+    /// uniquely-named projected field even when repeated, so it never collides and must not be elided here.
+    /// </summary>
+    internal static bool KeySelectorsMatch(LambdaExpression a, LambdaExpression b)
+    {
+        if (a.Parameters.Count != 1 || b.Parameters.Count != 1)
+        {
+            return false;
+        }
+
+        var membersA = a.Parameters[0].MatchMemberAccess<MemberInfo>(a.Body);
+        var membersB = b.Parameters[0].MatchMemberAccess<MemberInfo>(b.Body);
+
+        return membersA is [var memberA] && membersB is [var memberB] && memberA == memberB;
+    }
+
     /// <summary>
     /// Visit the <see cref="MethodCallExpression"/> to capture the cardinality and final expression
     /// when found on a <see cref="Queryable"/> method.
@@ -80,7 +198,7 @@ internal sealed class MongoQueryableMethodTranslatingExpressionVisitor : Queryab
     /// otherwise <see cref="QueryCompilationContext.NotTranslatedExpression"/>.</returns>
     protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
     {
-        _finalExpression ??= methodCallExpression;
+        _finalExpression ??= ElideRedundantOrderings(methodCallExpression);
 
         var method = methodCallExpression.Method;
 #if !EF8

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -3456,15 +3456,11 @@ OrderDetails.
 
     public override async Task OrderBy_ThenBy_same_column_different_direction(bool async)
     {
-        // Fails: Multiple ordering issue EF-253
-        Assert.Contains(
-            "Duplicate element name '_id'.",
-            (await Assert.ThrowsAsync<InvalidOperationException>(() => base.OrderBy_ThenBy_same_column_different_direction(async)))
-            .Message);
+        await base.OrderBy_ThenBy_same_column_different_direction(async);
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$match" : { "_id" : { "$regularExpression" : { "pattern" : "^A", "options" : "s" } } } }, { "$sort" : { "_id" : 1 } }, { "$project" : { "_v" : "$_id", "_id" : 0 } }
             """);
     }
 

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitorTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Query/Visitors/MongoQueryableMethodTranslatingExpressionVisitorTests.cs
@@ -1,0 +1,203 @@
+/* Copyright 2023-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Linq;
+using System.Linq.Expressions;
+using MongoDB.EntityFrameworkCore.Query.Visitors;
+
+namespace MongoDB.EntityFrameworkCore.UnitTests.Query.Visitors;
+
+public class MongoQueryableMethodTranslatingExpressionVisitorTests
+{
+    private class Customer
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string City { get; set; } = "";
+    }
+
+    private static readonly IQueryable<Customer> Source = new Customer[0].AsQueryable();
+
+    // Reads the OrderBy/ThenBy/... spine of an expression tree, outermost-in, and returns it in
+    // chronological (source-to-outermost) order as (method name, argument count) pairs. Argument
+    // count distinguishes the 2-arg (key selector only) and 3-arg (key selector + IComparer) overloads.
+    private static List<(string Name, int ArgCount)> GetOrderingChainShape(Expression expression)
+    {
+        var shape = new List<(string, int)>();
+        while (expression is MethodCallExpression { Arguments.Count: > 0 } call
+               && call.Method.DeclaringType == typeof(Queryable))
+        {
+            shape.Insert(0, (call.Method.Name, call.Arguments.Count));
+            expression = call.Arguments[0];
+        }
+
+        return shape;
+    }
+
+    [Fact]
+    public void Elides_ThenByDescending_duplicating_the_OrderBy_key()
+    {
+        var query = Source.OrderBy(c => c.Name).ThenByDescending(c => c.Name);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal([(nameof(Queryable.OrderBy), 2)], GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Elides_ThenBy_duplicating_the_OrderBy_key_in_the_same_direction()
+    {
+        var query = Source.OrderBy(c => c.Name).ThenBy(c => c.Name);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal([(nameof(Queryable.OrderBy), 2)], GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Keeps_two_independent_OrderBy_calls_on_the_same_key()
+    {
+        // .OrderBy().OrderByDescending() (as opposed to .OrderBy().ThenByDescending()) is two
+        // independent orderings - the second entirely supersedes the first - so both must be kept.
+        var query = Source.OrderBy(c => c.Name).OrderByDescending(c => c.Name);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal(
+            [(nameof(Queryable.OrderBy), 2), (nameof(Queryable.OrderByDescending), 2)],
+            GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Mid_chain_OrderBy_resets_duplicate_tracking()
+    {
+        // The second OrderByDescending starts a fresh ordering, so the ThenBy(Name) directly under it
+        // is a duplicate of *that* ordering (and is elided), while the first ThenBy(Name) - a duplicate
+        // of the original OrderBy - is also elided; the two survivors are the resetting pair.
+        var query = Source.OrderBy(c => c.Name).ThenBy(c => c.Name)
+            .OrderByDescending(c => c.Name).ThenBy(c => c.Name);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal(
+            [(nameof(Queryable.OrderBy), 2), (nameof(Queryable.OrderByDescending), 2)],
+            GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Elides_only_the_redundant_ordering_in_a_longer_chain()
+    {
+        // ThenBy(Name) duplicates OrderBy(Name) and is elided; ThenByDescending(City) is a genuinely
+        // new key and survives; the final ThenBy(City) duplicates it and is elided.
+        var query = Source.OrderBy(c => c.Name).ThenBy(c => c.Name)
+            .ThenByDescending(c => c.City).ThenBy(c => c.City);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal(
+            [(nameof(Queryable.OrderBy), 2), (nameof(Queryable.ThenByDescending), 2)],
+            GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Does_not_elide_ordering_with_an_explicit_comparer()
+    {
+        var query = Source.OrderBy(c => c.Name).ThenByDescending(c => c.Name, System.StringComparer.Ordinal);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal(
+            [(nameof(Queryable.OrderBy), 2), (nameof(Queryable.ThenByDescending), 3)],
+            GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Does_not_treat_an_earlier_comparer_ordering_as_a_match_for_a_later_plain_ordering()
+    {
+        var query = Source.OrderBy(c => c.Name, System.StringComparer.Ordinal).ThenByDescending(c => c.Name);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal(
+            [(nameof(Queryable.OrderBy), 3), (nameof(Queryable.ThenByDescending), 2)],
+            GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Does_not_elide_a_repeated_computed_key_selector()
+    {
+        // c.Name.Length is a two-hop computed key (Name, then Length) - EF materializes each such
+        // ordering into its own uniquely-named projected field, so repeating it never collides and
+        // must not be elided, unlike a direct single-hop property access.
+        var query = Source.OrderBy(c => c.Name.Length).ThenBy(c => c.Name.Length);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Equal(
+            [(nameof(Queryable.OrderBy), 2), (nameof(Queryable.ThenBy), 2)],
+            GetOrderingChainShape(result));
+    }
+
+    [Fact]
+    public void Leaves_a_non_ordering_expression_unchanged()
+    {
+        Expression<Func<Customer, bool>> predicate = c => c.Name == "A";
+        var query = Source.Where(predicate);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        Assert.Same(query.Expression, result);
+    }
+
+    [Fact]
+    public void Elides_through_an_intervening_Where_below_the_ordering_chain()
+    {
+        var query = Source.Where(c => c.City == "X").OrderBy(c => c.Name).ThenByDescending(c => c.Name);
+
+        var result = MongoQueryableMethodTranslatingExpressionVisitor.ElideRedundantOrderings(query.Expression);
+
+        var call = Assert.IsAssignableFrom<MethodCallExpression>(result);
+        Assert.Equal(nameof(Queryable.OrderBy), call.Method.Name);
+        var whereCall = Assert.IsAssignableFrom<MethodCallExpression>(call.Arguments[0]);
+        Assert.Equal(nameof(Queryable.Where), whereCall.Method.Name);
+    }
+
+    [Fact]
+    public void KeySelectorsMatch_returns_true_for_the_same_property_with_differently_named_parameters()
+    {
+        Expression<Func<Customer, string>> a = c => c.Name;
+        Expression<Func<Customer, string>> b = x => x.Name;
+
+        Assert.True(MongoQueryableMethodTranslatingExpressionVisitor.KeySelectorsMatch(a, b));
+    }
+
+    [Fact]
+    public void KeySelectorsMatch_returns_false_for_different_properties()
+    {
+        Expression<Func<Customer, string>> a = c => c.Name;
+        Expression<Func<Customer, string>> b = c => c.City;
+
+        Assert.False(MongoQueryableMethodTranslatingExpressionVisitor.KeySelectorsMatch(a, b));
+    }
+
+    [Fact]
+    public void KeySelectorsMatch_returns_false_for_a_computed_multi_hop_key()
+    {
+        Expression<Func<Customer, int>> a = c => c.Name.Length;
+        Expression<Func<Customer, int>> b = c => c.Name.Length;
+
+        Assert.False(MongoQueryableMethodTranslatingExpressionVisitor.KeySelectorsMatch(a, b));
+    }
+}


### PR DESCRIPTION
OrderBy(x).ThenByDescending(x) on the same simple property forwarded both orderings to the driver's LINQ provider unchanged, which rendered them into a single $sort document with a duplicate BSON field name and threw "Duplicate element name". Relational EF providers already drop this kind of no-op re-ordering from the generated SQL; elide it here too, narrowly scoped to direct single-hop member access so computed key selectors (which EF projects into distinct fields) are left untouched.