### PR TITLE
EF-254: Fix Take(0) throwing ArgumentOutOfRangeException

### DIFF
--- a/docs/failing-spec-tests.md
+++ b/docs/failing-spec-tests.md
@@ -64,7 +64,6 @@ that currently lack a ticket. Counts are sourced from `tests/MongoDB.EntityFrame
 | [EF-249](https://jira.mongodb.org/browse/EF-249) | `checked issue EF-249` | `checked { ... }` arithmetic is not honored — the `Checked_context_with_arithmetic_does_not_fail` test sees a different exception than EF expects. | 1 |
 | [EF-252](https://jira.mongodb.org/browse/EF-252) | `Concurrency detector tests broken EF-252` | `Throws_on_concurrent_query_first/list` — the concurrency detector does not fire as the EF base test expects. | 2 |
 | [EF-253](https://jira.mongodb.org/browse/EF-253) | `Multiple ordering issue EF-253` | `OrderBy(x).ThenBy(x)` on the same column with different directions does not emit the expected MQL. | 1 |
-| [EF-254](https://jira.mongodb.org/browse/EF-254) | `Take zero EF-254` | `.Skip(0).Take(0)` with a parameter does not produce the expected empty result. | 1 |
 | [EF-371](https://jira.mongodb.org/browse/EF-371) | `returns wrong data (0 rows instead of 6) EF-371` | A self-referencing two-hop reference navigation (`e.Manager.Manager`) collapses to a single join and hop 2 degrades to an inner `$unwind`, so the query returns 0 rows instead of 6. Baselined green on EF10 by asserting the wrong-data failure; the EF8/EF9 arm is a translation failure tagged EF-X020. | 1 |
 
 ## MongoDB C# Driver tickets — `CSHARP-NNNN`

--- a/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
+++ b/src/MongoDB.EntityFrameworkCore/Query/Visitors/MongoEFToLinqTranslatingExpressionVisitor.cs
@@ -616,7 +616,42 @@ internal sealed partial class MongoEFToLinqTranslatingExpressionVisitor : System
             return sizeRewrite;
         }
 
+        var zeroTakeRewrite = TryRewriteZeroTake(node);
+        if (zeroTakeRewrite != null)
+        {
+            return zeroTakeRewrite;
+        }
+
         return base.VisitMethodCall(node);
+    }
+
+    /// <summary>
+    /// Rewrites <c>source.Take(0)</c> (constant or parameterized) into <c>source.Where(_ => false)</c>.
+    /// The driver's <c>AstLimitStage</c> rejects a limit of 0 (EF-254) — a MongoDB <c>$limit</c> stage of 0
+    /// is meaningless server-side, so the driver's guard is correct and shouldn't be relaxed. The provider
+    /// already knows the concrete count by translation time (EF query parameters are resolved to constants
+    /// upstream of this visitor), so it can short-circuit to the equivalent empty-result shape itself
+    /// without ever emitting <c>$limit</c>.
+    /// </summary>
+    private Expression? TryRewriteZeroTake(MethodCallExpression node)
+    {
+        if (node.Method.Name != nameof(Queryable.Take)
+            || node.Method.DeclaringType != typeof(Queryable)
+            || node.Arguments.Count != 2
+            || TryEvaluateToConstant(node.Arguments[1]) is not 0)
+        {
+            return null;
+        }
+
+        var elementType = node.Method.GetGenericArguments()[0];
+        var parameter = Expression.Parameter(elementType, "_");
+        var falsePredicate = Expression.Lambda(Expression.Constant(false), parameter);
+
+        return Visit(Expression.Call(
+            null,
+            QueryableMethods.Where.MakeGenericMethod(elementType),
+            node.Arguments[0],
+            Expression.Quote(falsePredicate)));
     }
 
     /// <summary>

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SkipTakeOrderingTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Query/SkipTakeOrderingTests.cs
@@ -63,6 +63,33 @@ public class SkipTakeOrderingTests(ReadOnlySampleGuidesFixture database)
     }
 
     [Fact]
+    public void Take_with_zero_constant()
+    {
+        var results = _db.Planets.Take(0).ToArray();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Take_with_zero_parameter()
+    {
+        var size = 0;
+        var results = _db.Planets.Take(size).ToArray();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void SkipTake_with_zero_take_parameter()
+    {
+        var page = 0;
+        var size = 0;
+        var results = _db.Planets.OrderBy(p => p.orderFromSun).Skip(page).Take(size).ToArray();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
     public void SkipTake_with_constant_integer()
     {
         // If this test is flaky due to non-deterministic ordering

--- a/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
+++ b/tests/MongoDB.EntityFrameworkCore.SpecificationTests/Query/NorthwindMiscellaneousQueryMongoTest.cs
@@ -3963,14 +3963,15 @@ OrderDetails.{ "$match" : { "$and" : [{ "$expr" : { "$eq" : [{ "$add" : [{ "$toI
 
     public override async Task Skip_0_Take_0_works_when_parameter(bool async)
     {
-        // Fails: Take zero EF-254
-        Assert.Contains(
-            "Value is not greater than 0: 0",
-            (await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => base.Skip_0_Take_0_works_when_parameter(async))).Message);
+        await base.Skip_0_Take_0_works_when_parameter(async);
 
         AssertMql(
             """
-            Customers.
+            Customers.{ "$sort" : { "_id" : 1 } }, { "$skip" : 0 }, { "$match" : { "_id" : { "$type" : -1 } } }
+            """,
+            //
+            """
+            Customers.{ "$sort" : { "_id" : 1 } }, { "$skip" : 1 }, { "$limit" : 1 }
             """);
     }
 


### PR DESCRIPTION
Take(0) (constant or parameterized) flowed straight through to the driver's AstLimitStage, which rejects a limit of 0 since a $limit stage of 0 is meaningless server-side. Rewrite Take(0) to an equivalent Where(_ => false) during EF-to-driver-LINQ translation instead, so the provider never asks the driver for $limit: 0.