### PR TITLE
EF-295: Fix many-to-many join entity losing composite key to duplicate shadow property shadow property

### DIFF
--- a/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
+++ b/src/MongoDB.EntityFrameworkCore/Metadata/Conventions/PrimaryKeyDiscoveryConvention.cs
@@ -85,9 +85,11 @@ public class PrimaryKeyDiscoveryConvention : KeyDiscoveryConvention
         // Try the standard provider to look for "Id", "EntityId" etc.
         base.TryConfigurePrimaryKey(entityTypeBuilder);
 
-        // Set what we decided to use for the primary key as "_id" in the document
+        // Set what we decided to use for the primary key as "_id" in the document. Composite keys are
+        // instead nested as a subdocument under "_id" with each property keeping its own element name
+        // (see BsonSerializerFactory.GetPropertySerializationInfo), so only rename a single-property key.
         var keys = entityType.GetKeys().Where(k => k.IsPrimaryKey()).ToArray();
-        if (keys.Length == 1)
+        if (keys.Length == 1 && keys[0].Properties.Count == 1)
         {
             keys[0].Properties[0].SetElementName("_id");
         }

--- a/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.FunctionalTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
@@ -14,8 +14,12 @@
  */
 
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.EntityFrameworkCore.Extensions;
 
 namespace MongoDB.EntityFrameworkCore.FunctionalTests.Metadata.Conventions;
 
@@ -173,6 +177,96 @@ public class MongoPrimaryKeyDiscoveryConventionTests(TemporaryDatabaseFixture da
             using var db = SingleEntityDbContext.Create(collection);
             var found = db.Entities.Single(f => f.ProductId == id);
             Assert.Equal(name, found.name);
+        }
+    }
+
+    [Fact]
+    public void Many_to_many_join_document_has_no_duplicate_shadow_property()
+    {
+        var fruitsCollection = TemporaryDatabaseFixtureBase.CreateCollectionName("Fruits") + Guid.NewGuid().ToString("N")[..8];
+        var jamsCollection = TemporaryDatabaseFixtureBase.CreateCollectionName("Jams") + Guid.NewGuid().ToString("N")[..8];
+        var joinCollection = TemporaryDatabaseFixtureBase.CreateCollectionName("FruitJam") + Guid.NewGuid().ToString("N")[..8];
+
+        var fruit = new Fruit {Id = Guid.NewGuid(), Name = "Apple"};
+        var jam = new Jam {Id = Guid.NewGuid(), Name = "Strawberry"};
+        fruit.Jams.Add(jam);
+
+        using (var db = new FruitJamDbContext(database, fruitsCollection, jamsCollection, joinCollection))
+        {
+            db.Fruits.Add(fruit);
+            db.SaveChanges();
+        }
+
+        var joinDocuments = database.MongoDatabase.GetCollection<BsonDocument>(joinCollection)
+            .Find(FilterDefinition<BsonDocument>.Empty).ToList();
+
+        Assert.Single(joinDocuments);
+
+        // The composite key {FruitsId, JamsId} is nested under the single top-level "_id" field,
+        // each property keeping its own natural element name.
+        var document = joinDocuments[0];
+        Assert.Equal(["_id"], document.Names.ToArray());
+
+        var idDocument = document["_id"].AsBsonDocument;
+        Assert.Equal(["FruitsId", "JamsId"], idDocument.Names.OrderBy(n => n).ToArray());
+    }
+
+    class Fruit
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public List<Jam> Jams { get; } = new();
+    }
+
+    class Jam
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public List<Fruit> Fruits { get; } = new();
+    }
+
+    class FruitJamDbContext : DbContext
+    {
+        private readonly string _fruitsCollection;
+        private readonly string _jamsCollection;
+        private readonly string _joinCollection;
+
+        public DbSet<Fruit> Fruits { get; set; }
+        public DbSet<Jam> Jams { get; set; }
+
+        public FruitJamDbContext(
+            TemporaryDatabaseFixture database,
+            string fruitsCollection,
+            string jamsCollection,
+            string joinCollection)
+            : base(new DbContextOptionsBuilder<FruitJamDbContext>()
+                .UseMongoDB(database.Client, database.MongoDatabase.DatabaseNamespace.DatabaseName)
+                .ReplaceService<IModelCacheKeyFactory, IgnoreCacheKeyFactory>()
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options)
+        {
+            _fruitsCollection = fruitsCollection;
+            _jamsCollection = jamsCollection;
+            _joinCollection = joinCollection;
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Fruit>().ToCollection(_fruitsCollection);
+            modelBuilder.Entity<Jam>().ToCollection(_jamsCollection);
+            modelBuilder.Entity<Fruit>()
+                .HasMany(f => f.Jams)
+                .WithMany(j => j.Fruits)
+                .UsingEntity(j => j.ToCollection(_joinCollection));
+        }
+
+        sealed class IgnoreCacheKeyFactory : IModelCacheKeyFactory
+        {
+            private static int _count;
+            public object Create(DbContext context, bool designTime)
+                => Interlocked.Increment(ref _count);
         }
     }
 }

--- a/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
+++ b/tests/MongoDB.EntityFrameworkCore.UnitTests/Metadata/Conventions/PrimaryKeyDiscoveryConventionTests.cs
@@ -49,6 +49,20 @@ public static class PrimaryKeyDiscoveryConventionTests
         Assert.Single(keys[0].Properties, p => p.PropertyInfo.Equals(expectedProperty));
     }
 
+    [Fact]
+    public static void Many_to_many_join_entity_gets_composite_primary_key_without_extra_shadow_property()
+    {
+        using var db = new ManyToManyDbContext();
+
+        var joinEntityType = db.Model.GetEntityTypes().Single(e => e.ClrType == typeof(Dictionary<string, object>));
+
+        var primaryKey = joinEntityType.FindPrimaryKey();
+        Assert.NotNull(primaryKey);
+        Assert.Equal(["FruitsId", "JamsId"], primaryKey.Properties.Select(p => p.Name).OrderBy(n => n));
+
+        Assert.Equal(["FruitsId", "JamsId"], joinEntityType.GetProperties().Select(p => p.Name).OrderBy(n => n));
+    }
+
     class Vendor
     {
         public string _id { get; set; }
@@ -59,6 +73,20 @@ public static class PrimaryKeyDiscoveryConventionTests
     {
         public ObjectId _id { get; set; }
         public string name { get; set; }
+    }
+
+    class Fruit
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public List<Jam> Jams { get; } = new();
+    }
+
+    class Jam
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public List<Fruit> Fruits { get; } = new();
     }
 
     abstract class BaseDbContext : DbContext
@@ -73,5 +101,19 @@ public static class PrimaryKeyDiscoveryConventionTests
             => optionsBuilder
                 .UseMongoDB("mongodb://localhost:27017", "UnitTests")
                 .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+    }
+
+    class ManyToManyDbContext : DbContext
+    {
+        public DbSet<Fruit> Fruits { get; set; }
+        public DbSet<Jam> Jams { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder
+                .UseMongoDB("mongodb://localhost:27017", "UnitTests")
+                .ConfigureWarnings(x => x.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning));
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.Entity<Fruit>().HasMany(f => f.Jams).WithMany(j => j.Fruits);
     }
 }


### PR DESCRIPTION
PrimaryKeyDiscoveryConvention's "_id" shortcut collapsed a correctly discovered composite key (e.g. {FruitsId, JamsId} on a many-to-many join entity) down to a single property whenever that property was re-tagged with element name "_id", causing EF Core to synthesize a duplicate shadow FK property. Skip the shortcut when a multi-property primary key already exists.